### PR TITLE
Wolfboot self-update fix

### DIFF
--- a/include/wolfboot/wolfboot.h
+++ b/include/wolfboot/wolfboot.h
@@ -73,6 +73,7 @@ void wolfBoot_erase_partition(uint8_t part);
 void wolfBoot_update_trigger(void);
 void wolfBoot_success(void);
 uint32_t wolfBoot_get_image_version(uint8_t part);
+uint16_t wolfBoot_get_image_type(uint8_t part);
 #define wolfBoot_current_firmware_version() wolfBoot_get_image_version(PART_BOOT)
 #define wolfBoot_update_firmware_version() wolfBoot_get_image_version(PART_UPDATE)
 

--- a/src/image.c
+++ b/src/image.c
@@ -211,6 +211,7 @@ int wolfBoot_open_image(struct wolfBoot_image *img, uint8_t part)
     if (!img)
         return -1;
     memset(img, 0, sizeof(struct wolfBoot_image));
+    img->part = part;
     if (part == PART_SWAP) {
         img->part = PART_SWAP;
         img->hdr = (void *)WOLFBOOT_PARTITION_SWAP_ADDRESS;
@@ -237,7 +238,6 @@ int wolfBoot_open_image(struct wolfBoot_image *img, uint8_t part)
 
     if (*size >= WOLFBOOT_PARTITION_SIZE)
        return -1;
-    img->part = part;
     img->hdr_ok = 1;
     img->fw_size = *size;
     img->fw_base = img->hdr + IMAGE_HEADER_SIZE;

--- a/src/libwolfboot.c
+++ b/src/libwolfboot.c
@@ -304,3 +304,31 @@ uint32_t wolfBoot_get_image_version(uint8_t part)
     }
     return 0;
 }
+
+uint16_t wolfBoot_get_image_type(uint8_t part)
+{
+    uint16_t *type_field = NULL;
+    uint8_t *image = NULL;
+    uint32_t *magic = NULL;
+    if(part == PART_UPDATE) {
+#ifdef PART_UPDATE_EXT
+        ext_flash_read((uint32_t)WOLFBOOT_PARTITION_UPDATE_ADDRESS, hdr_cpy, IMAGE_HEADER_SIZE);
+        hdr_cpy_done = 1;
+        image = hdr_cpy;
+#else
+        image = (uint8_t *)WOLFBOOT_PARTITION_UPDATE_ADDRESS;
+#endif
+    }
+    if (part == PART_BOOT)
+        image = (uint8_t *)WOLFBOOT_PARTITION_BOOT_ADDRESS;
+
+    if (image) {
+        magic = (uint32_t *)image;
+        if (*magic != WOLFBOOT_MAGIC)
+            return 0;
+        wolfBoot_find_header(image + IMAGE_HEADER_OFFSET, HDR_IMG_TYPE, (void *)&type_field);
+        if (type_field)
+            return *type_field;
+    }
+    return 0;
+}

--- a/src/loader.c
+++ b/src/loader.c
@@ -89,7 +89,7 @@ static int wolfBoot_update(int fallback_allowed)
     if ((update.fw_size + IMAGE_HEADER_SIZE) > total_size)
             total_size = update.fw_size + IMAGE_HEADER_SIZE;
 
-    if (total_size < IMAGE_HEADER_SIZE)
+    if (total_size <= IMAGE_HEADER_SIZE)
         return -1;
 
     /* Check the first sector to detect interrupted update */

--- a/src/loader.c
+++ b/src/loader.c
@@ -95,16 +95,15 @@ static int wolfBoot_update(int fallback_allowed)
     /* Check the first sector to detect interrupted update */
     if ((wolfBoot_get_sector_flag(PART_UPDATE, 0, &flag) < 0) || (flag == SECT_FLAG_NEW))
     {
-        uint8_t *update_type;
+        uint16_t update_type;
         /* In case this is a new update, do the required
          * checks on the firmware update
          * before starting the swap
          */
 
-        if (wolfBoot_find_header(update.hdr + IMAGE_HEADER_OFFSET, HDR_IMG_TYPE, &update_type) == sizeof(uint16_t)) {
-            if ((update_type[0] != HDR_IMG_TYPE_APP) || update_type[1] != (HDR_IMG_TYPE_AUTH >> 8))
-                return -1;
-        }
+        update_type = wolfBoot_get_image_type(PART_UPDATE);
+        if (((update_type & 0x00FF) != HDR_IMG_TYPE_APP) || ((update_type & 0xFF00) != HDR_IMG_TYPE_AUTH))
+            return -1;
         if (!update.hdr_ok || (wolfBoot_verify_integrity(&update) < 0)
                 || (wolfBoot_verify_authenticity(&update) < 0)) {
             return -1;
@@ -307,9 +306,7 @@ static void wolfBoot_check_self_update(void)
     /* Check for self update in the UPDATE partition */
     if ((wolfBoot_get_partition_state(PART_UPDATE, &st) == 0) && (st == IMG_STATE_UPDATING) &&
             (wolfBoot_open_image(&update, PART_UPDATE) == 0) &&
-            (wolfBoot_find_header(update.hdr + IMAGE_HEADER_OFFSET, HDR_IMG_TYPE, &update_type) == sizeof(uint16_t)) &&
-            update_type[0] == HDR_IMG_TYPE_WOLFBOOT &&
-            update_type[1] == (HDR_IMG_TYPE_AUTH >> 8)) {
+            wolfBoot_get_image_type(PART_UPDATE) == (HDR_IMG_TYPE_WOLFBOOT | HDR_IMG_TYPE_AUTH)) {
         uint32_t update_version = wolfBoot_update_firmware_version();
         if (update_version <= wolfboot_version) {
             hal_flash_unlock();


### PR DESCRIPTION
Fixes to recognize update_type when the update resides on external memory (e.g. SPI flash).