### PR TITLE
Added -ffunction-sections -fdata-sections to CFLAGS to group unused symbols

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@
 include tools/config.mk
 
 ## Initializers
-CFLAGS:=-D__WOLFBOOT  -DWOLFBOOT_VERSION=$(WOLFBOOT_VERSION)UL
+CFLAGS:=-D__WOLFBOOT  -DWOLFBOOT_VERSION=$(WOLFBOOT_VERSION)UL -ffunction-sections -fdata-sections
 LSCRIPT:=config/target.ld
 LDFLAGS:=-T $(LSCRIPT) -Wl,-gc-sections -Wl,-Map=wolfboot.map -ffreestanding -nostartfiles
 OBJS:= \


### PR DESCRIPTION
Added missing CFLAGS to group unused symbols.
wolfBoot binary size is consistently reduced.

Updating benchmark figures accordingly.