### PR TITLE
Link sha256.o module even if sha3 is selected, as it's needed by RSA

### DIFF
--- a/arch.mk
+++ b/arch.mk
@@ -13,9 +13,9 @@ ARCH_FLASH_OFFSET=0x0
 # Default SPI driver name
 SPI_TARGET=$(TARGET)
 
+
 ## Hash settings
 ifeq ($(HASH),SHA256)
-  WOLFCRYPT_OBJS+=./lib/wolfssl/wolfcrypt/src/sha256.o
   CFLAGS+=-DWOLFBOOT_HASH_SHA256
 endif
 
@@ -24,6 +24,9 @@ ifeq ($(HASH),SHA3)
   CFLAGS+=-DWOLFBOOT_HASH_SHA3_384
   SIGN_OPTIONS+=--sha3
 endif
+
+# Include SHA256 module because it's implicitly needed by RSA
+WOLFCRYPT_OBJS+=./lib/wolfssl/wolfcrypt/src/sha256.o
 
 ## ARM
 ifeq ($(ARCH),ARM)


### PR DESCRIPTION
According to Jenkins, two test cases (101 & 111) are still failing, because linking RSA+SHA3 excludes sha256 and results in missing symbols at linking time. sha256 can be included in all cases and discarded automatically when not needed.

