### PR TITLE
Fix importing Ed25519 key in C sign tool

### DIFF
--- a/tools/keytools/sign.c
+++ b/tools/keytools/sign.c
@@ -325,14 +325,9 @@ int main(int argc, char** argv)
         #ifdef HAVE_ED25519            
             ret = wc_ed25519_init(&key.ed);
             if (ret == 0) {
-                ret = wc_ed25519_import_private_only(key_buffer, key_buffer_sz, &key.ed);
-                if (ret == 0) {
-                    ret = wc_ed25519_export_public(&key.ed, key_buffer, &pubkey_sz);
-                    if (ret == 0) {
-                        pubkey = key_buffer;
-                        pubkey_sz = ED25519_PUB_KEY_SIZE;
-                    }
-                }
+                pubkey = key_buffer + ED25519_KEY_SIZE;
+                pubkey_sz = ED25519_PUB_KEY_SIZE;
+                ret = wc_ed25519_import_private_key(key_buffer, ED25519_KEY_SIZE, pubkey, pubkey_sz, &key.ed);
             }
         #endif
         }


### PR DESCRIPTION
Ed25519 sign failed with the native C tool. Private key import returned -132. Replaced with full key import/manual set of pubkey buffer.