### PR TITLE
Fixed bug in keygen.c append missing public key to ed25519.der

### DIFF
--- a/tools/keytools/keygen.c
+++ b/tools/keytools/keygen.c
@@ -130,6 +130,7 @@ static void keygen_rsa(WC_RNG *rng, char *pubkeyfile, int size)
         exit(4);
     }
     fwrite(priv_der, privlen, 1, fpriv);
+    fwrite(pub, 32, 1, fpriv);
     fclose(fpriv);
 
     fpub = fopen(pubkeyfile, "w");


### PR DESCRIPTION
Fix for keygen.c (ed25519 key):
Ed25519.der should contain the full key (both private + public halves).
