### PR TITLE
[Jenkins] fixed SPI CS pin config on test-bench

### DIFF
--- a/tools/test.mk
+++ b/tools/test.mk
@@ -54,25 +54,37 @@ $(EXPVER):
 # Testbed actions
 #
 #
+# tpm-mute mode is the default
 #
+tpm-mute:
+	@if ! (test -d /sys/class/gpio/gpio7); then echo "7" > /sys/class/gpio/export || true; fi
+	@echo "out" >/sys/class/gpio/gpio7/direction
+	@echo "1" >/sys/class/gpio/gpio7/value || true
+
+tpm-unmute:
+	@if ! (test -d /sys/class/gpio/gpio7); then echo "7" > /sys/class/gpio/export || true; fi
+	@echo "in" >/sys/class/gpio/gpio7/direction
+
 testbed-on: FORCE
 	@if ! (test -d /sys/class/gpio/gpio4); then echo "4" > /sys/class/gpio/export || true; fi
 	@echo "out" >/sys/class/gpio/gpio4/direction
 	@echo "0" >/sys/class/gpio/gpio4/value || true
+	@make tpm-mute
 	@echo "Testbed on."
 
 testbed-off: FORCE
+	@make tpm-mute
 	@if ! (test -d /sys/class/gpio/gpio4); then echo "4" > /sys/class/gpio/export || true; fi
 	@echo "out" >/sys/class/gpio/gpio4/direction
 	@echo "1" >/sys/class/gpio/gpio4/value || true
 	@echo "Testbed off."
 
+
 test-reset: FORCE
-	@(sleep 1 && make testbed-off && sleep 1 && make testbed-on) &
+	@(sleep 1 && st-flash reset && sleep 1)&
 
 test-spi-on: FORCE
 	@make testbed-off
-	@echo "7" >/sys/class/gpio/unexport || true
 	@echo "8" >/sys/class/gpio/unexport || true
 	@echo "9" >/sys/class/gpio/unexport || true
 	@echo "10" >/sys/class/gpio/unexport || true
@@ -81,27 +93,17 @@ test-spi-on: FORCE
 	@modprobe spidev
 
 test-spi-off: FORCE
-	@rmmod spi_bcm2835
-	@rmmod spidev
-	@echo "7" >/sys/class/gpio/export
-	@echo "8" >/sys/class/gpio/export
-	@echo "9" >/sys/class/gpio/export
-	@echo "10" >/sys/class/gpio/export
-	@echo "11" >/sys/class/gpio/export
+	@rmmod spi_bcm2835 || true
+	@rmmod spidev || true
+	@echo "8" >/sys/class/gpio/export || true
+	@echo "9" >/sys/class/gpio/export || true
+	@echo "10" >/sys/class/gpio/export || true
+	@echo "11" >/sys/class/gpio/export || true
 	@echo "in" >/sys/class/gpio/gpio8/direction
 	@echo "in" >/sys/class/gpio/gpio9/direction
 	@echo "in" >/sys/class/gpio/gpio10/direction
 	@echo "in" >/sys/class/gpio/gpio11/direction
 	@make testbed-on
-
-test-tpm-off: FORCE
-	@if ! (test -d /sys/class/gpio/gpio7); then echo "7" > /sys/class/gpio/export || true; fi
-	@echo "out" >/sys/class/gpio/gpio7/direction
-	@echo "1" >/sys/class/gpio/gpio7/value || true
-
-test-tpm-on: FORCE
-	@echo "7" >/sys/class/gpio/unexport || true
-
 
 test-update: test-app/image.bin FORCE
 	@dd if=/dev/zero bs=131067 count=1 2>/dev/null | tr "\000" "\377" > test-update.bin
@@ -136,10 +138,9 @@ test-update-ext: test-app/image.bin FORCE
 	@(dd if=/dev/zero bs=1M count=1 | tr '\000' '\377' > test-update.rom)
 	@dd if=test-app/image_v$(TEST_UPDATE_VERSION)_signed.bin of=test-update.rom bs=1 count=524283 conv=notrunc
 	@printf "pBOOT" | dd of=test-update.rom obs=1 seek=524283 count=5 conv=notrunc
-	@make test-spi-on
+	@make test-spi-on || true
 	flashrom -c $(SPI_CHIP) -p linux_spi:dev=/dev/spidev0.0 -w test-update.rom
 	@make test-spi-off
-	@make test-tpm-off
 	@make test-reset
 	@sleep 2
 	@make clean
@@ -151,11 +152,10 @@ test-erase: FORCE
 	@st-flash erase
 
 test-erase-ext: FORCE
-	@make test-spi-on
+	@make test-spi-on || true
 	@echo Mass-erasing the external SPI flash:
 	flashrom -c $(SPI_CHIP) -p linux_spi:dev=/dev/spidev0.0 -E
-	@make test-spi-off
-	@make test-tpm-off
+	@make test-spi-off || true
 
 test-factory: factory.bin
 	@make test-reset
@@ -307,14 +307,16 @@ test-53-rollback-RSA: $(EXPVER) FORCE
 	@make test-03-rollback SIGN=RSA2048
 
 test-61-forward-update-no-downgrade-TPM: $(EXPVER) FORCE
-	@make test-tpm-on
+	@make test-spi-off || true
+	@make tpm-unmute
 	@make test-01-forward-update-no-downgrade SIGN=ECC256 WOLFTPM=1 TPM2=1
-	@make test-tpm-off
+	@make tpm-mute
 
 test-63-rollback-TPM: $(EXPVER) FORCE
-	@make test-tpm-on
+	@make test-spi-off || true
+	@make tpm-unmute
 	@make test-03-rollback SIGN=ECC256 WOLFTPM=1
-	@make test-tpm-off
+	@make tpm-mute
 
 test-71-forward-update-no-downgrade-RSA-4096: $(EXPVER) FORCE
 	@make test-01-forward-update-no-downgrade SIGN=RSA4096
@@ -335,14 +337,16 @@ test-111-forward-update-no-downgrade-RSA4096-SHA3: $(EXPVER) FORCE
 	@make test-01-forward-update-no-downgrade SIGN=RSA4096 HASH=SHA3
 
 test-161-forward-update-no-downgrade-TPM-RSA: $(EXPVER) FORCE
-	@make test-tpm-on
+	@make test-spi-off || true
+	@make tpm-unmute
 	@make test-01-forward-update-no-downgrade SIGN=RSA2048 WOLFTPM=1
-	@make test-tpm-off
+	@make tpm-mute
 
 test-163-rollback-TPM-RSA: $(EXPVER) FORCE
-	@make test-tpm-on
+	@make test-spi-off || true
+	@make tpm-unmute
 	@make test-03-rollback SIGN=RSA2048 WOLFTPM=1
-	@make test-tpm-off
+	@make tpm-mute
 
 test-all: clean test-01-forward-update-no-downgrade test-02-forward-update-allow-downgrade test-03-rollback \
 	test-11-forward-update-no-downgrade-ECC test-13-rollback-ECC test-21-forward-update-no-downgrade-SPI test-23-rollback-SPI \


### PR DESCRIPTION
TPM pin must be floating only if target is controlling it (TPM tests). 

In all other tests, the TPM CS must be controlled by the bench and set to 1.

This patch enforces TPM_CS=1 on testbed on/off, and provide tpm-mute/unmute targets used during non-regression tests with TPM controlled by the target.
