### PR TITLE
Allow bootloader update from SPI flash

### DIFF
--- a/hal/spi/spi_drv_nrf52.c
+++ b/hal/spi/spi_drv_nrf52.c
@@ -58,14 +58,14 @@
 #define M4   0x40000000  
 #define M8   0x80000000  
 
-void spi_cs_off(int pin)
+void RAMFUNCTION spi_cs_off(int pin)
 {
     GPIO_OUTSET = (1 << pin);
     while ((GPIO_OUT & (1 << pin)) == 0)
         ;
 }
 
-void spi_cs_on(int pin)
+void RAMFUNCTION spi_cs_on(int pin)
 {
     GPIO_OUTCLR = (1 << pin);
     while ((GPIO_OUT & (1 << pin)) != 0)
@@ -73,7 +73,7 @@ void spi_cs_on(int pin)
 
 }
 
-uint8_t spi_read(void)
+uint8_t RAMFUNCTION spi_read(void)
 {
     volatile uint32_t reg = SPI_EV_RDY;
     while (!reg)
@@ -83,7 +83,7 @@ uint8_t spi_read(void)
     return reg;
 }
 
-void spi_write(const char byte)
+void RAMFUNCTION spi_write(const char byte)
 {
     uint32_t reg;
     SPI_EV_RDY = 0;

--- a/hal/spi/spi_drv_stm32.c
+++ b/hal/spi/spi_drv_stm32.c
@@ -28,14 +28,14 @@
 #include "spi_drv.h"
 #include "spi_drv_stm32.h"
 
-void spi_cs_off(int pin)
+void RAMFUNCTION spi_cs_off(int pin)
 {
     SPI_PIO_CS_BSRR |= (1 << pin);
     while(!(SPI_PIO_CS_ODR & (1 << pin)))
         ;
 }
 
-void spi_cs_on(int pin)
+void RAMFUNCTION spi_cs_on(int pin)
 {
     SPI_PIO_CS_BSRR |= (1 << (pin + 16));
     while(SPI_PIO_CS_ODR & (1 << pin))
@@ -122,7 +122,7 @@ static void spi1_reset(void)
     APB2_CLOCK_RST &= ~SPI1_APB2_CLOCK_ER_VAL;
 }
 
-uint8_t spi_read(void)
+uint8_t RAMFUNCTION spi_read(void)
 {
     volatile uint32_t reg;
     do {
@@ -131,7 +131,7 @@ uint8_t spi_read(void)
     return (uint8_t)SPI1_DR;
 }
 
-void spi_write(const char byte)
+void RAMFUNCTION spi_write(const char byte)
 {
     int i;
     volatile uint32_t reg;
@@ -161,7 +161,7 @@ void spi_init(int polarity, int phase)
     }
 }
 
-void spi_release(void)
+void RAMFUNCTION spi_release(void)
 {
     spi1_reset();
 	SPI1_CR2 &= ~SPI_CR2_SSOE;

--- a/include/spi_drv.h
+++ b/include/spi_drv.h
@@ -30,6 +30,7 @@
 #define SPI_DRV_H_INCLUDED
 
 #include <stdint.h>
+#include "image.h"
 
 #if defined(PLATFORM_stm32f4) || defined(PLATFORM_stm32f7) || defined(PLATFORM_stm32wb)
 #include "hal/spi/spi_drv_stm32.h"

--- a/src/spi_flash.c
+++ b/src/spi_flash.c
@@ -53,7 +53,7 @@ static enum write_mode {
     SST_SINGLEBYTE = 0x01
 } chip_write_mode = WB_WRITEPAGE;
 
-static void write_address(uint32_t address)
+static void RAMFUNCTION write_address(uint32_t address)
 {
     spi_write((address & 0xFF0000) >> 16);
     spi_read();
@@ -63,7 +63,7 @@ static void write_address(uint32_t address)
     spi_read();
 }
 
-static uint8_t read_status(void)
+static uint8_t RAMFUNCTION read_status(void)
 {
     uint8_t status;
     spi_cs_on(SPI_CS_FLASH);
@@ -212,7 +212,7 @@ void spi_flash_sector_erase(uint32_t address)
     wait_busy();
 }
 
-int spi_flash_read(uint32_t address, void *data, int len)
+int RAMFUNCTION spi_flash_read(uint32_t address, void *data, int len)
 {
     uint8_t *buf = data;
     int i = 0;


### PR DESCRIPTION
Added RAMFUNCTION tag to SPI flash functions in order to allow wolfBoot updates from SPI flash.