### PR TITLE
Relocate encryption key slot to the end of the flash partition

### DIFF
--- a/tools/scripts/prepare_encrypted_update.sh
+++ b/tools/scripts/prepare_encrypted_update.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# SIZE is WOLFBOOT_PARTITION_SIZE - 5
-SIZE=131067 
+# SIZE is WOLFBOOT_PARTITION_SIZE - 49 (44B: key + nonce, 5B: "pBOOT")
+SIZE=131023
 VERSION=8
 APP=test-app/image_v"$VERSION"_signed_and_encrypted.bin
 


### PR DESCRIPTION
- Encryption key slot moved to the end of the partition
- When encryption is enabled, partition flag and sector flags bitmap are moved back by `ENCRYPT_KEY_SIZE + ENCRYPT_NONCE_SIZE`
- Updated `uart_flash_server` to detect and support encrypted partitions
ZD 10733