### PR TITLE
increase spi speed

### DIFF
--- a/hal/spi/spi_drv_stm32.c
+++ b/hal/spi/spi_drv_stm32.c
@@ -155,7 +155,11 @@ void spi_init(int polarity, int phase)
         spi_tpm2_pin_setup();
         APB2_CLOCK_ER |= SPI1_APB2_CLOCK_ER_VAL;
         spi1_reset();
+#ifdef PLATFORM_stm32l0
         SPI1_CR1 = SPI_CR1_MASTER | (polarity << 1) | (phase << 0);
+#else
+        SPI1_CR1 = SPI_CR1_MASTER | (5 << 3) | (polarity << 1) | (phase << 0);
+#endif
         SPI1_CR2 |= SPI_CR2_SSOE;
         SPI1_CR1 |= SPI_CR1_SPI_EN;
     }

--- a/hal/spi/spi_drv_stm32.c
+++ b/hal/spi/spi_drv_stm32.c
@@ -155,7 +155,7 @@ void spi_init(int polarity, int phase)
         spi_tpm2_pin_setup();
         APB2_CLOCK_ER |= SPI1_APB2_CLOCK_ER_VAL;
         spi1_reset();
-        SPI1_CR1 = SPI_CR1_MASTER | (5 << 3) | (polarity << 1) | (phase << 0);
+        SPI1_CR1 = SPI_CR1_MASTER | (polarity << 1) | (phase << 0);
         SPI1_CR2 |= SPI_CR2_SSOE;
         SPI1_CR1 |= SPI_CR1_SPI_EN;
     }


### PR DESCRIPTION
Hi,

By removing this flag, we're setting the baudrate prescaler from fPCLK/64 to fPCLK/2. This results in faster transfer speeds to external flash. We've already tested this change on all of our instances for a longer time.