### PR TITLE
Remove unnecessary KEYGEN_TOOL from test-enc.mk

### DIFF
--- a/tools/test-enc.mk
+++ b/tools/test-enc.mk
@@ -1,5 +1,4 @@
 ENC_TEST_UPDATE_VERSION?=2
-KEYGEN_TOOL=python3 ./tools/keytools/keygen.py
 SIGN_ARGS?=--ecc256
 SIGN_ENC_ARGS?=--ecc256 --encrypt /tmp/enc_key.der
 USBTTY?=/dev/ttyACM0


### PR DESCRIPTION
KEYGEN_TOOL is not used in this file and doesn't have proper detection logic for right variant of the tool. Main Makefile includes this file after test.mk and stray KEYGEN_TOOL define here overrides tool variant already detected by test.mk with python version.