### PR TITLE
Support for overriding the wolfBoot root

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@
 include tools/config.mk
 
 ## Initializers
-WOLFBOOT_ROOT=$(PWD)
+WOLFBOOT_ROOT?=$(PWD)
 CFLAGS:=-D__WOLFBOOT -DWOLFBOOT_VERSION=$(WOLFBOOT_VERSION)UL -ffunction-sections -fdata-sections
 LSCRIPT:=config/target.ld
 LDFLAGS:=-T $(LSCRIPT) -Wl,-gc-sections -Wl,-Map=wolfboot.map -ffreestanding -nostartfiles

--- a/tools/test-enc.mk
+++ b/tools/test-enc.mk
@@ -1,18 +1,27 @@
 ENC_TEST_UPDATE_VERSION?=2
-KEYGEN_TOOL=python3 ./tools/keytools/keygen.py
 SIGN_ARGS?=--ecc256
 SIGN_ENC_ARGS?=--ecc256 --encrypt /tmp/enc_key.der
 USBTTY?=/dev/ttyACM0
 TIMEOUT?=60
 
-ifneq ("$(wildcard ./tools/keytools/sign)","")
-    SIGN_TOOL=./tools/keytools/sign
+ifneq ("$(wildcard $(WOLFBOOT_ROOT)/tools/keytools/keygen)","")
+	KEYGEN_TOOL=$(WOLFBOOT_ROOT)/tools/keytools/keygen
 else
-    ifneq ("$(wildcard ./tools/keytools/sign.exe)","")
-        SIGN_TOOL=./tools/keytools/sign.exe
-    else
-        SIGN_TOOL=python3 ./tools/keytools/sign.py
-    endif
+	ifneq ("$(wildcard $(WOLFBOOT_ROOT)/tools/keytools/keygen.exe)","")
+		KEYGEN_TOOL=$(WOLFBOOT_ROOT)/tools/keytools/keygen.exe
+	else
+		KEYGEN_TOOL=python3 $(WOLFBOOT_ROOT)/tools/keytools/keygen.py
+	endif
+endif
+
+ifneq ("$(wildcard $(WOLFBOOT_ROOT)/tools/keytools/sign)","")
+	SIGN_TOOL=$(WOLFBOOT_ROOT)/tools/keytools/sign
+else
+	ifneq ("$(wildcard $(WOLFBOOT_ROOT)/tools/keytools/sign.exe)","")
+		SIGN_TOOL=$(WOLFBOOT_ROOT)/tools/keytools/sign.exe
+	else
+		SIGN_TOOL=python3 $(WOLFBOOT_ROOT)/tools/keytools/sign.py
+	endif
 endif
 
 tools/uart-flash-server/ufserver: FORCE

--- a/tools/test.mk
+++ b/tools/test.mk
@@ -5,23 +5,23 @@ SPI_CHIP=SST25VF080B
 SPI_OPTIONS=SPI_FLASH=1 WOLFBOOT_PARTITION_SIZE=0x80000 WOLFBOOT_PARTITION_UPDATE_ADDRESS=0x00000 WOLFBOOT_PARTITION_SWAP_ADDRESS=0x80000
 SIGN_ARGS=
 
-ifneq ("$(wildcard ./tools/keytools/keygen)","")
-	KEYGEN_TOOL=./tools/keytools/keygen
+ifneq ("$(wildcard $(WOLFBOOT_ROOT)/tools/keytools/keygen)","")
+	KEYGEN_TOOL=$(WOLFBOOT_ROOT)/tools/keytools/keygen
 else
-	ifneq ("$(wildcard ./tools/keytools/keygen.exe)","")
-		KEYGEN_TOOL=./tools/keytools/keygen.exe
+	ifneq ("$(wildcard $(WOLFBOOT_ROOT)/tools/keytools/keygen.exe)","")
+		KEYGEN_TOOL=$(WOLFBOOT_ROOT)/tools/keytools/keygen.exe
 	else
-		KEYGEN_TOOL=python3 ./tools/keytools/keygen.py
+		KEYGEN_TOOL=python3 $(WOLFBOOT_ROOT)/tools/keytools/keygen.py
 	endif
 endif
 
-ifneq ("$(wildcard ./tools/keytools/sign)","")
-	SIGN_TOOL=./tools/keytools/sign
+ifneq ("$(wildcard $(WOLFBOOT_ROOT)/tools/keytools/sign)","")
+	SIGN_TOOL=$(WOLFBOOT_ROOT)/tools/keytools/sign
 else
-	ifneq ("$(wildcard ./tools/keytools/sign.exe)","")
-		SIGN_TOOL=./tools/keytools/sign.exe
+	ifneq ("$(wildcard $(WOLFBOOT_ROOT)/tools/keytools/sign.exe)","")
+		SIGN_TOOL=$(WOLFBOOT_ROOT)/tools/keytools/sign.exe
 	else
-		SIGN_TOOL=python3 ./tools/keytools/sign.py
+		SIGN_TOOL=python3 $(WOLFBOOT_ROOT)/tools/keytools/sign.py
 	endif
 endif
 


### PR DESCRIPTION
Allow override of `WOLFBOOT_ROOT` to allow proper detection of the signing/keygen tools.