### PR TITLE
Enhanced debug prints and image test vectors

### DIFF
--- a/src/image.c
+++ b/src/image.c
@@ -643,7 +643,7 @@ int wolfBoot_open_image(struct wolfBoot_image *img, uint8_t part)
         else
             image = (uint8_t*)img->hdr;
         if (*((uint32_t*)image) != UBOOT_FDT_MAGIC) {
-            wolfBoot_printf("%s(): value 0x%08x at %p does not match expected DTB image magic 0x%08lx", \
+            wolfBoot_printf("%s(): value 0x%08x at %p does not match expected DTB image magic 0x%08lx\r\n", \
                             __func__, *((uint32_t*)image), image, UBOOT_FDT_MAGIC);
             return -1;
         }
@@ -677,14 +677,14 @@ int wolfBoot_open_image(struct wolfBoot_image *img, uint8_t part)
 
     magic = (uint32_t *)(image);
     if (*magic != WOLFBOOT_MAGIC) {
-        wolfBoot_printf("%s(): value 0x%08x at %p does not match expected image magic 0x%08x", \
+        wolfBoot_printf("%s(): value 0x%08x at %p does not match expected image magic 0x%08x\r\n", \
                         __func__, *magic, image, WOLFBOOT_MAGIC);
         return -1;
     }
     size = (uint32_t *)(image + sizeof (uint32_t));
 
     if (*size > (WOLFBOOT_PARTITION_SIZE - IMAGE_HEADER_SIZE)) {
-        wolfBoot_printf("%s(): image size 0x%08x exceeds max available partition space 0x%08x", \
+        wolfBoot_printf("%s(): image size 0x%08x exceeds max available partition space 0x%08x\r\n", \
                         __func__, *size,  (WOLFBOOT_PARTITION_SIZE - IMAGE_HEADER_SIZE));
         return -1;
     }

--- a/src/image.c
+++ b/src/image.c
@@ -23,6 +23,7 @@
 #include "image.h"
 #include "hal.h"
 #include "spi_drv.h"
+#include "printf.h"
 
 #include <wolfssl/wolfcrypt/settings.h>
 
@@ -635,12 +636,15 @@ int wolfBoot_open_image(struct wolfBoot_image *img, uint8_t part)
     if (part == PART_DTS_BOOT || part == PART_DTS_UPDATE) {
         img->hdr = (part == PART_DTS_BOOT) ? (void*)WOLFBOOT_DTS_BOOT_ADDRESS
                                            : (void*)WOLFBOOT_DTS_UPDATE_ADDRESS;
+        wolfBoot_printf("%s(): looking for %s partition at %p\r\n", __func__, (part == PART_DTS_BOOT) ? "DTB boot" : "DTB update", img->hdr);
         if (PART_IS_EXT(img))
             image = fetch_hdr_cpy(img);
         else
             image = (uint8_t*)img->hdr;
-        if (*((uint32_t*)image) != UBOOT_FDT_MAGIC)
+        if (*((uint32_t*)image) != UBOOT_FDT_MAGIC) {
+            wolfBoot_printf("%s(): value 0x%08x at %p does not match expected DTB image magic 0x%08x", __func__, *((uint32_t*)image), image, UBOOT_FDT_MAGIC);
             return -1;
+        }
         img->hdr_ok = 1;
         img->fw_base = img->hdr;
         /* DTS data is big endian */
@@ -654,8 +658,10 @@ int wolfBoot_open_image(struct wolfBoot_image *img, uint8_t part)
 #endif
     if (part == PART_BOOT) {
         img->hdr = (void*)WOLFBOOT_PARTITION_BOOT_ADDRESS;
+        wolfBoot_printf("%s(): looking for boot partition at %p\r\n", __func__, img->hdr);
     } else if (part == PART_UPDATE) {
         img->hdr = (void*)WOLFBOOT_PARTITION_UPDATE_ADDRESS;
+        wolfBoot_printf("%s(): looking for update partition at %p\r\n", __func__, img->hdr);
     } else
         return -1;
 
@@ -668,12 +674,16 @@ int wolfBoot_open_image(struct wolfBoot_image *img, uint8_t part)
         image = (uint8_t *)img->hdr;
 
     magic = (uint32_t *)(image);
-    if (*magic != WOLFBOOT_MAGIC)
+    if (*magic != WOLFBOOT_MAGIC) {
+        wolfBoot_printf("%s(): value 0x%08x at %p does not match expected image magic 0x%08x", __func__, *magic, image, WOLFBOOT_MAGIC);
         return -1;
+    }
     size = (uint32_t *)(image + sizeof (uint32_t));
 
-    if (*size > (WOLFBOOT_PARTITION_SIZE - IMAGE_HEADER_SIZE))
-       return -1;
+    if (*size > (WOLFBOOT_PARTITION_SIZE - IMAGE_HEADER_SIZE)) {
+        wolfBoot_printf("%s(): image size 0x%08x exceeds max available partition space 0x%08x", __func__, *size,  (WOLFBOOT_PARTITION_SIZE - IMAGE_HEADER_SIZE));
+        return -1;
+    }
     img->hdr_ok = 1;
     img->fw_size = *size;
     img->fw_base = img->hdr + IMAGE_HEADER_SIZE;

--- a/src/image.c
+++ b/src/image.c
@@ -636,13 +636,15 @@ int wolfBoot_open_image(struct wolfBoot_image *img, uint8_t part)
     if (part == PART_DTS_BOOT || part == PART_DTS_UPDATE) {
         img->hdr = (part == PART_DTS_BOOT) ? (void*)WOLFBOOT_DTS_BOOT_ADDRESS
                                            : (void*)WOLFBOOT_DTS_UPDATE_ADDRESS;
-        wolfBoot_printf("%s(): looking for %s partition at %p\r\n", __func__, (part == PART_DTS_BOOT) ? "DTB boot" : "DTB update", img->hdr);
+        wolfBoot_printf("%s(): looking for %s partition at %p\r\n", \
+                        __func__, (part == PART_DTS_BOOT) ? "DTB boot" : "DTB update", img->hdr);
         if (PART_IS_EXT(img))
             image = fetch_hdr_cpy(img);
         else
             image = (uint8_t*)img->hdr;
         if (*((uint32_t*)image) != UBOOT_FDT_MAGIC) {
-            wolfBoot_printf("%s(): value 0x%08x at %p does not match expected DTB image magic 0x%08x", __func__, *((uint32_t*)image), image, UBOOT_FDT_MAGIC);
+            wolfBoot_printf("%s(): value 0x%08x at %p does not match expected DTB image magic 0x%08lx", \
+                            __func__, *((uint32_t*)image), image, UBOOT_FDT_MAGIC);
             return -1;
         }
         img->hdr_ok = 1;
@@ -675,13 +677,15 @@ int wolfBoot_open_image(struct wolfBoot_image *img, uint8_t part)
 
     magic = (uint32_t *)(image);
     if (*magic != WOLFBOOT_MAGIC) {
-        wolfBoot_printf("%s(): value 0x%08x at %p does not match expected image magic 0x%08x", __func__, *magic, image, WOLFBOOT_MAGIC);
+        wolfBoot_printf("%s(): value 0x%08x at %p does not match expected image magic 0x%08x", \
+                        __func__, *magic, image, WOLFBOOT_MAGIC);
         return -1;
     }
     size = (uint32_t *)(image + sizeof (uint32_t));
 
     if (*size > (WOLFBOOT_PARTITION_SIZE - IMAGE_HEADER_SIZE)) {
-        wolfBoot_printf("%s(): image size 0x%08x exceeds max available partition space 0x%08x", __func__, *size,  (WOLFBOOT_PARTITION_SIZE - IMAGE_HEADER_SIZE));
+        wolfBoot_printf("%s(): image size 0x%08x exceeds max available partition space 0x%08x", \
+                        __func__, *size,  (WOLFBOOT_PARTITION_SIZE - IMAGE_HEADER_SIZE));
         return -1;
     }
     img->hdr_ok = 1;

--- a/src/update_ram.c
+++ b/src/update_ram.c
@@ -34,7 +34,7 @@ extern void hal_flash_dualbank_swap(void);
 
 static inline void boot_panic(void)
 {
-    wolfBoot_printf("entering %s() - to die here\r\n", __func__);
+    wolfBoot_printf("%s(): entered - to die here\r\n", __func__);
     while(1)
         ;
 }
@@ -49,15 +49,15 @@ void RAMFUNCTION wolfBoot_start(void)
 #ifdef MMU
     uint32_t* dts_address = NULL;
 #endif
-    wolfBoot_printf("entering %s()\r\n", __func__);
+    wolfBoot_printf("%s(): entered\r\n", __func__);
 
     active = wolfBoot_dualboot_candidate();
 
-    wolfBoot_printf("Active Part %d\r\n", active);
+    wolfBoot_printf("%s(): Active Part %d\r\n", __func__, active);
 
     if (active < 0) {
         /* panic if no images available */
-        wolfBoot_printf("no partitions found\r\n");
+        wolfBoot_printf("%s(): no partitions found\r\n", __func__);
         boot_panic();
     }
     /* Check current status for failure (image still in TESTING), and fall-back
@@ -75,12 +75,15 @@ void RAMFUNCTION wolfBoot_start(void)
             ((ret = wolfBoot_verify_integrity(&os_image) < 0)) ||
             ((ret = wolfBoot_verify_authenticity(&os_image)) < 0)) {
 
-            wolfBoot_printf("Failure %d: Part %d, Hdr %d, Hash %d, Sig %d\r\n", ret, 
-                active, os_image.hdr_ok, os_image.sha_ok, os_image.signature_ok);
+            wolfBoot_printf("%s(): Failure %d: Part %d, Hdr %s, Hash %s, Sig %s\r\n",
+                 __func__, ret, active, 
+                 os_image.hdr_ok ? "ok" : "?", 
+                 os_image.sha_ok ? "ok" : "?", 
+                 os_image.signature_ok ? "ok" : "?");
 
             /* panic if authentication fails and no backup */
             if (!wolfBoot_fallback_is_possible()) {
-                wolfBoot_printf("no fallback image available\r\n");
+                wolfBoot_printf("%s(): no fallback image available\r\n", __func__);
                 boot_panic();
             }
             else {
@@ -95,7 +98,7 @@ void RAMFUNCTION wolfBoot_start(void)
         }
     }
 
-    wolfBoot_printf("Firmware Valid\r\n");
+    wolfBoot_printf("%s(): Firmware Valid\r\n", __func__);
 
     /* First time we boot this update, set to TESTING to await
      * confirmation from the system
@@ -123,7 +126,7 @@ void RAMFUNCTION wolfBoot_start(void)
 #ifdef EXT_FLASH
     /* Load image to RAM */
     if (PART_IS_EXT(&os_image)) {
-        wolfBoot_printf("Loading %d to RAM at %p\r\n", os_image.fw_size, load_address);
+        wolfBoot_printf("%s(): Loading %d to RAM at %p\r\n", __func__, os_image.fw_size, load_address);
 
         ext_flash_read((uintptr_t)os_image.fw_base, 
                        (uint8_t*)load_address,
@@ -139,7 +142,7 @@ void RAMFUNCTION wolfBoot_start(void)
     #ifdef EXT_FLASH
         /* Load DTS to RAM */
         if (PART_IS_EXT(&os_image)) {
-            wolfBoot_printf("Loading DTB %d to RAM at %p\r\n", os_image.fw_size, dts_address);
+            wolfBoot_printf("%s(): Loading DTB %d to RAM at %p\r\n", __func__, os_image.fw_size, dts_address);
 
             ext_flash_read((uintptr_t)os_image.fw_base, 
                         (uint8_t*)dts_address,
@@ -152,10 +155,10 @@ void RAMFUNCTION wolfBoot_start(void)
     hal_prepare_boot();
 	
 #ifdef MMU
-    wolfBoot_printf("Booting at %p, with DTB at %p\r\n", load_address, dts_address);
+    wolfBoot_printf("%s(): Booting at %p, with DTB at %p\r\n", __func__, load_address, dts_address);
     do_boot((uint32_t*)load_address, (uint32_t*)dts_address);
 #else
-    wolfBoot_printf("Booting at %p\r\n", load_address);
+    wolfBoot_printf("%s(): Booting at %p\r\n", __func__, load_address);
     do_boot((uint32_t*)load_address);
 #endif
 }

--- a/src/update_ram.c
+++ b/src/update_ram.c
@@ -152,7 +152,7 @@ void RAMFUNCTION wolfBoot_start(void)
     hal_prepare_boot();
 	
 #ifdef MMU
-    wolfBoot_printf("Booting at %p, with DTB at %p\n", load_address, dts_address);
+    wolfBoot_printf("Booting at %p, with DTB at %p\r\n", load_address, dts_address);
     do_boot((uint32_t*)load_address, (uint32_t*)dts_address);
 #else
     wolfBoot_printf("Booting at %p\r\n", load_address);

--- a/src/update_ram.c
+++ b/src/update_ram.c
@@ -155,7 +155,7 @@ void RAMFUNCTION wolfBoot_start(void)
     wolfBoot_printf("Booting at %p, with DTB at %p\n", load_address, dts_address);
     do_boot((uint32_t*)load_address, (uint32_t*)dts_address);
 #else
+    wolfBoot_printf("Booting at %p\r\n", load_address);
     do_boot((uint32_t*)load_address);
 #endif
-    wolfBoot_printf("Booting at %p\r\n", load_address);
 }

--- a/tools/scripts/create-image-test-vectors.sh
+++ b/tools/scripts/create-image-test-vectors.sh
@@ -24,8 +24,8 @@ python3 ${WBDIR}/tools/keytools/sign.py --rsa4096 --sha3 20m.bin ${WBDIR}/rsa409
 echo "INFO: create a forged signature"
 
 cp 1m.bin 1m-forged.bin
-cp ${WBDIR}/rsa4096.der rsa4096-forged.der
-dd if=/dev/urandom of=rsa4096-forged.der bs=1 count=16 seek=1024 conv=notrunc
+python3 ${WBDIR}/tools/keytools/keygen.py --rsa4096 rsa4096-forged.c
+mv rsa4096.der rsa4096-forged.der
 python3 ${WBDIR}/tools/keytools/sign.py --rsa4096 --sha3 1m-forged.bin rsa4096-forged.der 1
 
 echo "INFO: tamper with signed test material"
@@ -37,25 +37,28 @@ dd if=/dev/urandom of=1m_v1_signed-but-tampered.bin bs=1 count=1 seek=10k conv=n
 
 echo "INFO: create test images"
 
-cat ${WBDIR}/wolfboot-align.bin 1m_v1_signed.bin > kernel8-without-dtb.img
+cat ${WBDIR}/wolfboot-align.bin 1m_v1_signed.bin > test-05-no-dtb-partition.img
 cat ${WBDIR}/wolfboot-align.bin 1m-forged_v1_signed.bin > kernel8-forged.img
-cp kernel8-without-dtb.img kernel8-with-dtb.img
-cp kernel8-forged.img kernel8-forged-with-dtb.img
-cp kernel8-without-dtb.img kernel8-with-dtb-tampered.img
+cat ${WBDIR}/wolfboot-align.bin 1m.bin > test-01-no-boot-partition.img
+cp test-05-no-dtb-partition.img test-07-with-signed-dtb.img
+cp test-05-no-dtb-partition.img test-08-with-raw-dtb.img
+cp kernel8-forged.img test-04-forged-boot-image-with-signed-dtb.img
+cp test-05-no-dtb-partition.img test-06-with-tampered-dtb.img
 
-cat ${WBDIR}/wolfboot-align.bin 1m_v1_signed-but-tampered.bin > kernel8-tampered-with-dtb.img
+cat ${WBDIR}/wolfboot-align.bin 1m_v1_signed-but-tampered.bin > test-03-tampered-boot-image-with-signed-dtb.img
 
 cat ${WBDIR}/wolfboot-align.bin 20m_v1_signed.bin > kernel8-oversized.img
-cp kernel8-oversized.img kernel8-oversized-with-dtb.img
+cp kernel8-oversized.img test-02-oversized-boot-image-with-signed-dtb.img
 
-dd if=tes_v1_signed.bin of=kernel8-with-dtb.img bs=1 seek=128k conv=notrunc
-dd if=tes_v1_signed.bin of=kernel8-forged-with-dtb.img bs=1 seek=128k conv=notrunc
-dd if=tes_v1_signed-but-tampered.bin of=kernel8-with-dtb-tampered.img bs=1 seek=128k conv=notrunc
-dd if=tes_v1_signed.bin of=kernel8-oversized-with-dtb.img bs=1 seek=128k conv=notrunc
+dd if=tes_v1_signed.bin of=test-07-with-signed-dtb.img bs=1 seek=128k conv=notrunc
+dd if=test.dtb of=test-08-with-raw-dtb.img bs=1 seek=128k conv=notrunc
+dd if=tes_v1_signed.bin of=test-04-forged-boot-image-with-signed-dtb.img bs=1 seek=128k conv=notrunc
+dd if=tes_v1_signed-but-tampered.bin of=test-06-with-tampered-dtb.img bs=1 seek=128k conv=notrunc
+dd if=tes_v1_signed.bin of=test-02-oversized-boot-image-with-signed-dtb.img bs=1 seek=128k conv=notrunc
 
 echo "INFO: clean-up"
 
-rm rsa4096-forged.der kernel8-forged.img kernel8-oversized.img *.bin test.dtb
+rm rsa4096-forged.* kernel8-forged.img kernel8-oversized.img *.bin test.dtb
 
 echo "INFO: Created following image test vectors, boot them for debug prints"
 cd ..

--- a/tools/scripts/create-image-test-vectors.sh
+++ b/tools/scripts/create-image-test-vectors.sh
@@ -11,7 +11,7 @@ cd image-test-vectors
 
 echo "INFO: create dummy images and download a DTB"
 
-curl -o test.dtb https://github.com/raspberrypi/firmware/blob/master/boot/bcm2710-rpi-3-b.dtb
+curl -L -o test.dtb https://github.com/raspberrypi/firmware/raw/master/boot/bcm2710-rpi-3-b.dtb
 dd bs=1m count=1 if=/dev/urandom of=1m.bin
 dd bs=20m count=1 if=/dev/urandom of=20m.bin
 

--- a/tools/scripts/create-image-test-vectors.sh
+++ b/tools/scripts/create-image-test-vectors.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+
+cp config/examples/raspi3.config .config
+make distclean
+env LANG=C env LC_ALL=C make ARCH_FLASH_OFFSET=0x80000
+
+cd $(dirname $0)/../..
+WBDIR=$(pwd)
+mkdir -p image-test-vectors
+cd image-test-vectors
+
+echo "INFO: create dummy images and download a DTB"
+
+curl -o test.dtb https://github.com/raspberrypi/firmware/blob/master/boot/bcm2710-rpi-3-b.dtb
+dd bs=1m count=1 if=/dev/urandom of=1m.bin
+dd bs=20m count=1 if=/dev/urandom of=20m.bin
+
+echo "INFO: sign test material"
+
+python3 ${WBDIR}/tools/keytools/sign.py --rsa4096 --sha3 test.dtb ${WBDIR}/rsa4096.der 1
+python3 ${WBDIR}/tools/keytools/sign.py --rsa4096 --sha3 1m.bin ${WBDIR}/rsa4096.der 1
+python3 ${WBDIR}/tools/keytools/sign.py --rsa4096 --sha3 20m.bin ${WBDIR}/rsa4096.der 1
+
+echo "INFO: create a forged signature"
+
+cp 1m.bin 1m-forged.bin
+cp ${WBDIR}/rsa4096.der rsa4096-forged.der
+dd if=/dev/urandom of=rsa4096-forged.der bs=1 count=16 seek=1024 conv=notrunc
+python3 ${WBDIR}/tools/keytools/sign.py --rsa4096 --sha3 1m-forged.bin rsa4096-forged.der 1
+
+echo "INFO: tamper with signed test material"
+
+cp tes_v1_signed.bin tes_v1_signed-but-tampered.bin
+cp 1m_v1_signed.bin 1m_v1_signed-but-tampered.bin
+dd if=/dev/urandom of=tes_v1_signed-but-tampered.bin bs=1 count=1 seek=10k conv=notrunc
+dd if=/dev/urandom of=1m_v1_signed-but-tampered.bin bs=1 count=1 seek=10k conv=notrunc
+
+echo "INFO: create test images"
+
+cat ${WBDIR}/wolfboot-align.bin 1m_v1_signed.bin > kernel8-without-dtb.img
+cat ${WBDIR}/wolfboot-align.bin 1m-forged_v1_signed.bin > kernel8-forged.img
+cp kernel8-without-dtb.img kernel8-with-dtb.img
+cp kernel8-forged.img kernel8-forged-with-dtb.img
+cp kernel8-without-dtb.img kernel8-with-dtb-tampered.img
+
+cat ${WBDIR}/wolfboot-align.bin 1m_v1_signed-but-tampered.bin > kernel8-tampered-with-dtb.img
+
+cat ${WBDIR}/wolfboot-align.bin 20m_v1_signed.bin > kernel8-oversized.img
+cp kernel8-oversized.img kernel8-oversized-with-dtb.img
+
+dd if=tes_v1_signed.bin of=kernel8-with-dtb.img bs=1 seek=128k conv=notrunc
+dd if=tes_v1_signed.bin of=kernel8-forged-with-dtb.img bs=1 seek=128k conv=notrunc
+dd if=tes_v1_signed-but-tampered.bin of=kernel8-with-dtb-tampered.img bs=1 seek=128k conv=notrunc
+dd if=tes_v1_signed.bin of=kernel8-oversized-with-dtb.img bs=1 seek=128k conv=notrunc
+
+echo "INFO: clean-up"
+
+rm rsa4096-forged.der kernel8-forged.img kernel8-oversized.img *.bin test.dtb
+
+echo "INFO: Created following image test vectors, boot them for debug prints"
+cd ..
+ls -la image-test-vectors/*.img


### PR DESCRIPTION
Proposal to unify and enhance partition and image loading related debug prints. Also includes format string vs. parameter type mismatch fixes and proposal to use CRLF in debug prints for serial console friendliness.

Includes a script to generate image test vectors to exercise out different partition and image construction mistakes. Corresponding debug print output is given below:

```
$ qemu-system-aarch64 -M raspi3 -serial null -serial stdio -kernel image-test-vectors/test-01-no-boot-partition.img

raspi3:debug_uart_init() completed
raspi3:hal_init() completed
wolfBoot_start(): entered
wolfBoot_start(): Active Part -1
wolfBoot_start(): no partitions found
boot_panic(): entered - to die here

$ qemu-system-aarch64 -M raspi3 -serial null -serial stdio -kernel image-test-vectors/test-02-oversized-boot-image-with-signed-dtb.img

raspi3:debug_uart_init() completed
raspi3:hal_init() completed
wolfBoot_start(): entered
wolfBoot_start(): Active Part 0
wolfBoot_open_image(): looking for boot partition at 0x00000000000C0000
wolfBoot_open_image(): image size 0x01400000 exceeds max available partition space 0x00f5fc00
wolfBoot_start(): Failure -1: Part 0, Hdr ?, Hash ?, Sig ?
wolfBoot_start(): no fallback image available
boot_panic(): entered - to die here

$ qemu-system-aarch64 -M raspi3 -serial null -serial stdio -kernel image-test-vectors/test-03-tampered-boot-image-with-signed-dtb.img

raspi3:debug_uart_init() completed
raspi3:hal_init() completed
wolfBoot_start(): entered
wolfBoot_start(): Active Part 0
wolfBoot_open_image(): looking for boot partition at 0x00000000000C0000
wolfBoot_start(): Failure 1: Part 0, Hdr ok, Hash ?, Sig ?
wolfBoot_start(): no fallback image available
boot_panic(): entered - to die here

$ qemu-system-aarch64 -M raspi3 -serial null -serial stdio -kernel image-test-vectors/test-04-forged-boot-image-with-signed-dtb.img

raspi3:debug_uart_init() completed
raspi3:hal_init() completed
wolfBoot_start(): entered
wolfBoot_start(): Active Part 0
wolfBoot_open_image(): looking for boot partition at 0x00000000000C0000
wolfBoot_start(): Failure -1: Part 0, Hdr ok, Hash ok, Sig ?
wolfBoot_start(): no fallback image available
boot_panic(): entered - to die here

$ qemu-system-aarch64 -M raspi3 -serial null -serial stdio -kernel image-test-vectors/test-05-no-dtb-partition.img

raspi3:debug_uart_init() completed
raspi3:hal_init() completed
wolfBoot_start(): entered
wolfBoot_start(): Active Part 0
wolfBoot_open_image(): looking for boot partition at 0x00000000000C0000
wolfBoot_start(): Firmware Valid
wolfBoot_open_image(): looking for DTB boot partition at 0x00000000000A0000
wolfBoot_open_image(): value 0xffffffff at 0x00000000000A0000 does not match expected DTB image magic 0xedfe0dd0
wolfBoot_start(): Booting at 0x0000000003000000, with DTB at 0x0000000000000000

$ qemu-system-aarch64 -M raspi3 -serial null -serial stdio -kernel image-test-vectors/test-06-with-tampered-dtb.img

raspi3:debug_uart_init() completed
raspi3:hal_init() completed
wolfBoot_start(): entered
wolfBoot_start(): Active Part 0
wolfBoot_open_image(): looking for boot partition at 0x00000000000C0000
wolfBoot_start(): Firmware Valid
wolfBoot_open_image(): looking for DTB boot partition at 0x00000000000A0000
wolfBoot_open_image(): value 0x464c4f57 at 0x00000000000A0000 does not match expected DTB image magic 0xedfe0dd0
wolfBoot_start(): Booting at 0x0000000003000000, with DTB at 0x0000000000000000

$ qemu-system-aarch64 -M raspi3 -serial null -serial stdio -kernel image-test-vectors/test-07-with-signed-dtb.img

raspi3:debug_uart_init() completed
raspi3:hal_init() completed
wolfBoot_start(): entered
wolfBoot_start(): Active Part 0
wolfBoot_open_image(): looking for boot partition at 0x00000000000C0000
wolfBoot_start(): Firmware Valid
wolfBoot_open_image(): looking for DTB boot partition at 0x00000000000A0000
wolfBoot_open_image(): value 0x464c4f57 at 0x00000000000A0000 does not match expected DTB image magic 0xedfe0dd0
wolfBoot_start(): Booting at 0x0000000003000000, with DTB at 0x0000000000000000

$ qemu-system-aarch64 -M raspi3 -serial null -serial stdio -kernel image-test-vectors/test-08-with-raw-dtb.img

raspi3:debug_uart_init() completed
raspi3:hal_init() completed
wolfBoot_start(): entered
wolfBoot_start(): Active Part 0
wolfBoot_open_image(): looking for boot partition at 0x00000000000C0000
wolfBoot_start(): Firmware Valid
wolfBoot_open_image(): looking for DTB boot partition at 0x00000000000A0000
wolfBoot_start(): Booting at 0x0000000003000000, with DTB at 0x0000000004000000
```