### PR TITLE
fixes to stm327 hal_flash_write for bank 1 writes

### DIFF
--- a/hal/stm32h7.c
+++ b/hal/stm32h7.c
@@ -209,7 +209,7 @@ static void RAMFUNCTION flash_program_on(uint8_t bank)
             ;
     } else {
         FLASH_CR2 |= FLASH_CR_PG;
-        while ((FLASH_CR1 & FLASH_CR_PG) == 0)
+        while ((FLASH_CR2 & FLASH_CR_PG) == 0)
             ;
     }
 }
@@ -232,7 +232,7 @@ int RAMFUNCTION hal_flash_write(uint32_t address, const uint8_t *data, int len)
     int off = (address + i) - (((address + i) >> 5) << 5);
     uint32_t base_addr = (address + i) & (~0x1F); /* aligned to 256 bit */
 
-    if ((address & 0x01000000) != 0) {
+    if ((address & 0x0100000) != 0) {
         bank = 1;
     }
 


### PR DESCRIPTION
I encountered a few small problems while trying to use the sample stm32h7 test-app/hal to perform a full update cycle. The root issue was it failed to write the update partition magic/state because of some incorrect logic for Bank 1 (aka Bank 2) flash writes. These changes resolved the issue and I was able to successfully perform a full update cycle! I'm using a STM32H743ZI Nucleo for testing, which is very similar to the H753 Nucleo this code was originally written for.
