### PR TITLE
make: PPC/Big Endian support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ all: $(MAIN_TARGET)
 
 wolfboot.bin: wolfboot.elf
 	@echo "\t[BIN] $@"
-	$(Q)$(OBJCOPY) -O binary --gap-fill=255 $^ $@
+	$(Q)$(OBJCOPY) -O binary $^ $@
 
 align: wolfboot-align.bin
 
@@ -55,7 +55,7 @@ BOOTLOADER_PARTITION_SIZE=$$(( $(WOLFBOOT_PARTITION_BOOT_ADDRESS) - $(ARCH_FLASH
 BOOT_PAD_TO_ADDR=$$(($(WOLFBOOT_START) + $(BOOTLOADER_PARTITION_SIZE)))
 
 wolfboot-align.bin: wolfboot.elf
-	$(Q)$(OBJCOPY) -O binary --gap-fill=255 --pad-to=$(BOOT_PAD_TO_ADDR) wolfboot.elf $@
+	$(Q)$(OBJCOPY) -O binary wolfboot.elf $@
 	@echo
 	@echo "\t[SIZE]"
 	$(Q)$(SIZE) wolfboot.elf
@@ -127,7 +127,7 @@ keys: $(PRIVATE_KEY)
 
 clean:
 	@find . -type f -name "*.o" | xargs rm -f
-	@rm -f *.bin *.elf wolfboot.map *.bin  *.hex config/target.ld
+	@rm -f *.bin *.elf wolfboot.map test-update.rom *.hex config/target.ld
 	@make -C test-app clean
 	@make -C tools/check_config clean
 

--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,13 @@ clean:
 
 distclean: clean
 	@rm -f *.pem *.der tags ./src/*_pub_key.c include/target.h
-	@make -C tools/keytools clean
+	$(Q)$(MAKE) -C tools/keytools clean
+	$(Q)$(MAKE) -C tools/bin-assemble clean
+	$(Q)$(MAKE) -C tools/check_config clean
+	$(Q)$(MAKE) -C tools/test-expect-version clean
+	$(Q)$(MAKE) -C tools/test-update-server clean
+	$(Q)$(MAKE) -C tools/uart-flash-server clean
+	$(Q)$(MAKE) -C tools/unit-tests clean
 
 include/target.h: include/target.h.in FORCE
 	@cat include/target.h.in | \

--- a/Makefile
+++ b/Makefile
@@ -94,14 +94,10 @@ test-app/image_v1_signed.bin: test-app/image.bin
 	@echo "\t[SIGN] $(BOOT_IMG)"
 	$(Q)$(SIGN_TOOL) $(SIGN_OPTIONS) $(BOOT_IMG) $(PRIVATE_KEY) 1
 
-factory.bin: $(BOOT_IMG) wolfboot-align.bin $(PRIVATE_KEY) test-app/image_v1_signed.bin
+factory.bin: $(BOOT_IMG) wolfboot-align.bin $(PRIVATE_KEY) test-app/image_v1_signed.bin $(BINASSEMBLE)
 	@echo "\t[MERGE] $@"
-	$(Q)$(OBJCOPY) --set-start=$(ARCH_OFFSET) \
-		--add-section .signed_image=test-app/image_v1_signed.bin \
-		--change-section-vma .signed_image=$(WOLFBOOT_PARTITION_BOOT_ADDRESS) \
-		--set-section-flags .signed_image=alloc,readonly \
-		wolfboot.elf factory.elf
-	$(Q)$(OBJCOPY) --gap-fill=255 -O binary factory.elf $@
+	$(Q)$(BINASSEMBLE) $@ $(ARCH_FLASH_OFFSET) wolfboot-align.bin \
+                              $(WOLFBOOT_PARTITION_BOOT_ADDRESS) test-app/image_v1_signed.bin
 
 wolfboot.elf: include/target.h $(OBJS) $(LSCRIPT) FORCE
 	@echo "\t[LD] $@"

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ include tools/config.mk
 
 ## Initializers
 WOLFBOOT_ROOT?=$(PWD)
-CFLAGS:=-D__WOLFBOOT -DWOLFBOOT_VERSION=$(WOLFBOOT_VERSION)UL -ffunction-sections -fdata-sections
+CFLAGS+=-D__WOLFBOOT -DWOLFBOOT_VERSION=$(WOLFBOOT_VERSION)UL -ffunction-sections -fdata-sections
 LSCRIPT:=config/target.ld
 LDFLAGS:=-T $(LSCRIPT) -Wl,-gc-sections -Wl,-Map=wolfboot.map -ffreestanding -nostartfiles
 OBJS:= \
@@ -158,10 +158,6 @@ config: FORCE
 check_config:
 	make -C tools/check_config
 
-
-../src/libwolfboot.o: ../src/libwolfboot.c FORCE
-	@echo "\t[CC-$(ARCH)] $@"
-	$(Q)$(CC) $(CFLAGS) -c -o $@ ../src/libwolfboot.c
 
 %.o:%.c
 	@echo "\t[CC-$(ARCH)] $@"

--- a/arch.mk
+++ b/arch.mk
@@ -10,7 +10,7 @@ else
 endif
 
 # Default flash offset
-ARCH_FLASH_OFFSET=0x0
+ARCH_FLASH_OFFSET?=0x0
 
 # Default SPI driver name
 SPI_TARGET=$(TARGET)
@@ -124,6 +124,20 @@ ifeq ($(ARCH),RISCV)
 
   OBJS+=src/boot_riscv.o src/vector_riscv.o
   ARCH_FLASH_OFFSET=0x20010000
+endif
+
+# powerpc
+ifeq ($(ARCH),PPC)
+  CROSS_COMPILE:=powerpc-linux-gnu-
+  CFLAGS+=-fno-builtin-printf -DUSE_M_TIME -g -nostartfiles
+  LDFLAGS+=-Wl,--build-id=none
+  #MATH_OBJS += ./lib/wolfssl/wolfcrypt/src/sp_c32.o
+
+  # Prune unused functions and data
+  CFLAGS +=-ffunction-sections -fdata-sections
+  LDFLAGS+=-Wl,--gc-sections
+
+  OBJS+=src/boot_ppc_start.o src/boot_ppc.o
 endif
 
 ifeq ($(TARGET),kinetis)

--- a/include/wolfboot/wolfboot.h
+++ b/include/wolfboot/wolfboot.h
@@ -40,8 +40,13 @@
 #   define FLASHBUFFER_SIZE IMAGE_HEADER_SIZE
 #endif
 
-#define WOLFBOOT_MAGIC          0x464C4F57 /* WOLF */
-#define WOLFBOOT_MAGIC_TRAIL    0x544F4F42 /* BOOT */
+#ifdef BIG_ENDIAN_ORDER
+#    define WOLFBOOT_MAGIC          0X574F4C46 /* WOLF */
+#    define WOLFBOOT_MAGIC_TRAIL    0x424F4F54 /* BOOT */
+#else
+#    define WOLFBOOT_MAGIC          0x464C4F57 /* WOLF */
+#    define WOLFBOOT_MAGIC_TRAIL    0x544F4F42 /* BOOT */
+#endif
 
 #define HDR_END         0x00
 #define HDR_VERSION     0x01

--- a/src/image.c
+++ b/src/image.c
@@ -610,6 +610,16 @@ int wolfBoot_tpm2_init(void)
 
 #endif /* WOLFBOOT_TPM */
 
+static inline uint32_t im2n(uint32_t val)
+{
+#ifdef BIG_ENDIAN_ORDER
+    val = (((val & 0x000000FF) << 24) |
+           ((val & 0x0000FF00) <<  8) |
+           ((val & 0x00FF0000) >>  8) |
+           ((val & 0xFF000000) >> 24));
+#endif
+  return val;
+}
 
 int wolfBoot_open_image(struct wolfBoot_image *img, uint8_t part)
 {
@@ -673,10 +683,10 @@ int wolfBoot_open_image(struct wolfBoot_image *img, uint8_t part)
         return -1;
     size = (uint32_t *)(image + sizeof (uint32_t));
 
-    if (*size > (WOLFBOOT_PARTITION_SIZE - IMAGE_HEADER_SIZE))
+    if (im2n(*size) > (WOLFBOOT_PARTITION_SIZE - IMAGE_HEADER_SIZE))
        return -1;
     img->hdr_ok = 1;
-    img->fw_size = *size;
+    img->fw_size = im2n(*size);
     img->fw_base = img->hdr + IMAGE_HEADER_SIZE;
     img->trailer = img->hdr + WOLFBOOT_PARTITION_SIZE;
     return 0;

--- a/test-app/Makefile
+++ b/test-app/Makefile
@@ -180,7 +180,7 @@ standalone:LDFLAGS:=$(CFLAGS) -T standalone.ld -Wl,-gc-sections -Wl,-Map=image.m
 
 image.bin: image.elf
 	@echo "\t[BIN] $@"
-	$(Q)$(OBJCOPY) -O binary $^ $@
+	$(Q)$(OBJCOPY) --gap-fill=255 --pad-to $$(( $(WOLFBOOT_PARTITION_BOOT_ADDRESS) + $(WOLFBOOT_PARTITION_SIZE) )) -O binary $^ $@
 
 image.elf: $(APP_OBJS) $(LSCRIPT)
 	@echo "\t[LD] $@"

--- a/test-app/Makefile
+++ b/test-app/Makefile
@@ -180,7 +180,7 @@ standalone:LDFLAGS:=$(CFLAGS) -T standalone.ld -Wl,-gc-sections -Wl,-Map=image.m
 
 image.bin: image.elf
 	@echo "\t[BIN] $@"
-	$(Q)$(OBJCOPY) --gap-fill=255 --pad-to $$(( $(WOLFBOOT_PARTITION_BOOT_ADDRESS) + $(WOLFBOOT_PARTITION_SIZE) )) -O binary $^ $@
+	$(Q)$(OBJCOPY) -O binary $^ $@
 
 image.elf: $(APP_OBJS) $(LSCRIPT)
 	@echo "\t[LD] $@"

--- a/tools/bin-assemble/Makefile
+++ b/tools/bin-assemble/Makefile
@@ -1,0 +1,11 @@
+CC=gcc
+CFLAGS=-Wall -g -ggdb
+EXE=bin-assemble
+
+LIBS=
+
+$(EXE): $(EXE).o
+	$(CC) -o $@ $^ $(CFLAGS) $(LIBS)
+
+clean:
+	rm -f *.o $(EXE)

--- a/tools/bin-assemble/bin-assemble.c
+++ b/tools/bin-assemble/bin-assemble.c
@@ -1,0 +1,205 @@
+/* bin-assemble.c
+ *
+ * Copyright (C) 2006-2020 wolfSSL Inc.
+ *
+ * This file is part of wolfBoot.
+ *
+ * wolfBoot is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfBoot is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ *=============================================================================
+ *
+ * assemble binary parts based on address
+ *
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <errno.h>
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <string.h>
+
+#define BLOCK_SZ 1024
+
+void usage(const char* execname)
+{
+    fprintf(stderr,
+            "%s output [<address> <input>]\n"
+            "assemble binary parts with addresses",
+            execname);
+    exit(1);
+}
+
+typedef struct {
+    const char* fname;
+    size_t      address;
+    size_t      nbytes;
+} binentry_t;
+
+int binentry_address_compare(const void* a, const void* b)
+{
+    const binentry_t* ba = (const binentry_t*)a;
+    const binentry_t* bb = (const binentry_t*)b;
+
+    if (ba->address < bb->address) {
+        return -1;
+    } else if (ba->address > bb->address) {
+        return 1;
+    } else {
+        return 0;
+    }
+}
+
+
+int main(int argc, const char* argv[]) {
+    const char* outname = NULL;
+    size_t i = 0;
+    size_t num_entries = 0;
+    binentry_t* entries = NULL;
+    size_t cur_add = 0;
+    char fill = '\xff';
+    size_t nr = 0;
+    size_t nw = 0;
+    char data[BLOCK_SZ];
+    int err = 0;
+
+    /* require at least 1 input file */
+    if (argc < 4 || (argc % 2) != 0) {
+        usage(argv[0]);
+    }
+
+    outname = argv[1];
+    num_entries = (argc - 2) / 2;
+
+    entries = malloc( sizeof(binentry_t) * num_entries);
+    if (entries == NULL) {
+        fprintf(stderr, "unable to allocate %zu entries\n;", num_entries);
+        return EXIT_FAILURE;
+    }
+
+    for (i=0; i<num_entries; i++) {
+        char* endptr = NULL;
+        struct stat st;
+
+        entries[i].address = strtol(argv[2*i + 2], &endptr, 0);
+        if (*endptr) {
+            fprintf(stderr,
+                    "Remaining characters in adderss field %s\n", endptr);
+        }
+        entries[i].fname = argv[2*i + 3];
+
+        if (stat(entries[i].fname, &st)) {
+            fprintf(stderr, "unable to stat %s: %s\n", entries[i].fname,
+                    strerror(errno));
+            return EXIT_FAILURE;
+        }
+
+        entries[i].nbytes = st.st_size;
+
+#if VERBOSE
+        printf("%s %zu %zu\n",
+               entries[i].fname,
+               entries[i].address,
+               entries[i].nbytes);
+#endif
+    }
+
+    qsort(entries, num_entries, sizeof(binentry_t), binentry_address_compare);
+
+    // check for overlap
+    for (i=1; i<num_entries; i++) {
+        size_t endaddr = entries[i-1].address + entries[i-1].nbytes;
+        if (endaddr > entries[i].address) {
+            fprintf(stderr,
+              "overlap with %s(end address 0x%zx) and %s (start address 0x%zx \n",
+                    entries[i-1].fname, endaddr,
+                    entries[i].fname, entries[i].address);
+            err = 1;
+        }
+        if (err) {
+            return err;
+        }
+
+    }
+
+    // TODO: consider handling stdout "-"
+
+    FILE* fo = fopen(outname, "wb");
+    if (fo == NULL){
+        fprintf(stderr, "opening %s failed %s\n",
+                outname, strerror(errno));
+        return EXIT_FAILURE;
+    }
+
+    cur_add = entries[0].address;
+    for (i=0; i<num_entries; i++) {
+        FILE* fi = fopen(entries[i].fname, "rb");
+        if (fi == NULL){
+            fprintf(stderr, "opening %s failed %s\n",
+                    entries[i].fname, strerror(errno));
+            return EXIT_FAILURE;
+        }
+
+        /* fill until address */
+        while(cur_add < entries[i].address) {
+            nw = fwrite(&fill, 1, 1, fo);
+            if (nw != 1) {
+                fprintf(stderr,
+                  "Failed to write fill bytes at 0x%zu\n",
+                        cur_add);
+                return EXIT_FAILURE;
+            }
+
+            cur_add++;
+        }
+
+        while (!feof(fi)) {
+            nr = fread(data, 1, BLOCK_SZ, fi);
+            nw = fwrite(data, 1, nr, fo);
+            cur_add += nw;
+            if (nr != nw) {
+                fprintf(stderr,
+                  "Failed to wrote %zu bytes of the %zu bytes read from %s\n",
+                        nw, nr, entries[i].fname);
+                return EXIT_FAILURE;
+            }
+
+            if (ferror(fi)) {
+                fprintf(stderr,
+                        "error reading from %s\n",
+                        entries[i].fname);
+                return EXIT_FAILURE;
+            }
+
+            if (ferror(fo)) {
+                fprintf(stderr,
+                        "error writing to %s\n",
+                        entries[i].fname);
+                return EXIT_FAILURE;
+            }
+
+        }
+
+
+        fclose(fi);
+    }
+
+    fclose(fo);
+
+    return 0;
+}

--- a/tools/test-expect-version/Makefile
+++ b/tools/test-expect-version/Makefile
@@ -1,8 +1,8 @@
 CC=gcc
-CFLAGS=-Wall -DWOLFSSL_DTLS -DWOLFSSL_DEBUG -DTFM_TIMING_RESISTANT -g -ggdb
+CFLAGS=-Wall -g -ggdb
 EXE=test-expect-version
 
-LIBS=-lwolfssl -lpthread
+LIBS=
 
 $(EXE): $(EXE).o
 	$(CC) -o $@ $^ $(CFLAGS) $(LIBS)

--- a/tools/test-update-server/Makefile
+++ b/tools/test-update-server/Makefile
@@ -1,8 +1,8 @@
 CC=gcc
-CFLAGS=-Wall -DWOLFSSL_DEBUG -DTFM_TIMING_RESISTANT -g -ggdb
+CFLAGS=-Wall -g -ggdb
 EXE=server
 
-LIBS=-lwolfssl -lpthread
+LIBS=-lpthread
 
 $(EXE): $(EXE).o
 	$(CC) -o $@ $^ $(CFLAGS) $(LIBS)

--- a/tools/test.mk
+++ b/tools/test.mk
@@ -120,11 +120,9 @@ test-update: test-app/image.bin FORCE
 		(make test-reset && sleep 1 && st-flash --reset write test-update.bin 0x08040000) || \
 		(make test-reset && sleep 1 && st-flash --reset write test-update.bin 0x08040000)
 
-test-self-update: wolfboot.bin test-app/image.bin FORCE
+test-self-update: FORCE
 	@mv $(PRIVATE_KEY) private_key.old
-	@make clean
-	@rm src/*_pub_key.c
-	@make factory.bin RAM_CODE=1 WOLFBOOT_VERSION=$(WOLFBOOT_VERSION) SIGN=$(SIGN)
+	@make -b factory.bin RAM_CODE=1 WOLFBOOT_VERSION=$(WOLFBOOT_VERSION) SIGN=$(SIGN)
 	@$(SIGN_TOOL) $(SIGN_ARGS) test-app/image.bin $(PRIVATE_KEY) $(TEST_UPDATE_VERSION)
 	@st-flash --reset write test-app/image_v2_signed.bin 0x08020000 || \
 		(make test-reset && sleep 1 && st-flash --reset write test-app/image_v2_signed.bin 0x08020000) || \
@@ -288,8 +286,6 @@ test-23-rollback-SPI: $(EXPVER) FORCE
 
 test-34-forward-self-update: $(EXPVER) FORCE
 	@echo Creating and uploading factory image...
-	@make clean
-	@make distclean
 	@make test-factory RAM_CODE=1 SIGN=$(SIGN)
 	@echo Expecting version '1'
 	@(test `$(EXPVER)` -eq 1)
@@ -297,6 +293,7 @@ test-34-forward-self-update: $(EXPVER) FORCE
 	@echo Updating keys, firmware, bootloader
 	@make test-self-update WOLFBOOT_VERSION=4 RAM_CODE=1 SIGN=$(SIGN)
 	@sleep 2
+	@echo Expecting version '2'
 	@(test `$(EXPVER)` -eq 2)
 	@make clean
 	@echo TEST PASSED

--- a/tools/test.mk
+++ b/tools/test.mk
@@ -1,6 +1,7 @@
 TEST_UPDATE_VERSION?=2
 WOLFBOOT_VERSION?=0
 EXPVER=tools/test-expect-version/test-expect-version
+BINASSEMBLE=tools/bin-assemble/bin-assemble
 SPI_CHIP=SST25VF080B
 SPI_OPTIONS=SPI_FLASH=1 WOLFBOOT_PARTITION_SIZE=0x80000 WOLFBOOT_PARTITION_UPDATE_ADDRESS=0x00000 WOLFBOOT_PARTITION_SWAP_ADDRESS=0x80000
 SIGN_ARGS=
@@ -49,7 +50,10 @@ ifeq ($(HASH),SHA3)
 endif
 
 $(EXPVER):
-	make -C tools/test-expect-version
+	$(MAKE) -C $(dir $@)
+
+$(BINASSEMBLE):
+	$(MAKE) -C $(dir $@)
 
 # Testbed actions
 #


### PR DESCRIPTION
Add `bin-assemble` tool instead of `dd` for more flexible assembly of factory image.
Add Big Endian support for header and trailer

makefile clean up
 * remove unused targets
 * distclean - cleans all tools
 * remove use of some temp files