### PR TITLE
Fix for Jenkins tests

### DIFF
--- a/include/uart_flash.h
+++ b/include/uart_flash.h
@@ -35,7 +35,7 @@
 
 #ifdef UART_FLASH
     #ifndef UART_FLASH_BITRATE
-      #define UART_FLASH_BITRATE 460800
+      #define UART_FLASH_BITRATE 115200
     #endif
     void uart_send_current_version(void);
 #else

--- a/tools/test-delta.mk
+++ b/tools/test-delta.mk
@@ -1,8 +1,8 @@
-SIGN_ARGS?=--ecc256
-SIGN_DELTA_ARGS?=--ecc256 --encrypt /tmp/enc_key.der
-USBTTY?=/dev/ttyACM0
-TIMEOUT?=60
-EXPVER=tools/test-expect-version/test-expect-version /dev/ttyACM0
+test-delta-update:SIGN_ARGS?=--ecc256
+test-delta-update:SIGN_DELTA_ARGS?=--ecc256 --encrypt /tmp/enc_key.der
+test-delta-update:USBTTY?=/dev/ttyACM0
+test-delta-update:TIMEOUT?=60
+test-delta-update:EXPVER=tools/test-expect-version/test-expect-version /dev/ttyACM0
 
 test-delta-update: factory.bin test-app/image.bin tools/uart-flash-server/ufserver tools/delta/bmdiff tools/test-expect-version/test-expect-version
 	@st-flash erase

--- a/tools/test-enc.mk
+++ b/tools/test-enc.mk
@@ -1,8 +1,8 @@
-ENC_TEST_UPDATE_VERSION?=2
-SIGN_ARGS?=--ecc256
-SIGN_ENC_ARGS?=--ecc256 --encrypt /tmp/enc_key.der
-USBTTY?=/dev/ttyACM0
-TIMEOUT?=60
+test-enc-update:ENC_TEST_UPDATE_VERSION?=2
+test-enc-update:SIGN_ARGS?=--ecc256
+test-enc-update:SIGN_ENC_ARGS?=--ecc256 --encrypt /tmp/enc_key.der
+test-enc-update:USBTTY?=/dev/ttyACM0
+test-enc-update:TIMEOUT?=60
 
 tools/uart-flash-server/ufserver: FORCE
 	@make -C `dirname $@`

--- a/tools/uart-flash-server/ufserver.c
+++ b/tools/uart-flash-server/ufserver.c
@@ -52,7 +52,7 @@
 
 #define FIRMWARE_PARTITION_SIZE 0x20000
 #define SWAP_SIZE 0x1000
-#define UART_BITRATE 460800
+#define UART_BITRATE 115200
 
 const char msgSha[]         = "Verifying SHA digest...";
 const char msgReadUpdate[]  = "Fetching update blocks ";


### PR DESCRIPTION
After merging #125 some tests are now broken.
This patch should fix jenkins non-regression tests.

Goals:
- Isolate variable definitions in the tests targets
- Set UART speed for STM32WB55 tests to 115200 to match the speed in the test application