### PR TITLE
Fixed key import ranges in ecc sign.py

### DIFF
--- a/tools/keytools/sign.py
+++ b/tools/keytools/sign.py
@@ -409,7 +409,7 @@ elif not sha_only and not manual_sign:
 
     if sign == 'ecc256':
         ecc = ciphers.EccPrivate()
-        ecc.decode_key_raw(wolfboot_key_buffer[0:31], wolfboot_key_buffer[32:63], wolfboot_key_buffer[64:])
+        ecc.decode_key_raw(wolfboot_key_buffer[0:32], wolfboot_key_buffer[32:64], wolfboot_key_buffer[64:])
         pubkey = wolfboot_key_buffer[0:64]
 
     if sign == 'rsa2048':


### PR DESCRIPTION
Same issue as [wolfcrypt-py/pulls/24](https://github.com/wolfSSL/wolfcrypt-py/pull/24)

The array slicing in `ecc.decode_key_raw()` call wrongly assumed array as
inclusive (i.e. [0:31] to include from 0 to 31, instead of the correct
form [0:32]).