### PR TITLE
Fix STM32L5 dual-bank mode

### DIFF
--- a/hal/stm32l5.c
+++ b/hal/stm32l5.c
@@ -642,6 +642,17 @@ static void gtzc_init(void)
 
 #define OPTR_SWAP_BANK (1 << 20)
 
+#define AIRCR *(volatile uint32_t *)(0xE000ED0C)
+#define AIRCR_VKEY (0x05FA << 16)
+#define AIRCR_SYSRESETREQ (1 << 2)
+
+static void RAMFUNCTION stm32l5_reboot(void)
+{
+    AIRCR = AIRCR_SYSRESETREQ | AIRCR_VKEY;
+    while(1)
+        ;
+
+}
 
 void RAMFUNCTION hal_flash_dualbank_swap(void)
 {
@@ -655,6 +666,7 @@ void RAMFUNCTION hal_flash_dualbank_swap(void)
         FLASH_OPTR |= FLASH_OPTR_SWAP_BANK;
     hal_flash_opt_lock();
     hal_flash_lock();
+    stm32l5_reboot();
 }
 
 static void led_unsecure()

--- a/test-app/app_stm32l5.c
+++ b/test-app/app_stm32l5.c
@@ -27,6 +27,7 @@
 #include <string.h>
 #include "system.h"
 #include "hal.h"
+#include "wolfboot/wolfboot.h"
 
 #define LED_BOOT_PIN (12)  //PG12 - Discovery - Green Led
 #define LED_USR_PIN (3) //PD3  - Discovery  - Red Led
@@ -100,6 +101,8 @@ void main(void)
     boot_led_on();
     usr_led_on();
     boot_led_off();
+    if (wolfBoot_current_firmware_version() > 1)
+        boot_led_on();
     while(1)
         ;
 }


### PR DESCRIPTION
This patch fixes the dual-bank secure boot mode on STM32L5.

HW swap on this platform will reboot the system, so the status flag of the partition must be only updated after the swap (i.e. in the next reboot in this case, where the active partition is currently mapped as BOOT).

Changed the test app for stm32l5 to keep the boot led on when the version is >1.
