### PR TITLE
Added tests for ed448, fixed sign.py

### DIFF
--- a/options.mk
+++ b/options.mk
@@ -72,6 +72,11 @@ ifeq ($(SIGN),ED448)
     ./lib/wolfssl/wolfcrypt/src/wolfmath.o \
     ./lib/wolfssl/wolfcrypt/src/wc_port.o \
     ./lib/wolfssl/wolfcrypt/src/fe_low_mem.o
+  ifeq ($(WOLFBOOT_SMALL_STACK),1)
+    STACK_USAGE?=1024
+  else
+    STACK_USAGE?=4376
+  endif
 
   ifneq ($(HASH),SHA3)
     WOLFCRYPT_OBJS+=./lib/wolfssl/wolfcrypt/src/sha3.o
@@ -80,7 +85,6 @@ ifeq ($(SIGN),ED448)
   CFLAGS+=-D"WOLFBOOT_SIGN_ED448"
   IMAGE_HEADER_SIZE=512
   CFLAGS+=-DIMAGE_HEADER_SIZE=512
-  STACK_USAGE?=4376
 endif
 
 ifeq ($(SIGN),RSA2048)

--- a/src/xmalloc.c
+++ b/src/xmalloc.c
@@ -184,7 +184,7 @@ static struct xmalloc_slot xmalloc_pool[] = {
     { (uint8_t *)sha_block, HASH_BLOCK_SIZE * sizeof(uint32_t), 0 },
 #endif
     { (uint8_t *)aslide, GE448_WINDOW_BUF_SIZE, 0 },
-    { (uint8_t *)aslide, GE448_WINDOW_BUF_SIZE, 0 },
+    { (uint8_t *)bslide, GE448_WINDOW_BUF_SIZE, 0 },
     { (uint8_t *)&pi, sizeof(ge448_p2), 0 },
     { (uint8_t *)&p2, sizeof(ge448_p2), 0},
     { NULL, 0, 0}

--- a/src/xmalloc.c
+++ b/src/xmalloc.c
@@ -167,6 +167,32 @@ static struct xmalloc_slot xmalloc_pool[] = {
     { NULL, 0, 0}
 };
 
+
+#elif defined WOLFBOOT_SIGN_ED448
+
+#include <wolfssl/wolfcrypt/ge_448.h>
+
+#define GE448_WINDOW_BUF_SIZE 448
+
+static uint32_t aslide[GE448_WINDOW_BUF_SIZE / sizeof(uint32_t)];
+static uint32_t bslide[GE448_WINDOW_BUF_SIZE / sizeof(uint32_t)];
+static ge448_p2 pi, p2;
+static uint32_t sha_block[HASH_BLOCK_SIZE];
+
+static struct xmalloc_slot xmalloc_pool[] = {
+#ifdef WOLFBOOT_HASH_SHA256
+    { (uint8_t *)sha_block, HASH_BLOCK_SIZE * sizeof(uint32_t), 0 },
+#endif
+    { (uint8_t *)aslide, GE448_WINDOW_BUF_SIZE, 0 },
+    { (uint8_t *)aslide, GE448_WINDOW_BUF_SIZE, 0 },
+    { (uint8_t *)&pi, sizeof(ge448_p2), 0 },
+    { (uint8_t *)&p2, sizeof(ge448_p2), 0},
+    { NULL, 0, 0}
+};
+
+
+
+
 #elif defined(WOLFBOOT_SIGN_RSA2048) || defined(WOLFBOOT_SIGN_RSA4096)
 
 static uint32_t sha_block[HASH_BLOCK_SIZE];

--- a/tools/keytools/sign.py
+++ b/tools/keytools/sign.py
@@ -207,7 +207,7 @@ def make_header(image_file, fw_version, extra_fields=[]):
             print("Signing the firmware...")
             if (sign == 'ed25519'):
                 signature = ed.sign(digest)
-            if (sign == 'ed448'):
+            elif (sign == 'ed448'):
                 signature = ed.sign(digest)
             elif (sign == 'ecc256'):
                 r, s = ecc.sign_raw(digest)
@@ -422,6 +422,8 @@ elif not sha_only and not manual_sign:
         privkey, pubkey = ed.encode_key()
 
     if sign == 'ed448':
+        HDR_SIGNATURE_LEN = 114
+        WOLFBOOT_HEADER_SIZE = 512
         ed = ciphers.Ed448Private(key = wolfboot_key_buffer)
         privkey, pubkey = ed.encode_key()
 

--- a/tools/test.mk
+++ b/tools/test.mk
@@ -34,6 +34,10 @@ ifeq ($(SIGN),ED25519)
   SIGN_ARGS+= --ed25519
 endif
 
+ifeq ($(SIGN),ED448)
+  SIGN_ARGS+= --ed448
+endif
+
 ifeq ($(SIGN),ECC256)
   SIGN_ARGS+= --ecc256
 endif
@@ -347,7 +351,7 @@ test-63-rollback-TPM: $(EXPVER) FORCE
 	@make test-03-rollback SIGN=ECC256 WOLFTPM=1
 	@make tpm-mute
 
-# Group '7': RSA 4096 bit
+# Group '7': RSA 4096 bit and ED448
 #
 #
 test-71-forward-update-no-downgrade-RSA-4096: $(EXPVER) FORCE
@@ -356,7 +360,13 @@ test-71-forward-update-no-downgrade-RSA-4096: $(EXPVER) FORCE
 test-73-rollback-RSA-4096: $(EXPVER) FORCE
 	@make test-03-rollback SIGN=RSA4096
 
-# Group '8,9,10,11': SHA3 combined with the four ciphers
+test-74-forward-update-no-downgrade-ED448: $(EXPVER) FORCE
+	@make test-01-forward-update-no-downgrade SIGN=ED448
+
+test-75-rollback-ED448: $(EXPVER) FORCE
+	@make test-03-rollback SIGN=ED448
+
+# Group '8,9,10,11': SHA3 combined with the five ciphers
 #
 #
 
@@ -371,6 +381,9 @@ test-101-forward-update-no-downgrade-RSA2048-SHA3: $(EXPVER) FORCE
 
 test-111-forward-update-no-downgrade-RSA4096-SHA3: $(EXPVER) FORCE
 	@make test-01-forward-update-no-downgrade SIGN=RSA4096 HASH=SHA3
+
+test-112-forward-update-no-downgrade-ED448-SHA3: $(EXPVER) FORCE
+	@make test-01-forward-update-no-downgrade SIGN=ED448 HASH=SHA3 IMAGE_HEADER_SIZE=512
 
 # Group 16: TPM with RSA
 #
@@ -416,6 +429,9 @@ test-251-smallstack-forward-update-no-downgrade-RSA: $(EXPVER) FORCE
 test-271-smallstack-forward-update-no-downgrade-RSA4096: $(EXPVER) FORCE
 	@make test-71-forward-update-no-downgrade-RSA-4096 WOLFBOOT_SMALL_STACK=1
 
+test-274-smallstack-forward-update-no-downgrade-ED448: $(EXPVER) FORCE
+	@make test-74-forward-update-no-downgrade-ED448 WOLFBOOT_SMALL_STACK=1
+
 test-281-smallstack-forward-update-no-downgrade-ED25519-SHA3: $(EXPVER) FORCE
 	@make test-81-forward-update-no-downgrade-ED25519-SHA3 WOLFBOOT_SMALL_STACK=1
 
@@ -427,6 +443,9 @@ test-301-smallstack-forward-update-no-downgrade-RSA2048-SHA3: $(EXPVER) FORCE
 
 test-311-smallstack-forward-update-no-downgrade-RSA4096-SHA3: $(EXPVER) FORCE
 	@make test-111-forward-update-no-downgrade-RSA4096-SHA3 WOLFBOOT_SMALL_STACK=1
+
+test-312-smallstack-forward-update-no-downgrade-ED448-SHA3: $(EXPVER) FORCE
+	@make test-112-forward-update-no-downgrade-ED448-SHA3 WOLFBOOT_SMALL_STACK=1
 
 test-371-smallstack-forward-update-no-downgrade-NOSIGN: $(EXPVER) FORCE
 	@make test-171-forward-update-no-downgrade-NOSIGN WOLFBOOT_SMALL_STACK=1
@@ -449,6 +468,9 @@ test-451-fastmath-forward-update-no-downgrade-RSA: $(EXPVER) FORCE
 test-471-fastmath-forward-update-no-downgrade-RSA4096: $(EXPVER) FORCE
 	@make test-71-forward-update-no-downgrade-RSA-4096 SPMATH=0
 
+test-474-fastmath-forward-update-no-downgrade-ED448: $(EXPVER) FORCE
+	@make test-74-forward-update-no-downgrade-ED448 SPMATH=0
+
 test-481-fastmath-forward-update-no-downgrade-ED25519-SHA3: $(EXPVER) FORCE
 	@make test-81-forward-update-no-downgrade-ED25519-SHA3 SPMATH=0
 
@@ -460,6 +482,9 @@ test-501-fastmath-forward-update-no-downgrade-RSA2048-SHA3: $(EXPVER) FORCE
 
 test-511-fastmath-forward-update-no-downgrade-RSA4096-SHA3: $(EXPVER) FORCE
 	@make test-111-forward-update-no-downgrade-RSA4096-SHA3 SPMATH=0
+
+test-512-fastmath-forward-update-no-downgrade-ED448-SHA3: $(EXPVER) FORCE
+	@make test-112-forward-update-no-downgrade-ED448-SHA3 SPMATH=0
 
 test-571-fastmath-forward-update-no-downgrade-NOSIGN: $(EXPVER) FORCE
 	@make test-171-forward-update-no-downgrade-NOSIGN SPMATH=0
@@ -482,6 +507,9 @@ test-651-no-asm-forward-update-no-downgrade-RSA: $(EXPVER) FORCE
 test-671-no-asm-forward-update-no-downgrade-RSA4096: $(EXPVER) FORCE
 	@make test-71-forward-update-no-downgrade-RSA-4096 NO_ASM=1
 
+test-674-no-asm-forward-update-no-downgrade-ED448: $(EXPVER) FORCE
+	@make test-74-forward-update-no-downgrade-ED448 NO_ASM=1
+
 test-681-no-asm-forward-update-no-downgrade-ED25519-SHA3: $(EXPVER) FORCE
 	@make test-81-forward-update-no-downgrade-ED25519-SHA3 NO_ASM=1
 
@@ -493,6 +521,9 @@ test-701-no-asm-forward-update-no-downgrade-RSA2048-SHA3: $(EXPVER) FORCE
 
 test-711-no-asm-forward-update-no-downgrade-RSA4096-SHA3: $(EXPVER) FORCE
 	@make test-111-forward-update-no-downgrade-RSA4096-SHA3 NO_ASM=1
+
+test-712-no-asm-forward-update-no-downgrade-ED448-SHA3: $(EXPVER) FORCE
+	@make test-112-forward-update-no-downgrade-ED448-SHA3 NO_ASM=1
 
 test-771-no-asm-forward-update-no-downgrade-NOSIGN: $(EXPVER) FORCE
 	@make test-171-forward-update-no-downgrade-NOSIGN NO_ASM=1
@@ -514,6 +545,9 @@ test-851-no-asm-smallstack-forward-update-no-downgrade-RSA: $(EXPVER) FORCE
 
 test-871-no-asm-smallstack-forward-update-no-downgrade-RSA4096: $(EXPVER) FORCE
 	@make test-71-forward-update-no-downgrade-RSA-4096 NO_ASM=1 WOLFBOOT_SMALL_STACK=1
+
+test-874-no-asm-smallstack-forward-update-no-downgrade-ED448: $(EXPVER) FORCE
+	@make test-74-forward-update-no-downgrade-ED448 NO_ASM=1 WOLFBOOT_SMALL_STACK=1
 
 test-881-no-asm-smallstack-forward-update-no-downgrade-ED25519-SHA3: $(EXPVER) FORCE
 	@make test-81-forward-update-no-downgrade-ED25519-SHA3 NO_ASM=1 WOLFBOOT_SMALL_STACK=1
@@ -560,6 +594,9 @@ test-1101-fastmath-smallstack-forward-update-no-downgrade-RSA2048-SHA3: $(EXPVER
 test-1111-fastmath-smallstack-forward-update-no-downgrade-RSA4096-SHA3: $(EXPVER) FORCE
 	@make test-111-forward-update-no-downgrade-RSA4096-SHA3 SPMATH=0 WOLFBOOT_SMALL_STACK=1
 
+test-1112-fastmath-smallstack-forward-update-no-downgrade-ED448-SHA3: $(EXPVER) FORCE
+	@make test-112-forward-update-no-downgrade-ED448-SHA3 SPMATH=0 WOLFBOOT_SMALL_STACK=1
+
 test-1171-fastmath-smallstack-forward-update-no-downgrade-NOSIGN: $(EXPVER) FORCE
 	@make test-171-forward-update-no-downgrade-NOSIGN SPMATH=0 WOLFBOOT_SMALL_STACK=1
 
@@ -582,6 +619,7 @@ test-base: clean
 	make test-63-rollback-TPM
 	make test-71-forward-update-no-downgrade-RSA-4096
 	make test-73-rollback-RSA-4096
+	make test-74-forward-update-no-downgrade-ED448
 
 test-sha3: clean
 	@echo SHA3 Tests
@@ -592,6 +630,7 @@ test-sha3: clean
 	make test-91-forward-update-no-downgrade-ECC256-SHA3
 	make test-101-forward-update-no-downgrade-RSA2048-SHA3
 	make test-111-forward-update-no-downgrade-RSA4096-SHA3
+	make test-112-forward-update-no-downgrade-ED448-SHA3
 
 test-tpm: clean
 	@echo TPM Tests
@@ -619,10 +658,12 @@ test-smallstack: clean
 	make test-221-smallstack-forward-update-no-downgrade-SPI
 	make test-251-smallstack-forward-update-no-downgrade-RSA
 	make test-271-smallstack-forward-update-no-downgrade-RSA4096
+	make test-274-smallstack-forward-update-no-downgrade-ED448
 	make test-281-smallstack-forward-update-no-downgrade-ED25519-SHA3
 	make test-291-smallstack-forward-update-no-downgrade-ECC256-SHA3
 	make test-301-smallstack-forward-update-no-downgrade-RSA2048-SHA3
 	make test-311-smallstack-forward-update-no-downgrade-RSA4096-SHA3
+	make test-312-smallstack-forward-update-no-downgrade-ED448-SHA3
 	make test-371-smallstack-forward-update-no-downgrade-NOSIGN
 
 test-fastmath: clean
@@ -635,10 +676,12 @@ test-fastmath: clean
 	make test-421-fastmath-forward-update-no-downgrade-SPI
 	make test-451-fastmath-forward-update-no-downgrade-RSA
 	true || make test-471-fastmath-forward-update-no-downgrade-RSA4096 #Not enough RAM
+	make test-474-fastmath-forward-update-no-downgrade-ED448
 	make test-481-fastmath-forward-update-no-downgrade-ED25519-SHA3
 	make test-491-fastmath-forward-update-no-downgrade-ECC256-SHA3
 	make test-501-fastmath-forward-update-no-downgrade-RSA2048-SHA3
 	true || make test-511-fastmath-forward-update-no-downgrade-RSA4096-SHA3 #Not enough RAM
+	make test-512-fastmath-forward-update-no-downgrade-ED448-SHA3
 	make test-571-fastmath-forward-update-no-downgrade-NOSIGN
 
 test-no-asm: clean
@@ -651,10 +694,12 @@ test-no-asm: clean
 	make test-621-no-asm-forward-update-no-downgrade-SPI
 	make test-651-no-asm-forward-update-no-downgrade-RSA
 	make test-671-no-asm-forward-update-no-downgrade-RSA4096
+	make test-674-no-asm-forward-update-no-downgrade-ED448
 	make test-681-no-asm-forward-update-no-downgrade-ED25519-SHA3
 	make test-691-no-asm-forward-update-no-downgrade-ECC256-SHA3
 	make test-701-no-asm-forward-update-no-downgrade-RSA2048-SHA3
 	make test-711-no-asm-forward-update-no-downgrade-RSA4096-SHA3
+	make test-712-no-asm-forward-update-no-downgrade-ED448-SHA3
 	make test-771-no-asm-forward-update-no-downgrade-NOSIGN
 
 test-no-asm-smallstack: clean
@@ -667,10 +712,12 @@ test-no-asm-smallstack: clean
 	make test-821-no-asm-smallstack-forward-update-no-downgrade-SPI
 	make test-851-no-asm-smallstack-forward-update-no-downgrade-RSA
 	make test-871-no-asm-smallstack-forward-update-no-downgrade-RSA4096
+	make test-874-no-asm-smallstack-forward-update-no-downgrade-ED448
 	make test-881-no-asm-smallstack-forward-update-no-downgrade-ED25519-SHA3
 	make test-891-no-asm-smallstack-forward-update-no-downgrade-ECC256-SHA3
 	make test-901-no-asm-smallstack-forward-update-no-downgrade-RSA2048-SHA3
 	make test-911-no-asm-smallstack-forward-update-no-downgrade-RSA4096-SHA3
+	make test-912-no-asm-smallstack-forward-update-no-downgrade-ED448-SHA3
 	make test-971-no-asm-smallstack-forward-update-no-downgrade-NOSIGN
 
 test-fastmath-smallstack: clean
@@ -683,10 +730,12 @@ test-fastmath-smallstack: clean
 	make test-1021-fastmath-smallstack-forward-update-no-downgrade-SPI
 	make test-1051-fastmath-smallstack-forward-update-no-downgrade-RSA
 	make test-1071-fastmath-smallstack-forward-update-no-downgrade-RSA4096
+	make test-1074-fastmath-smallstack-forward-update-no-downgrade-ED448
 	make test-1081-fastmath-smallstack-forward-update-no-downgrade-ED25519-SHA3
 	make test-1091-fastmath-smallstack-forward-update-no-downgrade-ECC256-SHA3
 	make test-1101-fastmath-smallstack-forward-update-no-downgrade-RSA2048-SHA3
 	make test-1111-fastmath-smallstack-forward-update-no-downgrade-RSA4096-SHA3
+	make test-1112-fastmath-smallstack-forward-update-no-downgrade-ED448-SHA3
 	make test-1171-fastmath-smallstack-forward-update-no-downgrade-NOSIGN
 
 


### PR DESCRIPTION
- Added CI tests for Ed448
- Fixed `sign.py` signature len and manifest header size
- Added support for Ed448 with `WOLFBOOT_SMALL_STACK`, using fixed `xmalloc`