### PR TITLE
Delta update fixes

### DIFF
--- a/src/delta.c
+++ b/src/delta.c
@@ -83,7 +83,7 @@ static inline uint8_t *patch_read_cache(WB_PATCH_CTX *ctx)
 
         if (ctx->p_off < ctx->patch_cache_start +
                 (DELTA_PATCH_BLOCK_SIZE - BLOCK_HDR_SIZE))
-            return ctx->patch_cache + ctx->p_off;
+            return ctx->patch_cache + ctx->p_off - ctx->patch_cache_start;
     }
     ctx->patch_cache_start = ctx->p_off;
     ext_flash_check_read(

--- a/tools/uart-flash-server/Makefile
+++ b/tools/uart-flash-server/Makefile
@@ -1,10 +1,21 @@
 CC=$(CROSS_COMPILE)gcc
 CFLAGS=-Wall -DWOLFSSL_DEBUG -DTFM_TIMING_RESISTANT -DWOLFBOOT_SIGN_ECC256 -DWOLFBOOT_HASH_SHA256 -g -ggdb -I../../include -I../../hal -Wextra
+Q?=@
+ifeq ($(V),1)
+   Q=
+endif
 
 EXE=ufserver
 
-$(EXE): $(EXE).o ../../src/libwolfboot.o
-	$(CC) -o $@ $^ $(CFLAGS) $(LIBS)
+$(EXE): $(EXE).o libwolfboot.o
+	$(Q)$(CC) -o $@ $^ $(CFLAGS) $(LIBS)
+
+%.o: %.c
+	$(Q)$(CC) $(CFLAGS) -c -o $(@) $(^)
+
+libwolfboot.o: ../../src/libwolfboot.c
+	$(Q)$(CC) $(CFLAGS) -c -o $(@) $(^)
+
 
 clean:
-	rm -f *.o $(EXE) ../../src/libwolfboot.o
+	$(Q)rm -f *.o $(EXE)


### PR DESCRIPTION
- Fixed patch offset in delta update (ZD12933)
- uart-flash-server: build own libwolfboot.o (to avoid object mismatch when building after wolfBoot)
- Fixed test cases for delta updates
