### PR TITLE
Fixes for Cortex R5 self-update

### DIFF
--- a/hal/ti_hercules.c
+++ b/hal/ti_hercules.c
@@ -77,7 +77,7 @@ void hal_prepare_boot(void)
 {
 }
 
-static inline Fapi_FlashBankType f021_lookup_bank(uint32_t address) {
+static inline Fapi_FlashBankType RAMFUNCTION f021_lookup_bank(uint32_t address) {
     Fapi_FlashBankType bank = Fapi_FlashBank0;
 
     if (address >= 0x200000) {

--- a/src/boot_arm.c
+++ b/src/boot_arm.c
@@ -500,15 +500,24 @@ void (* const IV[])(void) =
 
 #ifdef RAM_CODE
 
-#define AIRCR *(volatile uint32_t *)(0xE000ED0C)
-#define AIRCR_VKEY (0x05FA << 16)
-#define AIRCR_SYSRESETREQ (1 << 2)
+#ifdef CORTEX_R5
+  // Section 2.5.1.45 of spnu563A
+#  define SYSECR    *((volatile uint32_t *)0xFFFFFFE0)
+#  define ECR_RESET (1 << 15)
+#else
+#  define AIRCR *(volatile uint32_t *)(0xE000ED0C)
+#  define AIRCR_VKEY (0x05FA << 16)
+#  define AIRCR_SYSRESETREQ (1 << 2)
+#endif
 
 void RAMFUNCTION arch_reboot(void)
 {
+#ifdef CORTEX_R5
+    SYSECR = ECR_RESET;
+#else
     AIRCR = AIRCR_SYSRESETREQ | AIRCR_VKEY;
+#endif
     while(1)
         ;
-
 }
 #endif /* RAM_CODE */


### PR DESCRIPTION
 - load `f021_lookup_bank()` into RAM
 - `arch_reboot()` for TMS570