### PR TITLE
Fixes to build PSOC6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,7 @@ factory.bin: $(BOOT_IMG) wolfboot.bin $(PRIVATE_KEY) test-app/image_v1_signed.bi
 
 wolfboot.elf: include/target.h $(OBJS) $(LSCRIPT) FORCE
 	@echo "\t[LD] $@"
+	@echo $(OBJS)
 	$(Q)$(LD) $(LDFLAGS) $(LD_START_GROUP) $(OBJS) $(LD_END_GROUP) -o $@
 
 $(LSCRIPT): hal/$(TARGET).ld FORCE

--- a/arch.mk
+++ b/arch.mk
@@ -254,7 +254,7 @@ endif
 
 ifeq ($(TARGET),psoc6)
     CORTEX_M0=1
-    PKA_EXTRA_OBJS+= $(CYPRESS_PDL)/drivers/source/cy_flash.o \
+    OBJS+= $(CYPRESS_PDL)/drivers/source/cy_flash.o \
                      $(CYPRESS_PDL)/drivers/source/cy_ipc_pipe.o \
                      $(CYPRESS_PDL)/drivers/source/cy_ipc_sema.o \
                      $(CYPRESS_PDL)/drivers/source/cy_ipc_drv.o \
@@ -266,6 +266,19 @@ ifeq ($(TARGET),psoc6)
                      $(CYPRESS_PDL)/drivers/source/cy_wdt.o \
                      $(CYPRESS_PDL)/drivers/source/TOOLCHAIN_GCC_ARM/cy_syslib_gcc.o \
                      $(CYPRESS_PDL)/devices/templates/COMPONENT_MTB/COMPONENT_CM0P/system_psoc6_cm0plus.o
+    PSOC6_CRYPTO_OBJS=./lib/wolfssl/wolfcrypt/src/port/cypress/psoc6_crypto.o \
+					 $(CYPRESS_PDL)/drivers/source/cy_crypto_core_vu.o \
+					 $(CYPRESS_PDL)/drivers/source/cy_crypto_core_ecc_domain_params.o \
+					 $(CYPRESS_PDL)/drivers/source/cy_crypto_core_ecc_nist_p.o \
+					 $(CYPRESS_PDL)/drivers/source/cy_crypto_core_ecc_ecdsa.o \
+					 $(CYPRESS_PDL)/drivers/source/cy_crypto_core_sha_v2.o \
+					 $(CYPRESS_PDL)/drivers/source/cy_crypto_core_sha_v1.o \
+					 $(CYPRESS_PDL)/drivers/source/cy_crypto_core_mem_v2.o \
+					 $(CYPRESS_PDL)/drivers/source/cy_crypto_core_mem_v1.o \
+					 $(CYPRESS_PDL)/drivers/source/cy_crypto_core_hw.o \
+					 $(CYPRESS_PDL)/drivers/source/cy_crypto_core_hw_v1.o \
+					 $(CYPRESS_PDL)/drivers/source/cy_crypto.o
+
     CFLAGS+=-I$(CYPRESS_PDL)/drivers/include/ \
         -I$(CYPRESS_PDL)/devices/include \
         -I$(CYPRESS_PDL)/cmsis/include \


### PR DESCRIPTION
ZD 13482

- Merging of #81 lost the `PSOC6_CRYPTO_OBJS` block: re-added.
- Sha512_Init_ex is now used internally by ed25519, so added a stub in the driver
- PSoC6 BSP included in all cases, not as part of `PKA_OBJS`

Tested with `cypsoc6.config`; `make` and `make SIGN=ECC256`.