### PR TITLE
Fixed delta manifest header alignment

### DIFF
--- a/options.mk
+++ b/options.mk
@@ -10,7 +10,7 @@ endif
 ifeq ($(SIGN),NONE)
   SIGN_OPTIONS+=--no-sign
   PRIVATE_KEY=
-  STACK_USAGE=1024
+  STACK_USAGE=1180
   CFLAGS+=-DWOLFBOOT_NO_SIGN
 endif
 
@@ -57,7 +57,7 @@ ifeq ($(SIGN),ED25519)
     ./lib/wolfssl/wolfcrypt/src/fe_low_mem.o
   PUBLIC_KEY_OBJS=./src/ed25519_pub_key.o
   CFLAGS+=-D"WOLFBOOT_SIGN_ED25519"
-  STACK_USAGE?=1024
+  STACK_USAGE?=1180
 endif
 
 ifeq ($(SIGN),ED448)

--- a/tools/keytools/sign.c
+++ b/tools/keytools/sign.c
@@ -448,10 +448,17 @@ static int make_header_ex(int is_diff, uint8_t *pubkey, uint32_t pubkey_sz, cons
         &image_type);
 
     if (is_diff) {
+        /* Append pad bytes, so fields are 4-byte aligned */
+        while ((header_idx % 4) != 0)
+            header_idx++;
         header_append_tag(header, &header_idx, HDR_IMG_DELTA_BASE, 4,
                 &delta_base_version);
         header_append_tag(header, &header_idx, HDR_IMG_DELTA_SIZE, 2,
                 &patch_len);
+
+        /* Append pad bytes, so fields are 4-byte aligned */
+        while ((header_idx % 4) != 0)
+            header_idx++;
         header_append_tag(header, &header_idx, HDR_IMG_DELTA_INVERSE, 4,
                 &patch_inv_off);
         header_append_tag(header, &header_idx, HDR_IMG_DELTA_INVERSE_SIZE, 2,


### PR DESCRIPTION
ZD 12933

Manifest header 'extra' fields must be word-aligned. The python `sign` tool now adds padding bytes accordingly when adding extra fields.