### PR TITLE
Fixed STM32L4 HAL, added IMAGE_HEADER_SIZE option

### DIFF
--- a/options.mk
+++ b/options.mk
@@ -84,7 +84,6 @@ ifeq ($(SIGN),ED448)
   PUBLIC_KEY_OBJS=./src/ed448_pub_key.o
   CFLAGS+=-D"WOLFBOOT_SIGN_ED448"
   IMAGE_HEADER_SIZE=512
-  CFLAGS+=-DIMAGE_HEADER_SIZE=512
 endif
 
 ifeq ($(SIGN),RSA2048)
@@ -100,8 +99,7 @@ ifeq ($(SIGN),RSA2048)
     ./lib/wolfssl/wolfcrypt/src/hash.o \
     ./lib/wolfssl/wolfcrypt/src/wc_port.o
   PUBLIC_KEY_OBJS=./src/rsa2048_pub_key.o
-  CFLAGS+=-D"WOLFBOOT_SIGN_RSA2048" $(RSA_EXTRA_CFLAGS) \
-		  -D"IMAGE_HEADER_SIZE=512"
+  CFLAGS+=-D"WOLFBOOT_SIGN_RSA2048" $(RSA_EXTRA_CFLAGS)
   ifeq ($(WOLFBOOT_SMALL_STACK),1)
     ifneq ($(SPMATH),1)
       STACK_USAGE=5008
@@ -130,8 +128,7 @@ ifeq ($(SIGN),RSA4096)
     ./lib/wolfssl/wolfcrypt/src/hash.o \
     ./lib/wolfssl/wolfcrypt/src/wc_port.o
   PUBLIC_KEY_OBJS=./src/rsa4096_pub_key.o
-  CFLAGS+=-D"WOLFBOOT_SIGN_RSA4096" $(RSA_EXTRA_CFLAGS) \
-		  -D"IMAGE_HEADER_SIZE=1024"
+  CFLAGS+=-D"WOLFBOOT_SIGN_RSA4096" $(RSA_EXTRA_CFLAGS)
   ifeq ($(WOLFBOOT_SMALL_STACK),1)
     ifneq ($(SPMATH),1)
       STACK_USAGE=5888
@@ -290,5 +287,5 @@ ifeq ($(HASH),SHA3)
   SIGN_OPTIONS+=--sha3
 endif
 
-
+CFLAGS+=-DIMAGE_HEADER_SIZE=$(IMAGE_HEADER_SIZE)
 OBJS+=$(WOLFCRYPT_OBJS)

--- a/tools/keytools/Makefile
+++ b/tools/keytools/Makefile
@@ -21,6 +21,12 @@ OPTIMIZE        = -Os
 #CFLAGS+=$(DEBUG_FLAGS)
 CFLAGS+=$(OPTIMIZE)
 
+ifeq ($(IMAGE_HEADER_SIZE),)
+  IMAGE_HEADER_SIZE=256
+endif
+
+CFLAGS+=-DIMAGE_HEADER_SIZE=$(IMAGE_HEADER_SIZE)
+
 # Sources
 SRC=$(WOLFDIR)wolfcrypt/src/asn.c \
 	$(WOLFDIR)wolfcrypt/src/ecc.c \

--- a/tools/keytools/sign.c
+++ b/tools/keytools/sign.c
@@ -89,6 +89,10 @@
 	#define PATH_MAX 256
 #endif
 
+#ifndef IMAGE_HEADER_SIZE
+    #define IMAGE_HEADER_SIZE 256
+#endif
+
 #define WOLFBOOT_MAGIC          0x464C4F57 /* WOLF */
 
 #define HDR_VERSION     0x01
@@ -199,7 +203,7 @@ struct cmd_options {
 static struct cmd_options CMD = {
     .sign = SIGN_AUTO,
     .hash_algo = HASH_SHA256,
-    .header_sz = 256
+    .header_sz = IMAGE_HEADER_SIZE
 };
 
 static uint8_t *load_key(uint8_t **key_buffer, uint32_t *key_buffer_sz,
@@ -1125,23 +1129,28 @@ int main(int argc, char** argv)
 
     /* get header and signature sizes */
     if (CMD.sign == SIGN_ED25519) {
-        CMD.header_sz = 256;
+        if (CMD.header_sz < 256)
+            CMD.header_sz = 256;
         CMD.signature_sz = 64;
     }
     else if (CMD.sign == SIGN_ED448) {
-        CMD.header_sz = 512;
+        if (CMD.header_sz < 512)
+            CMD.header_sz = 512;
         CMD.signature_sz = 114;
     }
     else if (CMD.sign == SIGN_ECC256) {
-        CMD.header_sz = 256;
+        if (CMD.header_sz < 256)
+            CMD.header_sz = 256;
         CMD.signature_sz = 64;
     }
     else if (CMD.sign == SIGN_RSA2048) {
-        CMD.header_sz = 512;
+        if (CMD.header_sz < 512)
+            CMD.header_sz = 512;
         CMD.signature_sz = 256;
     }
     else if (CMD.sign == SIGN_RSA4096) {
-        CMD.header_sz = 1024;
+        if (CMD.header_sz < 1024)
+            CMD.header_sz = 1024;
         CMD.signature_sz = 512;
     }
     if (((CMD.sign != NO_SIGN) && (CMD.signature_sz == 0)) ||

--- a/tools/keytools/sign.py
+++ b/tools/keytools/sign.py
@@ -294,6 +294,24 @@ if (encrypt and delta):
     print("Encryption of delta images not supported yet.")
     sys.exit(1)
 
+try:
+    cfile = open(".config", "r")
+except:
+    cfile = None
+    pass
+
+if cfile:
+    l = cfile.readline()
+    while l != '':
+        if "IMAGE_HEADER_SIZE" in l:
+            val=l.split('=')[1].rstrip('\n')
+            WOLFBOOT_HEADER_SIZE = int(val,0)
+            print("IMAGE_HEADER_SIZE (from .config): " + str(WOLFBOOT_HEADER_SIZE))
+
+        l = cfile.readline()
+    cfile.close()
+
+
 image_file = argv[i+1]
 if sign != 'none':
     key_file = argv[i+2]
@@ -430,7 +448,8 @@ elif not sha_only and not manual_sign:
 
     if sign == 'ed448':
         HDR_SIGNATURE_LEN = 114
-        WOLFBOOT_HEADER_SIZE = 512
+        if WOLFBOOT_HEADER_SIZE < 512:
+            WOLFBOOT_HEADER_SIZE = 512
         ed = ciphers.Ed448Private(key = wolfboot_key_buffer)
         privkey, pubkey = ed.encode_key()
 
@@ -440,27 +459,30 @@ elif not sha_only and not manual_sign:
         pubkey = wolfboot_key_buffer[0:64]
 
     if sign == 'rsa2048':
-        WOLFBOOT_HEADER_SIZE = 512
+        if WOLFBOOT_HEADER_SIZE < 512:
+            WOLFBOOT_HEADER_SIZE = 512
         HDR_SIGNATURE_LEN = 256
         rsa = ciphers.RsaPrivate(wolfboot_key_buffer)
         privkey,pubkey = rsa.encode_key()
 
     if sign == 'rsa4096':
-        WOLFBOOT_HEADER_SIZE = 1024
+        if WOLFBOOT_HEADER_SIZE < 1024:
+            WOLFBOOT_HEADER_SIZE = 1024
         HDR_SIGNATURE_LEN = 512
         rsa = ciphers.RsaPrivate(wolfboot_key_buffer)
         privkey,pubkey = rsa.encode_key()
 
 else:
     if sign == 'rsa2048':
-        WOLFBOOT_HEADER_SIZE = 512
+        if WOLFBOOT_HEADER_SIZE < 512:
+            WOLFBOOT_HEADER_SIZE = 512
         HDR_SIGNATURE_LEN = 256
     if sign == 'rsa4096':
-        WOLFBOOT_HEADER_SIZE = 1024
+        if WOLFBOOT_HEADER_SIZE < 512:
+            WOLFBOOT_HEADER_SIZE = 1024
         HDR_SIGNATURE_LEN = 512
 
     pubkey = wolfboot_key_buffer
-
 
 header = make_header(image_file, fw_version)
 


### PR DESCRIPTION
- Fixes in STM32L4 HAL driver:
    - `hal_flash_erase` was using the wrong page index while looping. Changed to page-range to call the HAL_ function once.
    - `hal_flash_erase` was calling `hal_flash_unlock()/hal_flash_lock()`, which is not allowed (flash is unlocked at a higher level and could include multiple subsequent operations)
    - `hal_flash_write` refactored using the STM32WB as base - which is well tested and guaranteed to work with unaligned data
   
- New feature in `tools/keytools/sign.py` <- it now tries to read `IMAGE_HEADER_SIZE` from `.config`, if available and set, to override the default (256B). 

Should fix issues in ZD 13566