### PR TITLE
Fixed comparison of RSA4096 header size in sign.py

### DIFF
--- a/tools/keytools/sign.py
+++ b/tools/keytools/sign.py
@@ -491,7 +491,7 @@ else:
             WOLFBOOT_HEADER_SIZE = 512
         HDR_SIGNATURE_LEN = 256
     if sign == 'rsa4096':
-        if WOLFBOOT_HEADER_SIZE < 512:
+        if WOLFBOOT_HEADER_SIZE < 1024:
             WOLFBOOT_HEADER_SIZE = 1024
         HDR_SIGNATURE_LEN = 512
 


### PR DESCRIPTION
Fix error in comparison when setting the IMAGE_HEADER size in sign.py, in the RSA4096 case. Detected in ZD 13566.