### PR TITLE
Added SHA2-384 support for integrity checks

### DIFF
--- a/include/user_settings.h
+++ b/include/user_settings.h
@@ -163,6 +163,11 @@
 #   define NO_SHA256
 #endif
 
+#ifdef WOLFBOOT_HASH_SHA384
+#   define WOLFSSL_SHA384
+#   define NO_SHA256
+#endif
+
 #ifdef EXT_ENCRYPTED
 #   define HAVE_PWDBASED
 #else

--- a/include/wolfboot/wolfboot.h
+++ b/include/wolfboot/wolfboot.h
@@ -60,6 +60,7 @@
 #define HDR_IMG_DELTA_SIZE          0x06
 #define HDR_PUBKEY                  0x10
 #define HDR_SHA3_384                0x13
+#define HDR_SHA384                  0x14
 #define HDR_IMG_DELTA_INVERSE       0x15
 #define HDR_IMG_DELTA_INVERSE_SIZE  0x16
 #define HDR_SIGNATURE               0x20
@@ -143,6 +144,12 @@ int wolfBoot_dualboot_candidate(void);
 #   define WOLFBOOT_SHA_DIGEST_SIZE (32)
 #   define image_hash image_sha256
 #   define key_hash key_sha256
+#elif defined(WOLFBOOT_HASH_SHA384)
+#   define WOLFBOOT_SHA_BLOCK_SIZE (256)
+#   define WOLFBOOT_SHA_HDR HDR_SHA384
+#   define WOLFBOOT_SHA_DIGEST_SIZE (48)
+#   define image_hash image_sha384
+#   define key_hash key_sha384
 #elif defined(WOLFBOOT_HASH_SHA3_384)
 #   define WOLFBOOT_SHA_BLOCK_SIZE (128)
 #   define WOLFBOOT_SHA_HDR HDR_SHA3_384

--- a/options.mk
+++ b/options.mk
@@ -367,6 +367,14 @@ ifeq ($(HASH),SHA256)
   CFLAGS+=-D"WOLFBOOT_HASH_SHA256"
 endif
 
+ifeq ($(HASH),SHA384)
+  CFLAGS+=-D"WOLFBOOT_HASH_SHA384"
+  SIGN_OPTIONS+=--sha384
+  ifneq ($(SIGN),ED25519)
+    WOLFCRYPT_OBJS+=./lib/wolfssl/wolfcrypt/src/sha512.o
+  endif
+endif
+
 ifeq ($(HASH),SHA3)
   WOLFCRYPT_OBJS+=./lib/wolfssl/wolfcrypt/src/sha3.o
   CFLAGS+=-D"WOLFBOOT_HASH_SHA3_384"

--- a/src/image.c
+++ b/src/image.c
@@ -511,6 +511,67 @@ static void key_sha256(uint8_t *hash)
 #endif /* WOLFBOOT_NO_SIGN */
 #endif /* SHA2-256 */
 
+#if defined(WOLFBOOT_HASH_SHA384)
+
+#include <wolfssl/wolfcrypt/sha512.h>
+static int image_sha384(struct wolfBoot_image *img, uint8_t *hash)
+{
+    uint8_t *stored_sha, *end_sha;
+    uint16_t stored_sha_len;
+    uint8_t *p;
+    int blksz;
+    uint32_t position = 0;
+    wc_Sha384 sha384_ctx;
+    if (!img)
+        return -1;
+    p = get_img_hdr(img);
+    stored_sha_len = get_header(img, HDR_SHA384, &stored_sha);
+    if (stored_sha_len != WOLFBOOT_SHA_DIGEST_SIZE)
+        return -1;
+    wc_InitSha384(&sha384_ctx);
+    end_sha = stored_sha - (2 * sizeof(uint16_t)); /* Subtract 2 Type + 2 Len */
+    while (p < end_sha) {
+        blksz = WOLFBOOT_SHA_BLOCK_SIZE;
+        if (end_sha - p < blksz)
+            blksz = end_sha - p;
+        wc_Sha384Update(&sha384_ctx, p, blksz);
+        p += blksz;
+    }
+    do {
+        p = get_sha_block(img, position);
+        if (p == NULL)
+            break;
+        blksz = WOLFBOOT_SHA_BLOCK_SIZE;
+        if (position + blksz > img->fw_size)
+            blksz = img->fw_size - position;
+        wc_Sha384Update(&sha384_ctx, p, blksz);
+        position += blksz;
+    } while(position < img->fw_size);
+
+    wc_Sha384Final(&sha384_ctx, hash);
+    return 0;
+}
+
+#ifndef WOLFBOOT_NO_SIGN
+static void key_sha384(uint8_t *hash)
+{
+    int blksz;
+    unsigned int i = 0;
+    wc_Sha384 sha384_ctx;
+    wc_InitSha384(&sha384_ctx);
+    while(i < KEY_LEN)
+    {
+        blksz = WOLFBOOT_SHA_BLOCK_SIZE;
+        if ((i + blksz) > KEY_LEN)
+            blksz = KEY_LEN - i;
+        wc_Sha384Update(&sha384_ctx, (KEY_BUFFER + i), blksz);
+        i += blksz;
+    }
+    wc_Sha384Final(&sha384_ctx, hash);
+}
+#endif /* WOLFBOOT_NO_SIGN */
+#endif /* WOLFBOOT_HASH_SHA384 */
+
 #if defined(WOLFBOOT_HASH_SHA3_384)
 
 #include <wolfssl/wolfcrypt/sha3.h>

--- a/src/xmalloc.c
+++ b/src/xmalloc.c
@@ -47,6 +47,9 @@ struct xmalloc_slot {
 #ifdef WOLFBOOT_HASH_SHA256
 #   include <wolfssl/wolfcrypt/sha256.h>
 #   define HASH_BLOCK_SIZE WC_SHA256_BLOCK_SIZE
+#elif defined WOLFBOOT_HASH_SHA384
+#   include <wolfssl/wolfcrypt/sha512.h>
+#   define HASH_BLOCK_SIZE (WC_SHA384_BLOCK_SIZE / sizeof(uint32_t))
 #elif defined WOLFBOOT_HASH_SHA3_384
 #   include <wolfssl/wolfcrypt/sha3.h>
 #   define HASH_BLOCK_SIZE WC_SHA3_384_BLOCK_SIZE
@@ -148,7 +151,7 @@ static uint8_t mp_curve_specs[MP_CURVE_SPECS_SIZE];
 
 static uint32_t sha_block[HASH_BLOCK_SIZE];
 static struct xmalloc_slot xmalloc_pool[] = {
-#ifdef WOLFBOOT_HASH_SHA256
+#if defined(WOLFBOOT_HASH_SHA256) || defined(WOLFBOOT_HASH_SHA384)
     { (uint8_t *)sha_block, HASH_BLOCK_SIZE * sizeof(uint32_t), 0 },
 #endif
     { (uint8_t *)mp_curve_specs, MP_CURVE_SPECS_SIZE, 0 },
@@ -201,7 +204,7 @@ static uint32_t sha_block[HASH_BLOCK_SIZE];
 static uint32_t sha512_block[sizeof(word64) * 16];
 
 static struct xmalloc_slot xmalloc_pool[] = {
-#ifdef WOLFBOOT_HASH_SHA256
+#if defined(WOLFBOOT_HASH_SHA256) || defined(WOLFBOOT_HASH_SHA384)
     { (uint8_t *)sha_block, HASH_BLOCK_SIZE * sizeof(uint32_t), 0 },
 #endif
     { (uint8_t *)sha512_block, sizeof(word64) * 16, 0 },
@@ -221,7 +224,7 @@ static ge448_p2 pi, p2;
 static uint32_t sha_block[HASH_BLOCK_SIZE];
 
 static struct xmalloc_slot xmalloc_pool[] = {
-#ifdef WOLFBOOT_HASH_SHA256
+#if defined(WOLFBOOT_HASH_SHA256) || defined(WOLFBOOT_HASH_SHA384)
     { (uint8_t *)sha_block, HASH_BLOCK_SIZE * sizeof(uint32_t), 0 },
 #endif
     { (uint8_t *)aslide, GE448_WINDOW_BUF_SIZE, 0 },
@@ -257,8 +260,8 @@ static uint32_t sha_block[HASH_BLOCK_SIZE];
     #endif
     static uint8_t mp_digit_buf0[MPDIGIT_BUF0_SIZE];
     static struct xmalloc_slot xmalloc_pool[] = {
-    #ifdef WOLFBOOT_HASH_SHA256
-        { (uint8_t *)sha_block, WC_SHA256_BLOCK_SIZE * sizeof(uint32_t), 0 },
+    #if defined(WOLFBOOT_HASH_SHA256) || defined(WOLFBOOT_HASH_SHA384)
+        { (uint8_t *)sha_block, HASH_BLOCK_SIZE * sizeof(uint32_t), 0 },
     #endif
         { mp_digit_buf0, MPDIGIT_BUF0_SIZE, 0},
     #ifndef WOLFSSL_SP_ARM_CORTEX_M_ASM
@@ -276,8 +279,8 @@ static uint32_t sha_block[HASH_BLOCK_SIZE];
     static uint8_t mp_int_buffer4[MP_INT_SIZE * 5];
     static uint8_t mp_mont_reduce_buffer[MP_MONT_REDUCE_BUF_SIZE];
     static struct xmalloc_slot xmalloc_pool[] = {
-    #ifdef WOLFBOOT_HASH_SHA256
-        { (uint8_t *)sha_block, WC_SHA256_BLOCK_SIZE * sizeof(uint32_t), 0 },
+    #if defined(WOLFBOOT_HASH_SHA256) || defined(WOLFBOOT_HASH_SHA384)
+        { (uint8_t *)sha_block, HASH_BLOCK_SIZE * sizeof(uint32_t), 0 },
     #endif
         { mp_int_buffer0, MP_INT_SIZE, 0},
         { mp_int_buffer1, MP_INT_SIZE * 3, 0},
@@ -293,8 +296,8 @@ static uint32_t sha_block[HASH_BLOCK_SIZE];
 
 static uint32_t sha_block[HASH_BLOCK_SIZE];
 static struct xmalloc_slot xmalloc_pool[] = {
-#ifdef WOLFBOOT_HASH_SHA256
-    { (uint8_t *)sha_block, WC_SHA256_BLOCK_SIZE * sizeof(uint32_t), 0 },
+#if defined(WOLFBOOT_HASH_SHA256) || defined(WOLFBOOT_HASH_SHA384)
+    { (uint8_t *)sha_block, HASH_BLOCK_SIZE * sizeof(uint32_t), 0 },
 #endif
     { NULL, 0, 0}
 };

--- a/tools/keytools/user_settings.h
+++ b/tools/keytools/user_settings.h
@@ -64,6 +64,7 @@
 
 /* Hashing */
 #define WOLFSSL_SHA512 /* Required for ED25519 */
+#define WOLFSSL_SHA384 /* Required for ED25519 */
 #define WOLFSSL_SHA3
 #undef  NO_SHA256
 

--- a/tools/test-renode.mk
+++ b/tools/test-renode.mk
@@ -89,6 +89,9 @@ endif
 ifeq ($(HASH),SHA256)
   SIGN_ARGS+= --sha256
 endif
+ifeq ($(HASH),SHA384)
+  SIGN_ARGS+= --sha384
+endif
 ifeq ($(HASH),SHA3)
   SIGN_ARGS+= --sha3
 endif

--- a/tools/test.mk
+++ b/tools/test.mk
@@ -53,6 +53,9 @@ endif
 ifeq ($(HASH),SHA256)
   SIGN_ARGS+= --sha256
 endif
+ifeq ($(HASH),SHA384)
+  SIGN_ARGS+= --sha384
+endif
 ifeq ($(HASH),SHA3)
   SIGN_ARGS+= --sha3
 endif


### PR DESCRIPTION
Tested with Renode, via:

`make renode-update-all HASH=SHA384`

and

`make renode-update-all HASH=SHA384 WOLFBOOT_SMALL_STACK=1`