### PR TITLE
More renode tests + Ecc384 fixes

### DIFF
--- a/.github/workflows/test-renode-multi-mem.yml
+++ b/.github/workflows/test-renode-multi-mem.yml
@@ -1,0 +1,685 @@
+name: Renode Automated Tests: memory configurations
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build_and_test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      # Get the arm-non-eabi-gcc toolchain
+      - name: Install arm-none-eabi-gcc
+        uses: fiam/arm-none-eabi-gcc@v1
+        with:
+          # The arm-none-eabi-gcc release to use.
+          release: "9-2019-q4"
+
+      - name: Install wolfSSL
+        run: |
+          sudo apt-get install --no-install-recommends -y -q make libwolfssl-dev
+
+      - name: Build test-expect-version
+        run: |
+          make -C tools/test-expect-version
+
+      - name: make clean
+        run: |
+          make clean && make -C tools/keytools clean && rm -f include/target.h
+
+      - name: Select config
+        run: |
+          cp config/examples/nrf52840.config .config && make include/target.h
+
+      - name: Build key tools
+        run: |
+          make -C tools/keytools
+
+
+  ##### SMALL STACK tests
+
+  # ECC256 TEST
+      - name: make clean
+        run: |
+          make clean && rm -f include/target.h
+
+      - name: Select config
+        run: |
+          cp config/examples/nrf52840.config .config && make include/target.h SIGN=ECC256
+
+      - name: Build wolfboot and test app image v1, SIGN=ECC256
+        run: |
+          make SIGN=ECC256 WOLFBOOT_SMALL_STACK=1
+
+      - name: Build update image v2
+        run: |
+          make /tmp/renode-test-update.bin SIGN=ECC256 WOLFBOOT_SMALL_STACK=1 && cp /tmp/renode-test-update.bin test-app/
+
+      - name: Renode Tests ECC256
+        run: ./tools/renode/docker-test.sh
+
+# ECC384 TEST
+      - name: make clean
+        run: |
+          make clean && rm -f include/target.h
+
+      - name: Select config
+        run: |
+          cp config/examples/nrf52840.config .config && make include/target.h SIGN=ECC384
+
+      - name: Build wolfboot and test app image v1, SIGN=ECC384
+        run: |
+          make SIGN=ECC384 WOLFBOOT_SMALL_STACK=1
+
+      - name: Build update image v2
+        run: |
+          make /tmp/renode-test-update.bin SIGN=ECC384 WOLFBOOT_SMALL_STACK=1 && cp /tmp/renode-test-update.bin test-app/
+
+      - name: Renode Tests ECC384
+        run: ./tools/renode/docker-test.sh
+
+# ED25519 TEST
+      - name: make clean
+        run: |
+          make clean && rm -f include/target.h
+
+      - name: Select config
+        run: |
+          cp config/examples/nrf52840.config .config && make include/target.h SIGN=ED25519
+
+      - name: Build wolfboot and test app image v1, SIGN=ED25519
+        run: |
+          make SIGN=ED25519 WOLFBOOT_SMALL_STACK=1
+
+      - name: Build update image v2
+        run: |
+          make /tmp/renode-test-update.bin SIGN=ED25519 WOLFBOOT_SMALL_STACK=1 && cp /tmp/renode-test-update.bin test-app/
+
+      - name: Renode Tests ED25519
+        run: ./tools/renode/docker-test.sh
+
+# ED448 TEST
+      - name: make clean
+        run: |
+          make clean && rm -f include/target.h
+
+      - name: Select config
+        run: |
+          cp config/examples/nrf52840.config .config && make include/target.h SIGN=ED448
+
+      - name: Build wolfboot and test app image v1, SIGN=ED448
+        run: |
+          make SIGN=ED448 WOLFBOOT_SMALL_STACK=1
+
+      - name: Build update image v2
+        run: |
+          make /tmp/renode-test-update.bin SIGN=ED448 WOLFBOOT_SMALL_STACK=1 && cp /tmp/renode-test-update.bin test-app/
+
+      - name: Renode Tests ED448
+        run: ./tools/renode/docker-test.sh
+
+# RSA2048 TEST
+      - name: make clean
+        run: |
+          make clean && rm -f include/target.h
+
+      - name: Select config
+        run: |
+          cp config/examples/nrf52840.config .config && make include/target.h SIGN=RSA2048
+
+      - name: Build wolfboot and test app image v1, SIGN=RSA2048
+        run: |
+          make SIGN=RSA2048 WOLFBOOT_SMALL_STACK=1
+
+      - name: Build update image v2
+        run: |
+          make /tmp/renode-test-update.bin SIGN=RSA2048 WOLFBOOT_SMALL_STACK=1 && cp /tmp/renode-test-update.bin test-app/
+
+      - name: Renode Tests RSA2048
+        run: ./tools/renode/docker-test.sh
+
+# RSA4096 TEST
+      - name: make clean
+        run: |
+          make clean && rm -f include/target.h
+
+      - name: Select config
+        run: |
+          cp config/examples/nrf52840.config .config && make include/target.h SIGN=RSA4096
+
+      - name: Build wolfboot and test app image v1, SIGN=RSA4096
+        run: |
+          make SIGN=RSA4096 WOLFBOOT_SMALL_STACK=1
+
+      - name: Build update image v2
+        run: |
+          make /tmp/renode-test-update.bin SIGN=RSA4096 WOLFBOOT_SMALL_STACK=1 && cp /tmp/renode-test-update.bin test-app/
+
+      - name: Renode Tests RSA4096
+        run: ./tools/renode/docker-test.sh
+
+      - name: Upload Output Dir
+        uses: actions/upload-artifact@v2
+        with:
+          name: Renode Test Results
+          path: test_results/
+
+  ##### NO_ASM tests
+
+  # ECC256 TEST
+      - name: make clean
+        run: |
+          make clean && rm -f include/target.h
+
+      - name: Select config
+        run: |
+          cp config/examples/nrf52840.config .config && make include/target.h SIGN=ECC256
+
+      - name: Build wolfboot and test app image v1, SIGN=ECC256
+        run: |
+          make SIGN=ECC256 NO_ASM=1
+
+      - name: Build update image v2
+        run: |
+          make /tmp/renode-test-update.bin SIGN=ECC256 NO_ASM=1 && cp /tmp/renode-test-update.bin test-app/
+
+      - name: Renode Tests ECC256
+        run: ./tools/renode/docker-test.sh
+
+# ECC384 TEST
+      - name: make clean
+        run: |
+          make clean && rm -f include/target.h
+
+      - name: Select config
+        run: |
+          cp config/examples/nrf52840.config .config && make include/target.h SIGN=ECC384
+
+      - name: Build wolfboot and test app image v1, SIGN=ECC384
+        run: |
+          make SIGN=ECC384 NO_ASM=1
+
+      - name: Build update image v2
+        run: |
+          make /tmp/renode-test-update.bin SIGN=ECC384 NO_ASM=1 && cp /tmp/renode-test-update.bin test-app/
+
+      - name: Renode Tests ECC384
+        run: ./tools/renode/docker-test.sh
+
+# ED25519 TEST
+      - name: make clean
+        run: |
+          make clean && rm -f include/target.h
+
+      - name: Select config
+        run: |
+          cp config/examples/nrf52840.config .config && make include/target.h SIGN=ED25519
+
+      - name: Build wolfboot and test app image v1, SIGN=ED25519
+        run: |
+          make SIGN=ED25519 NO_ASM=1
+
+      - name: Build update image v2
+        run: |
+          make /tmp/renode-test-update.bin SIGN=ED25519 NO_ASM=1 && cp /tmp/renode-test-update.bin test-app/
+
+      - name: Renode Tests ED25519
+        run: ./tools/renode/docker-test.sh
+
+# ED448 TEST
+      - name: make clean
+        run: |
+          make clean && rm -f include/target.h
+
+      - name: Select config
+        run: |
+          cp config/examples/nrf52840.config .config && make include/target.h SIGN=ED448
+
+      - name: Build wolfboot and test app image v1, SIGN=ED448
+        run: |
+          make SIGN=ED448 NO_ASM=1
+
+      - name: Build update image v2
+        run: |
+          make /tmp/renode-test-update.bin SIGN=ED448 NO_ASM=1 && cp /tmp/renode-test-update.bin test-app/
+
+      - name: Renode Tests ED448
+        run: ./tools/renode/docker-test.sh
+
+# RSA2048 TEST
+      - name: make clean
+        run: |
+          make clean && rm -f include/target.h
+
+      - name: Select config
+        run: |
+          cp config/examples/nrf52840.config .config && make include/target.h SIGN=RSA2048
+
+      - name: Build wolfboot and test app image v1, SIGN=RSA2048
+        run: |
+          make SIGN=RSA2048 NO_ASM=1
+
+      - name: Build update image v2
+        run: |
+          make /tmp/renode-test-update.bin SIGN=RSA2048 NO_ASM=1 && cp /tmp/renode-test-update.bin test-app/
+
+      - name: Renode Tests RSA2048
+        run: ./tools/renode/docker-test.sh
+
+# RSA4096 TEST
+      - name: make clean
+        run: |
+          make clean && rm -f include/target.h
+
+      - name: Select config
+        run: |
+          cp config/examples/nrf52840.config .config && make include/target.h SIGN=RSA4096
+
+      - name: Build wolfboot and test app image v1, SIGN=RSA4096
+        run: |
+          make SIGN=RSA4096 NO_ASM=1
+
+      - name: Build update image v2
+        run: |
+          make /tmp/renode-test-update.bin SIGN=RSA4096 NO_ASM=1 && cp /tmp/renode-test-update.bin test-app/
+
+      - name: Renode Tests RSA4096
+        run: ./tools/renode/docker-test.sh
+
+      - name: Upload Output Dir
+        uses: actions/upload-artifact@v2
+        with:
+          name: Renode Test Results
+          path: test_results/
+  
+##### SMALL STACK + NO_ASM tests
+
+  # ECC256 TEST
+      - name: make clean
+        run: |
+          make clean && rm -f include/target.h
+
+      - name: Select config
+        run: |
+          cp config/examples/nrf52840.config .config && make include/target.h SIGN=ECC256
+
+      - name: Build wolfboot and test app image v1, SIGN=ECC256
+        run: |
+          make SIGN=ECC256 WOLFBOOT_SMALL_STACK=1 NO_ASM=1
+
+      - name: Build update image v2
+        run: |
+          make /tmp/renode-test-update.bin SIGN=ECC256 WOLFBOOT_SMALL_STACK=1 NO_ASM=1  && cp /tmp/renode-test-update.bin test-app/
+
+      - name: Renode Tests ECC256
+        run: ./tools/renode/docker-test.sh
+
+# ECC384 TEST
+      - name: make clean
+        run: |
+          make clean && rm -f include/target.h
+
+      - name: Select config
+        run: |
+          cp config/examples/nrf52840.config .config && make include/target.h SIGN=ECC384
+
+      - name: Build wolfboot and test app image v1, SIGN=ECC384
+        run: |
+          make SIGN=ECC384 WOLFBOOT_SMALL_STACK=1 NO_ASM=1
+
+      - name: Build update image v2
+        run: |
+          make /tmp/renode-test-update.bin SIGN=ECC384 WOLFBOOT_SMALL_STACK=1 NO_ASM=1 && cp /tmp/renode-test-update.bin test-app/
+
+      - name: Renode Tests ECC384
+        run: ./tools/renode/docker-test.sh
+
+# ED25519 TEST
+      - name: make clean
+        run: |
+          make clean && rm -f include/target.h
+
+      - name: Select config
+        run: |
+          cp config/examples/nrf52840.config .config && make include/target.h SIGN=ED25519
+
+      - name: Build wolfboot and test app image v1, SIGN=ED25519
+        run: |
+          make SIGN=ED25519 WOLFBOOT_SMALL_STACK=1 NO_ASM=1
+
+      - name: Build update image v2
+        run: |
+          make /tmp/renode-test-update.bin SIGN=ED25519 WOLFBOOT_SMALL_STACK=1 NO_ASM=1  && cp /tmp/renode-test-update.bin test-app/
+
+      - name: Renode Tests ED25519
+        run: ./tools/renode/docker-test.sh
+
+# ED448 TEST
+      - name: make clean
+        run: |
+          make clean && rm -f include/target.h
+
+      - name: Select config
+        run: |
+          cp config/examples/nrf52840.config .config && make include/target.h SIGN=ED448
+
+      - name: Build wolfboot and test app image v1, SIGN=ED448
+        run: |
+          make SIGN=ED448 WOLFBOOT_SMALL_STACK=1 NO_ASM=1
+
+      - name: Build update image v2
+        run: |
+          make /tmp/renode-test-update.bin SIGN=ED448 WOLFBOOT_SMALL_STACK=1 NO_ASM=1 && cp /tmp/renode-test-update.bin test-app/
+
+      - name: Renode Tests ED448
+        run: ./tools/renode/docker-test.sh
+
+# RSA2048 TEST
+      - name: make clean
+        run: |
+          make clean && rm -f include/target.h
+
+      - name: Select config
+        run: |
+          cp config/examples/nrf52840.config .config && make include/target.h SIGN=RSA2048
+
+      - name: Build wolfboot and test app image v1, SIGN=RSA2048
+        run: |
+          make SIGN=RSA2048 WOLFBOOT_SMALL_STACK=1 NO_ASM=1
+
+      - name: Build update image v2
+        run: |
+          make /tmp/renode-test-update.bin SIGN=RSA2048 WOLFBOOT_SMALL_STACK=1 NO_ASM=1 && cp /tmp/renode-test-update.bin test-app/
+
+      - name: Renode Tests RSA2048
+        run: ./tools/renode/docker-test.sh
+
+# RSA4096 TEST
+      - name: make clean
+        run: |
+          make clean && rm -f include/target.h
+
+      - name: Select config
+        run: |
+          cp config/examples/nrf52840.config .config && make include/target.h SIGN=RSA4096
+
+      - name: Build wolfboot and test app image v1, SIGN=RSA4096
+        run: |
+          make SIGN=RSA4096 WOLFBOOT_SMALL_STACK=1 NO_ASM=1
+
+      - name: Build update image v2
+        run: |
+          make /tmp/renode-test-update.bin SIGN=RSA4096 WOLFBOOT_SMALL_STACK=1 NO_ASM=1 && cp /tmp/renode-test-update.bin test-app/
+
+      - name: Renode Tests RSA4096
+        run: ./tools/renode/docker-test.sh
+
+      - name: Upload Output Dir
+        uses: actions/upload-artifact@v2
+        with:
+          name: Renode Test Results
+          path: test_results/
+
+    ##### FAST MATH tests
+
+  # ECC256 TEST
+      - name: make clean
+        run: |
+          make clean && rm -f include/target.h
+
+      - name: Select config
+        run: |
+          cp config/examples/nrf52840.config .config && make include/target.h SIGN=ECC256
+
+      - name: Build wolfboot and test app image v1, SIGN=ECC256
+        run: |
+          make SIGN=ECC256 SPMATH=0
+
+      - name: Build update image v2
+        run: |
+          make /tmp/renode-test-update.bin SIGN=ECC256 SPMATH=0 && cp /tmp/renode-test-update.bin test-app/
+
+      - name: Renode Tests ECC256
+        run: ./tools/renode/docker-test.sh
+
+# ECC384 TEST
+      - name: make clean
+        run: |
+          make clean && rm -f include/target.h
+
+      - name: Select config
+        run: |
+          cp config/examples/nrf52840.config .config && make include/target.h SIGN=ECC384
+
+      - name: Build wolfboot and test app image v1, SIGN=ECC384
+        run: |
+          make SIGN=ECC384 SPMATH=0
+
+      - name: Build update image v2
+        run: |
+          make /tmp/renode-test-update.bin SIGN=ECC384 SPMATH=0 && cp /tmp/renode-test-update.bin test-app/
+
+      - name: Renode Tests ECC384
+        run: ./tools/renode/docker-test.sh
+
+# ED25519 TEST
+      - name: make clean
+        run: |
+          make clean && rm -f include/target.h
+
+      - name: Select config
+        run: |
+          cp config/examples/nrf52840.config .config SPMATH=0 && make include/target.h SIGN=ED25519
+
+      - name: Build wolfboot and test app image v1, SIGN=ED25519
+        run: |
+          make SIGN=ED25519 SPMATH=0
+
+      - name: Build update image v2
+        run: |
+          make /tmp/renode-test-update.bin SIGN=ED25519 SPMATH=0 && cp /tmp/renode-test-update.bin test-app/
+
+      - name: Renode Tests ED25519
+        run: ./tools/renode/docker-test.sh
+
+# ED448 TEST
+      - name: make clean
+        run: |
+          make clean && rm -f include/target.h
+
+      - name: Select config
+        run: |
+          cp config/examples/nrf52840.config .config && make include/target.h SIGN=ED448
+
+      - name: Build wolfboot and test app image v1, SIGN=ED448
+        run: |
+          make SIGN=ED448 SPMATH=0
+
+      - name: Build update image v2
+        run: |
+          make /tmp/renode-test-update.bin SIGN=ED448 SPMATH=0 && cp /tmp/renode-test-update.bin test-app/
+
+      - name: Renode Tests ED448
+        run: ./tools/renode/docker-test.sh
+
+# RSA2048 TEST
+      - name: make clean
+        run: |
+          make clean && rm -f include/target.h
+
+      - name: Select config
+        run: |
+          cp config/examples/nrf52840.config .config && make include/target.h SIGN=RSA2048
+
+      - name: Build wolfboot and test app image v1, SIGN=RSA2048
+        run: |
+          make SIGN=RSA2048 SPMATH=0
+
+      - name: Build update image v2
+        run: |
+          make /tmp/renode-test-update.bin SIGN=RSA2048 SPMATH=0 && cp /tmp/renode-test-update.bin test-app/
+
+      - name: Renode Tests RSA2048
+        run: ./tools/renode/docker-test.sh
+
+# RSA4096 TEST
+      - name: make clean
+        run: |
+          make clean && rm -f include/target.h
+
+      - name: Select config
+        run: |
+          cp config/examples/nrf52840.config .config && make include/target.h SIGN=RSA4096
+
+      - name: Build wolfboot and test app image v1, SIGN=RSA4096
+        run: |
+          make SIGN=RSA4096 SPMATH=0
+
+      - name: Build update image v2
+        run: |
+          make /tmp/renode-test-update.bin SIGN=RSA4096 SPMATH=0 && cp /tmp/renode-test-update.bin test-app/
+
+      - name: Renode Tests RSA4096
+        run: ./tools/renode/docker-test.sh
+
+      - name: Upload Output Dir
+        uses: actions/upload-artifact@v2
+        with:
+          name: Renode Test Results
+          path: test_results/
+  
+##### SMALL STACK + FAST MATH tests
+
+  # ECC256 TEST
+      - name: make clean
+        run: |
+          make clean && rm -f include/target.h
+
+      - name: Select config
+        run: |
+          cp config/examples/nrf52840.config .config && make include/target.h SIGN=ECC256
+
+      - name: Build wolfboot and test app image v1, SIGN=ECC256
+        run: |
+          make SIGN=ECC256 WOLFBOOT_SMALL_STACK=1 SPMATH=0
+
+      - name: Build update image v2
+        run: |
+          make /tmp/renode-test-update.bin SIGN=ECC256 WOLFBOOT_SMALL_STACK=1 SPMATH=0 && cp /tmp/renode-test-update.bin test-app/
+
+      - name: Renode Tests ECC256
+        run: ./tools/renode/docker-test.sh
+
+# ECC384 TEST
+      - name: make clean
+        run: |
+          make clean && rm -f include/target.h
+
+      - name: Select config
+        run: |
+          cp config/examples/nrf52840.config .config && make include/target.h SIGN=ECC384
+
+      - name: Build wolfboot and test app image v1, SIGN=ECC384
+        run: |
+          make SIGN=ECC384 WOLFBOOT_SMALL_STACK=1 SPMATH=0
+
+      - name: Build update image v2
+        run: |
+          make /tmp/renode-test-update.bin SIGN=ECC384 WOLFBOOT_SMALL_STACK=1 SPMATH=0 && cp /tmp/renode-test-update.bin test-app/
+
+      - name: Renode Tests ECC384
+        run: ./tools/renode/docker-test.sh
+
+# ED25519 TEST
+      - name: make clean
+        run: |
+          make clean && rm -f include/target.h
+
+      - name: Select config
+        run: |
+          cp config/examples/nrf52840.config .config && make include/target.h SIGN=ED25519
+
+      - name: Build wolfboot and test app image v1, SIGN=ED25519
+        run: |
+          make SIGN=ED25519 WOLFBOOT_SMALL_STACK=1 SPMATH=0
+
+      - name: Build update image v2
+        run: |
+          make /tmp/renode-test-update.bin SIGN=ED25519 WOLFBOOT_SMALL_STACK=1 SPMATH=0 && cp /tmp/renode-test-update.bin test-app/
+
+      - name: Renode Tests ED25519
+        run: ./tools/renode/docker-test.sh
+
+# ED448 TEST
+      - name: make clean
+        run: |
+          make clean && rm -f include/target.h
+
+      - name: Select config
+        run: |
+          cp config/examples/nrf52840.config .config && make include/target.h SIGN=ED448
+
+      - name: Build wolfboot and test app image v1, SIGN=ED448
+        run: |
+          make SIGN=ED448 WOLFBOOT_SMALL_STACK=1 SPMATH=0
+
+      - name: Build update image v2
+        run: |
+          make /tmp/renode-test-update.bin SIGN=ED448 WOLFBOOT_SMALL_STACK=1 SPMATH=0 && cp /tmp/renode-test-update.bin test-app/
+
+      - name: Renode Tests ED448
+        run: ./tools/renode/docker-test.sh
+
+# RSA2048 TEST
+      - name: make clean
+        run: |
+          make clean && rm -f include/target.h
+
+      - name: Select config
+        run: |
+          cp config/examples/nrf52840.config .config && make include/target.h SIGN=RSA2048
+
+      - name: Build wolfboot and test app image v1, SIGN=RSA2048
+        run: |
+          make SIGN=RSA2048 WOLFBOOT_SMALL_STACK=1 SPMATH=0
+
+      - name: Build update image v2
+        run: |
+          make /tmp/renode-test-update.bin SIGN=RSA2048 WOLFBOOT_SMALL_STACK=1 SPMATH=0 && cp /tmp/renode-test-update.bin test-app/
+
+      - name: Renode Tests RSA2048
+        run: ./tools/renode/docker-test.sh
+
+# RSA4096 TEST
+      - name: make clean
+        run: |
+          make clean && rm -f include/target.h
+
+      - name: Select config
+        run: |
+          cp config/examples/nrf52840.config .config && make include/target.h SIGN=RSA4096
+
+      - name: Build wolfboot and test app image v1, SIGN=RSA4096
+        run: |
+          make SIGN=RSA4096 WOLFBOOT_SMALL_STACK=1 SPMATH=0
+
+      - name: Build update image v2
+        run: |
+          make /tmp/renode-test-update.bin SIGN=RSA4096 WOLFBOOT_SMALL_STACK=1 SPMATH=0 && cp /tmp/renode-test-update.bin test-app/
+
+      - name: Renode Tests RSA4096
+        run: ./tools/renode/docker-test.sh
+
+      - name: Upload Output Dir
+        uses: actions/upload-artifact@v2
+        with:
+          name: Renode Test Results
+          path: test_results/
+

--- a/.github/workflows/test-renode-multi-mem.yml
+++ b/.github/workflows/test-renode-multi-mem.yml
@@ -1,4 +1,4 @@
-name: Renode Automated Tests: memory configurations
+name: Renode Automated multi memory configurations
 
 on:
   push:

--- a/.github/workflows/test-renode-multi-mem.yml
+++ b/.github/workflows/test-renode-multi-mem.yml
@@ -476,7 +476,7 @@ jobs:
 
       - name: Select config
         run: |
-          cp config/examples/nrf52840.config .config SPMATH=0 && make include/target.h SIGN=ED25519
+          cp config/examples/nrf52840.config .config && make include/target.h SIGN=ED25519
 
       - name: Build wolfboot and test app image v1, SIGN=ED25519
         run: |

--- a/.github/workflows/test-renode-multi-sha.yml
+++ b/.github/workflows/test-renode-multi-sha.yml
@@ -1,4 +1,4 @@
-name: Renode Automated Tests: SHA algorithms
+name: Renode Automated multi SHA algorithms
 
 on:
   push:

--- a/.github/workflows/test-renode-multi-sha.yml
+++ b/.github/workflows/test-renode-multi-sha.yml
@@ -1,0 +1,300 @@
+name: Renode Automated Tests: SHA algorithms
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build_and_test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      # Get the arm-non-eabi-gcc toolchain
+      - name: Install arm-none-eabi-gcc
+        uses: fiam/arm-none-eabi-gcc@v1
+        with:
+          # The arm-none-eabi-gcc release to use.
+          release: "9-2019-q4"
+
+      - name: Install wolfSSL
+        run: |
+          sudo apt-get install --no-install-recommends -y -q make libwolfssl-dev
+
+      - name: Build test-expect-version
+        run: |
+          make -C tools/test-expect-version
+
+      - name: make clean
+        run: |
+          make clean && make -C tools/keytools clean && rm -f include/target.h
+
+      - name: Select config
+        run: |
+          cp config/examples/nrf52840.config .config && make include/target.h
+
+      - name: Build key tools
+        run: |
+          make -C tools/keytools
+
+
+  ##### SHA384 tests
+
+  # ECC256 TEST
+      - name: make clean
+        run: |
+          make clean && rm -f include/target.h
+
+      - name: Select config
+        run: |
+          cp config/examples/nrf52840.config .config && make include/target.h SIGN=ECC256
+
+      - name: Build wolfboot and test app image v1, SIGN=ECC256
+        run: |
+          make SIGN=ECC256 HASH=SHA384
+
+      - name: Build update image v2
+        run: |
+          make /tmp/renode-test-update.bin SIGN=ECC256 HASH=SHA384 && cp /tmp/renode-test-update.bin test-app/
+
+      - name: Renode Tests ECC256
+        run: ./tools/renode/docker-test.sh
+
+# ECC384 TEST
+      - name: make clean
+        run: |
+          make clean && rm -f include/target.h
+
+      - name: Select config
+        run: |
+          cp config/examples/nrf52840.config .config && make include/target.h SIGN=ECC384
+
+      - name: Build wolfboot and test app image v1, SIGN=ECC384
+        run: |
+          make SIGN=ECC384 HASH=SHA384
+
+      - name: Build update image v2
+        run: |
+          make /tmp/renode-test-update.bin SIGN=ECC384 HASH=SHA384 && cp /tmp/renode-test-update.bin test-app/
+
+      - name: Renode Tests ECC384
+        run: ./tools/renode/docker-test.sh
+
+# ED25519 TEST
+      - name: make clean
+        run: |
+          make clean && rm -f include/target.h
+
+      - name: Select config
+        run: |
+          cp config/examples/nrf52840.config .config && make include/target.h SIGN=ED25519
+
+      - name: Build wolfboot and test app image v1, SIGN=ED25519
+        run: |
+          make SIGN=ED25519 HASH=SHA384
+
+      - name: Build update image v2
+        run: |
+          make /tmp/renode-test-update.bin SIGN=ED25519 HASH=SHA384 && cp /tmp/renode-test-update.bin test-app/
+
+      - name: Renode Tests ED25519
+        run: ./tools/renode/docker-test.sh
+
+# ED448 TEST
+      - name: make clean
+        run: |
+          make clean && rm -f include/target.h
+
+      - name: Select config
+        run: |
+          cp config/examples/nrf52840.config .config && make include/target.h SIGN=ED448
+
+      - name: Build wolfboot and test app image v1, SIGN=ED448
+        run: |
+          make SIGN=ED448 HASH=SHA384
+
+      - name: Build update image v2
+        run: |
+          make /tmp/renode-test-update.bin SIGN=ED448 HASH=SHA384 && cp /tmp/renode-test-update.bin test-app/
+
+      - name: Renode Tests ED448
+        run: ./tools/renode/docker-test.sh
+
+# RSA2048 TEST
+      - name: make clean
+        run: |
+          make clean && rm -f include/target.h
+
+      - name: Select config
+        run: |
+          cp config/examples/nrf52840.config .config && make include/target.h SIGN=RSA2048
+
+      - name: Build wolfboot and test app image v1, SIGN=RSA2048
+        run: |
+          make SIGN=RSA2048 HASH=SHA384
+
+      - name: Build update image v2
+        run: |
+          make /tmp/renode-test-update.bin SIGN=RSA2048 HASH=SHA384 && cp /tmp/renode-test-update.bin test-app/
+
+      - name: Renode Tests RSA2048
+        run: ./tools/renode/docker-test.sh
+
+# RSA4096 TEST
+      - name: make clean
+        run: |
+          make clean && rm -f include/target.h
+
+      - name: Select config
+        run: |
+          cp config/examples/nrf52840.config .config && make include/target.h SIGN=RSA4096
+
+      - name: Build wolfboot and test app image v1, SIGN=RSA4096
+        run: |
+          make SIGN=RSA4096 HASH=SHA384
+
+      - name: Build update image v2
+        run: |
+          make /tmp/renode-test-update.bin SIGN=RSA4096 HASH=SHA384 && cp /tmp/renode-test-update.bin test-app/
+
+      - name: Renode Tests RSA4096
+        run: ./tools/renode/docker-test.sh
+
+      - name: Upload Output Dir
+        uses: actions/upload-artifact@v2
+        with:
+          name: Renode Test Results
+          path: test_results/
+
+  ##### SHA-384 tests
+
+  # ECC256 TEST
+      - name: make clean
+        run: |
+          make clean && rm -f include/target.h
+
+      - name: Select config
+        run: |
+          cp config/examples/nrf52840.config .config && make include/target.h SIGN=ECC256
+
+      - name: Build wolfboot and test app image v1, SIGN=ECC256
+        run: |
+          make SIGN=ECC256 HASH=SHA3
+
+      - name: Build update image v2
+        run: |
+          make /tmp/renode-test-update.bin SIGN=ECC256 HASH=SHA3 && cp /tmp/renode-test-update.bin test-app/
+
+      - name: Renode Tests ECC256
+        run: ./tools/renode/docker-test.sh
+
+# ECC384 TEST
+      - name: make clean
+        run: |
+          make clean && rm -f include/target.h
+
+      - name: Select config
+        run: |
+          cp config/examples/nrf52840.config .config && make include/target.h SIGN=ECC384
+
+      - name: Build wolfboot and test app image v1, SIGN=ECC384
+        run: |
+          make SIGN=ECC384 HASH=SHA3
+
+      - name: Build update image v2
+        run: |
+          make /tmp/renode-test-update.bin SIGN=ECC384 HASH=SHA3 && cp /tmp/renode-test-update.bin test-app/
+
+      - name: Renode Tests ECC384
+        run: ./tools/renode/docker-test.sh
+
+# ED25519 TEST
+      - name: make clean
+        run: |
+          make clean && rm -f include/target.h
+
+      - name: Select config
+        run: |
+          cp config/examples/nrf52840.config .config && make include/target.h SIGN=ED25519
+
+      - name: Build wolfboot and test app image v1, SIGN=ED25519
+        run: |
+          make SIGN=ED25519 HASH=SHA3
+
+      - name: Build update image v2
+        run: |
+          make /tmp/renode-test-update.bin SIGN=ED25519 HASH=SHA3 && cp /tmp/renode-test-update.bin test-app/
+
+      - name: Renode Tests ED25519
+        run: ./tools/renode/docker-test.sh
+
+# ED448 TEST
+      - name: make clean
+        run: |
+          make clean && rm -f include/target.h
+
+      - name: Select config
+        run: |
+          cp config/examples/nrf52840.config .config && make include/target.h SIGN=ED448
+
+      - name: Build wolfboot and test app image v1, SIGN=ED448
+        run: |
+          make SIGN=ED448 HASH=SHA3
+
+      - name: Build update image v2
+        run: |
+          make /tmp/renode-test-update.bin SIGN=ED448 HASH=SHA3 && cp /tmp/renode-test-update.bin test-app/
+
+      - name: Renode Tests ED448
+        run: ./tools/renode/docker-test.sh
+
+# RSA2048 TEST
+      - name: make clean
+        run: |
+          make clean && rm -f include/target.h
+
+      - name: Select config
+        run: |
+          cp config/examples/nrf52840.config .config && make include/target.h SIGN=RSA2048
+
+      - name: Build wolfboot and test app image v1, SIGN=RSA2048
+        run: |
+          make SIGN=RSA2048 HASH=SHA3
+
+      - name: Build update image v2
+        run: |
+          make /tmp/renode-test-update.bin SIGN=RSA2048 HASH=SHA3 && cp /tmp/renode-test-update.bin test-app/
+
+      - name: Renode Tests RSA2048
+        run: ./tools/renode/docker-test.sh
+
+# RSA4096 TEST
+      - name: make clean
+        run: |
+          make clean && rm -f include/target.h
+
+      - name: Select config
+        run: |
+          cp config/examples/nrf52840.config .config && make include/target.h SIGN=RSA4096
+
+      - name: Build wolfboot and test app image v1, SIGN=RSA4096
+        run: |
+          make SIGN=RSA4096 HASH=SHA3
+
+      - name: Build update image v2
+        run: |
+          make /tmp/renode-test-update.bin SIGN=RSA4096 HASH=SHA3 && cp /tmp/renode-test-update.bin test-app/
+
+      - name: Renode Tests RSA4096
+        run: ./tools/renode/docker-test.sh
+
+      - name: Upload Output Dir
+        uses: actions/upload-artifact@v2
+        with:
+          name: Renode Test Results
+          path: test_results/

--- a/options.mk
+++ b/options.mk
@@ -68,7 +68,7 @@ ifeq ($(SIGN),ECC384)
   else ifeq ($(WOLFTPM),1)
     STACK_USAGE=6680
   else ifneq ($(SPMATH),1)
-    STACK_USAGE=6056
+    STACK_USAGE=11248
   else
     STACK_USAGE=5880
   endif

--- a/src/xmalloc.c
+++ b/src/xmalloc.c
@@ -83,10 +83,11 @@ struct xmalloc_slot {
             #define MP_DIGITS_BUFFER_SIZE_1 (MP_DIGIT_SIZE * 2 * 12 * 6)
             #define MP_MONTGOMERY_SIZE (sizeof(int64_t) * 12)
         #else
-            #define MP_POINT_SIZE (220)
-            #define MP_DIGITS_BUFFER_SIZE_0 (MP_DIGIT_SIZE * 16 * 9)
-            #define MP_DIGITS_BUFFER_SIZE_1 (MP_DIGIT_SIZE * (4 * 9 + 3))
-            #define MP_DIGITS_BUFFER_SIZE_2 (MP_DIGIT_SIZE * (2 * 9 * 5))
+            #define MP_POINT_SIZE (364)
+            #define MP_DIGITS_BUFFER_SIZE_0 (MP_DIGIT_SIZE * 16 * 15)
+            #define MP_DIGITS_BUFFER_SIZE_1 (MP_DIGIT_SIZE * (4 * 15 + 3))
+            #define MP_DIGITS_BUFFER_SIZE_2 (MP_DIGIT_SIZE * (2 * 15 * 6))
+            #define MP_MONTGOMERY_SIZE (sizeof(int64_t) * 2 * 12)
         #endif
     #endif /* WOLFBOOT_SIGN_ECC384 */
     #ifndef WC_NO_CACHE_RESISTANT
@@ -97,7 +98,7 @@ struct xmalloc_slot {
     static uint8_t mp_points_2[MP_POINT_SIZE * (16 + 1)];
     static uint8_t mp_digits_buffer_0[MP_DIGITS_BUFFER_SIZE_0];
     static uint8_t mp_digits_buffer_1[MP_DIGITS_BUFFER_SIZE_1];
-    #if !defined(WOLFSSL_SP_ARM_CORTEX_M_ASM) && defined(WOLFBOOT_SIGN_ECC256)
+    #if !defined(WOLFSSL_SP_ARM_CORTEX_M_ASM) && (defined(WOLFBOOT_SIGN_ECC256) || defined(WOLFBOOT_SIGN_ECC384))
     static uint8_t mp_digits_buffer_2[MP_DIGITS_BUFFER_SIZE_2];
     static uint8_t mp_montgomery[MP_MONTGOMERY_SIZE];
     #elif defined(WOLFBOOT_SIGN_ECC384)
@@ -165,7 +166,7 @@ static struct xmalloc_slot xmalloc_pool[] = {
     #else
     { (uint8_t *)mp_points_1, MP_POINT_SIZE * 3, 0 },
     { (uint8_t *)mp_digits_buffer_2, MP_DIGITS_BUFFER_SIZE_2, 0 },
-    { (uint8_t *)mp_montgomery, sizeof(int64_t) * 2 * 8, 0 },
+    { (uint8_t *)mp_montgomery, MP_MONTGOMERY_SIZE, 0 },
     #endif
     { (uint8_t *)mp_points_2, MP_POINT_SIZE * (16 + 1), 0 },
     { (uint8_t *)mp_digits_buffer_0, MP_DIGITS_BUFFER_SIZE_0, 0},


### PR DESCRIPTION
Fixed XMALLOC buffers with the following configuration:

`SIGN=ECC384 WOLFBOOT_SMALL_STACK=1 NO_ASM=1`