### PR TITLE
Fixed SIGN=NONE. Improved tests

### DIFF
--- a/.github/workflows/test-renode-multi-mem.yml
+++ b/.github/workflows/test-renode-multi-mem.yml
@@ -45,6 +45,26 @@ jobs:
 
   ##### SMALL STACK tests
 
+  # SIGN=NONE TEST
+      - name: make clean
+        run: |
+          make clean && rm -f include/target.h
+
+      - name: Select config
+        run: |
+          cp config/examples/nrf52840.config .config && make include/target.h SIGN=NONE WOLFBOOT_SMALL_STACK=1
+
+      - name: Build wolfboot and test app image v1, SIGN=NONE WOLFBOOT_SMALL_STACK=1
+        run: |
+          make SIGN=NONE
+
+      - name: Build update image v2
+        run: |
+          make /tmp/renode-test-update.bin SIGN=NONE WOLFBOOT_SMALL_STACK=1 && cp /tmp/renode-test-update.bin test-app/
+
+      - name: Renode Tests SIGN=NONE WOLFBOOT_SMALL_STACK=1
+        run: ./tools/renode/docker-test.sh
+
   # ECC256 TEST
       - name: make clean
         run: |
@@ -298,7 +318,7 @@ jobs:
         with:
           name: Renode Test Results
           path: test_results/
-  
+
 ##### SMALL STACK + NO_ASM tests
 
   # ECC256 TEST
@@ -339,46 +359,6 @@ jobs:
           make /tmp/renode-test-update.bin SIGN=ECC384 WOLFBOOT_SMALL_STACK=1 NO_ASM=1 && cp /tmp/renode-test-update.bin test-app/
 
       - name: Renode Tests ECC384
-        run: ./tools/renode/docker-test.sh
-
-# ED25519 TEST
-      - name: make clean
-        run: |
-          make clean && rm -f include/target.h
-
-      - name: Select config
-        run: |
-          cp config/examples/nrf52840.config .config && make include/target.h SIGN=ED25519
-
-      - name: Build wolfboot and test app image v1, SIGN=ED25519
-        run: |
-          make SIGN=ED25519 WOLFBOOT_SMALL_STACK=1 NO_ASM=1
-
-      - name: Build update image v2
-        run: |
-          make /tmp/renode-test-update.bin SIGN=ED25519 WOLFBOOT_SMALL_STACK=1 NO_ASM=1  && cp /tmp/renode-test-update.bin test-app/
-
-      - name: Renode Tests ED25519
-        run: ./tools/renode/docker-test.sh
-
-# ED448 TEST
-      - name: make clean
-        run: |
-          make clean && rm -f include/target.h
-
-      - name: Select config
-        run: |
-          cp config/examples/nrf52840.config .config && make include/target.h SIGN=ED448
-
-      - name: Build wolfboot and test app image v1, SIGN=ED448
-        run: |
-          make SIGN=ED448 WOLFBOOT_SMALL_STACK=1 NO_ASM=1
-
-      - name: Build update image v2
-        run: |
-          make /tmp/renode-test-update.bin SIGN=ED448 WOLFBOOT_SMALL_STACK=1 NO_ASM=1 && cp /tmp/renode-test-update.bin test-app/
-
-      - name: Renode Tests ED448
         run: ./tools/renode/docker-test.sh
 
 # RSA2048 TEST
@@ -469,46 +449,6 @@ jobs:
       - name: Renode Tests ECC384
         run: ./tools/renode/docker-test.sh
 
-# ED25519 TEST
-      - name: make clean
-        run: |
-          make clean && rm -f include/target.h
-
-      - name: Select config
-        run: |
-          cp config/examples/nrf52840.config .config && make include/target.h SIGN=ED25519
-
-      - name: Build wolfboot and test app image v1, SIGN=ED25519
-        run: |
-          make SIGN=ED25519 SPMATH=0
-
-      - name: Build update image v2
-        run: |
-          make /tmp/renode-test-update.bin SIGN=ED25519 SPMATH=0 && cp /tmp/renode-test-update.bin test-app/
-
-      - name: Renode Tests ED25519
-        run: ./tools/renode/docker-test.sh
-
-# ED448 TEST
-      - name: make clean
-        run: |
-          make clean && rm -f include/target.h
-
-      - name: Select config
-        run: |
-          cp config/examples/nrf52840.config .config && make include/target.h SIGN=ED448
-
-      - name: Build wolfboot and test app image v1, SIGN=ED448
-        run: |
-          make SIGN=ED448 SPMATH=0
-
-      - name: Build update image v2
-        run: |
-          make /tmp/renode-test-update.bin SIGN=ED448 SPMATH=0 && cp /tmp/renode-test-update.bin test-app/
-
-      - name: Renode Tests ED448
-        run: ./tools/renode/docker-test.sh
-
 # RSA2048 TEST
       - name: make clean
         run: |
@@ -554,7 +494,7 @@ jobs:
         with:
           name: Renode Test Results
           path: test_results/
-  
+
 ##### SMALL STACK + FAST MATH tests
 
   # ECC256 TEST
@@ -595,46 +535,6 @@ jobs:
           make /tmp/renode-test-update.bin SIGN=ECC384 WOLFBOOT_SMALL_STACK=1 SPMATH=0 && cp /tmp/renode-test-update.bin test-app/
 
       - name: Renode Tests ECC384
-        run: ./tools/renode/docker-test.sh
-
-# ED25519 TEST
-      - name: make clean
-        run: |
-          make clean && rm -f include/target.h
-
-      - name: Select config
-        run: |
-          cp config/examples/nrf52840.config .config && make include/target.h SIGN=ED25519
-
-      - name: Build wolfboot and test app image v1, SIGN=ED25519
-        run: |
-          make SIGN=ED25519 WOLFBOOT_SMALL_STACK=1 SPMATH=0
-
-      - name: Build update image v2
-        run: |
-          make /tmp/renode-test-update.bin SIGN=ED25519 WOLFBOOT_SMALL_STACK=1 SPMATH=0 && cp /tmp/renode-test-update.bin test-app/
-
-      - name: Renode Tests ED25519
-        run: ./tools/renode/docker-test.sh
-
-# ED448 TEST
-      - name: make clean
-        run: |
-          make clean && rm -f include/target.h
-
-      - name: Select config
-        run: |
-          cp config/examples/nrf52840.config .config && make include/target.h SIGN=ED448
-
-      - name: Build wolfboot and test app image v1, SIGN=ED448
-        run: |
-          make SIGN=ED448 WOLFBOOT_SMALL_STACK=1 SPMATH=0
-
-      - name: Build update image v2
-        run: |
-          make /tmp/renode-test-update.bin SIGN=ED448 WOLFBOOT_SMALL_STACK=1 SPMATH=0 && cp /tmp/renode-test-update.bin test-app/
-
-      - name: Renode Tests ED448
         run: ./tools/renode/docker-test.sh
 
 # RSA2048 TEST

--- a/.github/workflows/test-renode-multi-mem.yml
+++ b/.github/workflows/test-renode-multi-mem.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Build wolfboot and test app image v1, SIGN=NONE WOLFBOOT_SMALL_STACK=1
         run: |
-          make SIGN=NONE
+          make SIGN=NONE WOLFBOOT_SMALL_STACK=1
 
       - name: Build update image v2
         run: |

--- a/.github/workflows/test-renode-multi-sha.yml
+++ b/.github/workflows/test-renode-multi-sha.yml
@@ -45,6 +45,27 @@ jobs:
 
   ##### SHA384 tests
 
+    # SIGN=NONE TEST
+      - name: make clean
+        run: |
+          make clean && rm -f include/target.h
+
+      - name: Select config
+        run: |
+          cp config/examples/nrf52840.config .config && make include/target.h SIGN=NONE HASH=SHA384
+
+      - name: Build wolfboot and test app image v1, SIGN=NONE HASH=SHA384
+        run: |
+          make SIGN=NONE
+
+      - name: Build update image v2
+        run: |
+          make /tmp/renode-test-update.bin SIGN=NONE HASH=SHA384 && cp /tmp/renode-test-update.bin test-app/
+
+      - name: Renode Tests SIGN=NONE HASH=SHA384
+        run: ./tools/renode/docker-test.sh
+
+
   # ECC256 TEST
       - name: make clean
         run: |
@@ -171,7 +192,26 @@ jobs:
           name: Renode Test Results
           path: test_results/
 
-  ##### SHA-384 tests
+  ##### SHA-3 tests
+  # SIGN=NONE TEST
+      - name: make clean
+        run: |
+          make clean && rm -f include/target.h
+
+      - name: Select config
+        run: |
+          cp config/examples/nrf52840.config .config && make include/target.h SIGN=NONE HASH=SHA3
+
+      - name: Build wolfboot and test app image v1, SIGN=NONE HASH=SHA3
+        run: |
+          make SIGN=NONE
+
+      - name: Build update image v2
+        run: |
+          make /tmp/renode-test-update.bin SIGN=NONE HASH=SHA3 && cp /tmp/renode-test-update.bin test-app/
+
+      - name: Renode Tests SIGN=NONE HASH=SHA3
+        run: ./tools/renode/docker-test.sh
 
   # ECC256 TEST
       - name: make clean

--- a/.github/workflows/test-renode-multi-sha.yml
+++ b/.github/workflows/test-renode-multi-sha.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Build wolfboot and test app image v1, SIGN=NONE HASH=SHA384
         run: |
-          make SIGN=NONE
+          make SIGN=NONE HASH=SHA384
 
       - name: Build update image v2
         run: |
@@ -204,7 +204,7 @@ jobs:
 
       - name: Build wolfboot and test app image v1, SIGN=NONE HASH=SHA3
         run: |
-          make SIGN=NONE
+          make SIGN=NONE HASH=SHA3
 
       - name: Build update image v2
         run: |

--- a/.github/workflows/test-renode-nrf52.yml
+++ b/.github/workflows/test-renode-nrf52.yml
@@ -42,6 +42,27 @@ jobs:
         run: |
           make -C tools/keytools
 
+   # SIGN=NONE TEST
+      - name: make clean
+        run: |
+          make clean && rm -f include/target.h
+
+      - name: Select config
+        run: |
+          cp config/examples/nrf52840.config .config && make include/target.h SIGN=NONE
+
+      - name: Build wolfboot and test app image v1, SIGN=NONE
+        run: |
+          make SIGN=NONE
+
+      - name: Build update image v2
+        run: |
+          make /tmp/renode-test-update.bin SIGN=NONE && cp /tmp/renode-test-update.bin test-app/
+
+      - name: Renode Tests SIGN=NONE
+        run: ./tools/renode/docker-test.sh
+
+
   # ECC256 TEST
       - name: make clean
         run: |

--- a/src/image.c
+++ b/src/image.c
@@ -613,7 +613,7 @@ static int image_sha3_384(struct wolfBoot_image *img, uint8_t *hash)
     wc_Sha3_384_Final(&sha3_ctx, hash);
     return 0;
 }
-
+#ifndef WOLFBOOT_NO_SIGN
 static void key_sha3_384(uint8_t *hash)
 {
     int blksz;
@@ -630,6 +630,7 @@ static void key_sha3_384(uint8_t *hash)
     }
     wc_Sha3_384_Final(&sha3_ctx, hash);
 }
+#endif /* WOLFBOOT_NO_SIGN */
 #endif /* SHA3-384 */
 
 #ifdef WOLFBOOT_TPM

--- a/src/image.c
+++ b/src/image.c
@@ -830,6 +830,7 @@ int wolfBoot_verify_integrity(struct wolfBoot_image *img)
 #ifdef WOLFBOOT_NO_SIGN
 int wolfBoot_verify_authenticity(struct wolfBoot_image *img)
 {
+    wolfBoot_image_confirm_signature_ok(img);
     return 0;
 }
 #else

--- a/tools/keytools/sign.c
+++ b/tools/keytools/sign.c
@@ -1195,7 +1195,7 @@ int main(int argc, char** argv)
 
     /* Parse Arguments */
     for (i=1; i<argc; i++) {
-        if (strcmp(argv[i], "--no-CMD.sign") == 0) {
+        if (strcmp(argv[i], "--no-sign") == 0) {
             CMD.sign = NO_SIGN;
             sign_str = "NONE";
         } else if (strcmp(argv[i], "--ed25519") == 0) {

--- a/tools/scripts/renode-test-all.sh
+++ b/tools/scripts/renode-test-all.sh
@@ -1,19 +1,16 @@
 #!/bin/bash
 
-EXTRA_TARGETS="stm32f7 nrf52840 hifive1"
+TARGETS="stm32f4 stm32f7 nrf52840 hifive1"
 
 if (test -e .config); then
     mv .config config.bak
 fi
 
-echo testing on stm32f4
-make renode-factory-all || exit 2
-
-for cfg in $EXTRA_TARGETS; do
+for cfg in $TARGETS; do
     rm -f .config
     echo testing on $cfg
     cp config/examples/$cfg.config .config || exit 1
-    make renode-factory-all || exit 2
+    make renode-factory-all Q="@" || exit 2
 done
 
 if (test -e config.bak); then


### PR DESCRIPTION
- Fixed SIGN=NONE option broken since #183 
- Improved renode tests: 
   - added SIGN=NONE cases
   - removed assembly cases with edwards curves
   - added boot time measurement to renode factory test