### PR TITLE
STM32L4: do not override HAL_GetTick when building libwolfboot

### DIFF
--- a/hal/stm32l4.c
+++ b/hal/stm32l4.c
@@ -260,7 +260,9 @@ void hal_prepare_boot(void)
  * It is defined here only to avoid a compiler error
  * for a missing symbol in hal_flash_driver.
  */
+#ifdef __WOLFBOOT
 uint32_t HAL_GetTick(void)
 {
     return 0;
 }
+#endif


### PR DESCRIPTION
Avoid the override of HAL_GetTick when compiling libwolfboot within the OS/application on STM32L4.

The override is needed to build the minimal flash driver in bootloader context, but must be provided via STM32 CubeMX HAL when building libwolfboot from the application.

See ZD14045.