### PR TITLE
Fixed build of delta update tools

### DIFF
--- a/tools/delta/Makefile
+++ b/tools/delta/Makefile
@@ -1,5 +1,5 @@
 all: bmdiff bmpatch
-CFLAGS+=-Wall -Werror -Wextra
+CFLAGS+=-Wall -Werror -Wextra -DDELTA_UPDATES
 
 ifeq ($(HASH),SHA3)
   WOLFCRYPT_OBJS+=./lib/wolfssl/wolfcrypt/src/sha3.o


### PR DESCRIPTION
Fixes a regression that prevents building delta.c symbols in delta update tools (under tools/delta).

Introduced in PR #180 
Discovered by jenkins job `wolfboot-autotest-incremental-update` running on master