### PR TITLE
Support for partition ID in the manifest header

### DIFF
--- a/docs/Signing.md
+++ b/docs/Signing.md
@@ -1,70 +1,176 @@
 # wolfBoot Key Tools
 
-Instructions for setting up Python, wolfCrypt-py module and wolfBoot for firmware signing and key generation.
+`keygen` and `sign` are two command line tools to be used on a PC (or automated
+server) environment to manage wolfBoot private keys and sign the initial
+firmware and all the updates for the target.
 
-Note: There is a pure C version of the key tool available as well. See [C Key Tools](#c-key-tools) below.
+## C or Python
 
-## Install Python3
+The tools are distributed in two versions, using the same command line syntax,
+for portability reasons.
 
-1. Download latest Python 3.x and run installer: https://www.python.org/downloads
-2. Check the box that says Add Python 3.x to PATH
+By default, if no C keytools are compiled, the makefiles and scripts in this
+repository will use the Python tools.
 
-## Install wolfCrypt
+### Python key tools
 
-```sh
-git clone https://github.com/wolfSSL/wolfssl.git
-cd wolfssl
-./configure --enable-keygen --enable-rsa --enable-ecc --enable-ed25519 --enable-ed448 --enable-des3 CFLAGS="-DWOLFSSL_PUBLIC_MP"
-make
-sudo make install
-```
+In order to use the python key tools, ensure that the `wolfcrypt` package is
+installed in your python environment. In most systems it's sufficient to run a
+command similar to:
 
-## Install wolfcrypt-py
+`pip install wolfcrypt`
 
-```sh
-git clone https://github.com/wolfSSL/wolfcrypt-py.git
-cd wolfcrypt-py
-sudo USE_LOCAL_WOLFSSL=/usr/local pip3 install .
-```
+to ensure that the dependencies are met.
 
-## Install wolfBoot
+### C Key Tools
 
-```sh
-git clone https://github.com/wolfSSL/wolfBoot.git
-cd wolfBoot
-git submodule update --init
-# Setup configuration (or copy template from ./config/examples)
-make config
-# Build the wolfBoot binary and sign an example test application
-make
-```
+A standalone C version of the key tools is available in: `./tools/keytools`.
 
-## C Key Tools
+These can be built in `tools/keytools` using `make` or from the wolfBoot root using `make keytools`.
 
-A standalone C version of the keygen tools is available in: `./tools/keytools`. 
+If the C version of the key tools exists they will be used by wolfBoot's makefile and scripts.
 
-These can be built in `tools/keytools` using `make` or from the wolfBoot root using `make keytools`. 
-
-If the C version of the key tools exists they will be used by wolfBoot (the default is the Python scripts).
-
-### Windows Visual Studio
+#### Windows Visual Studio
 
 Use the `wolfBootSignTool.vcxproj` Visual Studio project to build the `sign.exe` and `keygen.exe` tools for use on Windows.
 
 
 ## Command Line Usage
 
-```sh
-./tools/keytools/keygen [--ed25519 | --ed448 | --ecc256 | --rsa2048 | --rsa4096 ]  pub_key_file.c
-```
+### Sign tool
 
-```sh
-./tools/keytools/sign [--ed25519 | --ed448 | --ecc256 | --rsa2048 | --rsa4096 ] [--sha256 | --sha3] [--wolfboot-update] image key.der fw_version
-  - or -        ./tools/keytools/sign [--sha256 | --sha3] [--sha-only] [--wolfboot-update] image pub_key.der fw_version
-  - or -        ./tools/keytools/sign [--ed25519 | --ed448 | --ecc256 | --rsa2048 | --rsa4096 ] [--sha256 | --sha3] [--manual-sign] image pub_key.der fw_version signature.sig
-```
+`sign` and `sign.py` produce a signed firmware image by creating a manifest header
+in the format supported by wolfBoot.
 
-## Signing Firmware
+Usage: `sign[.py] [OPTIONS] IMAGE.BIN KEY.DER VERSION`
+
+`IMAGE.BIN`:  A file containing the binary firmware/software to sign
+`KEY.DER`:    Private key file, in DER format, to sign the binary image
+`VERSION`:    The version associated with this signed software
+`OPTIONS`:    Zero or more options, described below
+
+#### Public key signature options
+
+If none of the following arguments is given, the tool will try to guess the key
+size from the format and key length detected in KEY.DER.
+
+  * `--ed25519` Use ED25519 for signing the firmware. Assume that the given KEY.DER
+file is in this format.
+
+  * `--ed448` Use ED448 for signing the firmware. Assume that the given KEY.DER
+file is in this format.
+
+  * `--ecc256` Use ecc256 for signing the firmware. Assume that the given KEY.DER
+file is in this format.
+
+  * `--ecc384` Use ecc384 for signing the firmware. Assume that the given KEY.DER
+file is in this format.
+
+  * `--rsa2048` Use rsa2048 for signing the firmware. Assume that the given KEY.DER
+file is in this format.
+
+  * `--rsa4096` Use rsa4096 for signing the firmware. Assume that the given KEY.DER
+file is in this format.
+
+  * `--no-sign` Disable secure boot signature verification. No signature
+    verification is performed in the bootloader, and the KEY.DER argument is
+    ignored.
+
+#### Hash digest options
+
+If none of the following is used, '--sha256' is assumed by default.
+
+  * `--sha256` Use sha256 for digest calculation on binary images and public keys.
+
+  * `--sha348` Use sha384 for digest calculation on binary images and public keys.
+
+  * `--sha3` Use sha3-384 for digest calculation on binary images and public keys.
+
+#### Target partition id (Multiple partition images, "self-update" feature)
+
+If none of the following is used, "--id=1" is assumed by default. On systems
+with a single image to verify (e.g. microcontroller with a single active
+partitions), ID=1 is the default identifier for the firmware image to stage.
+ID=0 is reserved for wolfBoot 'self-update', and refers to the partition where
+the bootloader itself is stored.
+
+  * `--id N` Set image partition id to "N".
+
+  * `--wolfboot-update` Indicate that the image contains a signed self-update
+package for the bootloader. Equivalent to `--id=0`.
+
+#### Encryption using a symmetric key
+
+Although signed to be authenticated, by default the image is not encrypted and
+it's distributed as plain text. End-to-end encryption from the firmware
+packaging to the update process can be used if the firmware is stored on
+external non-volatile memories. Encrypted updates can be produced using a
+pre-shared, secret symmetric key,  by passing the following option:
+
+  * `--encrypt SHAREDKEY.BIN` use the file SHAREKEY.BIN to encrypt the image.
+
+
+The format of the file depends on the algorithm selected for the encryption.
+If no format is specified, and the `--encrypt SHAREDKEY.BIN` option is present,
+`--chacha` is assumed by default.
+
+See options below.
+
+  * `--chacha` Use ChaCha20 algorithm for encrypting the image. The file
+    SHAREDKEY.BIN is expected to be exactly 44 bytes in size, of which 32 will
+be used for the key, 12 for the initialization of the IV.
+
+  * `--aes128` Use AES-128 algorithm in counter mode for encrypting the image. The file
+    SHAREDKEY.BIN is expected to be exactly 32 bytes in size, of which 16 will
+be used for the key, 16 for the initialization of the IV.
+
+  * `--aes256` Use AES-256 algorithm in counter mode for encrypting the image. The file
+    SHAREDKEY.BIN is expected to be exactly 48 bytes in size, of which 32 will
+be used for the key, 16 for the initialization of the IV.
+
+
+#### Delta updates (incremental updates from a known version)
+
+An incremental update is created using the sign tool when the following option
+is provided:
+
+  * `--delta BASE_SIGNED_IMG.BIN` This option creates a binary diff file between
+    BASE_SIGNED_IMG.BIN and the new image signed starting from IMAGE.BIN. The
+result is stored in a file ending in `_signed_diff.bin`.
+
+#### Three-steps signing using external provisioning tools
+
+If the private key is not accessible, while it's possible to sign payloads using
+a third-party tool, the sign mechanism can be split in three phases:
+
+- Phase 1: Only create the sha digest for the image, and prepare an intermediate
+  file that can be signed by third party tool.
+
+This is done using the following option:
+
+   * `--sha-only` When this option is selected, the sign tool will create an
+     intermediate image including part of the manifest that must be signed,
+ending in `_digest.bin`. In this case, KEY.DER contains the public part of the
+key that will be used to sign the firmware in Phase 2.
+
+- Phase 2: The intermediate image `*_digest.bin` is signed by an external tool,
+  an HSM or a third party signing service. The signature is then exported in
+its raw format and copied to a file, e.g. IMAGE_SIGNATURE.SIG
+
+- Phase 3: use the following option to build the final authenticated firmware
+  image, including its manifest header in front:
+
+  * `--manual-sign` When this option is provided, the KEY.DER argument contains
+    the public part of the key that was used to sign the firmware in Phase 2.
+This option requires one extra argument at the end, after VERSION, which should
+be the filename of the signature that was the output of the previous phase, so
+IMAGE_SIGNATURE.SIG
+
+For a real-life example, see the section below.
+
+## Examples
+
+### Signing Firmware
 
 1. Load the private key to use for signing into `./rsa2048.der`, `./rsa4096.der`, `./ed25519.der`, `ecc256.der`, or `./ed448.der`
 2. Run the signing tool with asymmetric algorithm, hash algorithm, file to sign, key and version.
@@ -77,7 +183,7 @@ python3 ./tools/keytools/sign.py --rsa2048 --sha256 test-app/image.bin rsa2048.d
 
 Note: The last argument is the “version” number.
 
-## Signing Firmware with External Private Key (HSM)
+### Signing Firmware with External Private Key (HSM)
 
 Steps for manually signing firmware using an external key source.
 

--- a/docs/Signing.md
+++ b/docs/Signing.md
@@ -90,14 +90,14 @@ If none of the following is used, '--sha256' is assumed by default.
 
 If none of the following is used, "--id=1" is assumed by default. On systems
 with a single image to verify (e.g. microcontroller with a single active
-partitions), ID=1 is the default identifier for the firmware image to stage.
+partition), ID=1 is the default identifier for the firmware image to stage.
 ID=0 is reserved for wolfBoot 'self-update', and refers to the partition where
 the bootloader itself is stored.
 
   * `--id N` Set image partition id to "N".
 
   * `--wolfboot-update` Indicate that the image contains a signed self-update
-package for the bootloader. Equivalent to `--id=0`.
+package for the bootloader. Equivalent to `--id 0`.
 
 #### Encryption using a symmetric key
 

--- a/include/wolfboot/wolfboot.h
+++ b/include/wolfboot/wolfboot.h
@@ -66,6 +66,13 @@
 #define HDR_SIGNATURE               0x20
 #define HDR_PADDING                 0xFF
 
+/*
+ * 8 bits: auth type
+ * 4 bits: extra features
+ * 4 bits: partition id  (0 = bootloader)
+ *
+ */
+#define HDR_IMG_TYPE_AUTH_MASK    0xFF00
 #define HDR_IMG_TYPE_AUTH_NONE    0xFF00
 #define HDR_IMG_TYPE_AUTH_ED25519 0x0100
 #define HDR_IMG_TYPE_AUTH_ECC256  0x0200
@@ -74,9 +81,12 @@
 #define HDR_IMG_TYPE_AUTH_ED448   0x0500
 #define HDR_IMG_TYPE_AUTH_ECC384  0x0600
 #define HDR_IMG_TYPE_AUTH_ECC521  0x0700
+
+#define HDR_IMG_TYPE_DIFF         0x00D0
+
+#define HDR_IMG_TYPE_PART_MASK    0x000F
 #define HDR_IMG_TYPE_WOLFBOOT     0x0000
 #define HDR_IMG_TYPE_APP          0x0001
-#define HDR_IMG_TYPE_DIFF         0x00D0
 
 
 #ifdef __WOLFBOOT
@@ -131,6 +141,11 @@ uint32_t wolfBoot_image_size(uint8_t *image);
 uint32_t wolfBoot_get_blob_version(uint8_t *blob);
 uint32_t wolfBoot_get_blob_type(uint8_t *blob);
 uint32_t wolfBoot_get_blob_diffbase_version(uint8_t *blob);
+
+/* Get partition ID from manifest header */
+static inline uint8_t wolfBoot_get_blob_partition_id(uint8_t *blob) {
+    return wolfBoot_get_blob_type(blob) & HDR_IMG_TYPE_PART_MASK;
+}
 
 #ifdef WOLFBOOT_FIXED_PARTITIONS
 void wolfBoot_erase_partition(uint8_t part);

--- a/tools/keytools/sign.c
+++ b/tools/keytools/sign.c
@@ -125,6 +125,7 @@
 #define HDR_IMG_DELTA_INVERSE 0x15
 #define HDR_IMG_DELTA_INVERSE_SIZE 0x16
 
+#define HDR_IMG_TYPE_AUTH_MASK    0xFF00
 #define HDR_IMG_TYPE_AUTH_NONE    0xFF00
 #define HDR_IMG_TYPE_AUTH_ED25519 0x0100
 #define HDR_IMG_TYPE_AUTH_ECC256  0x0200
@@ -220,13 +221,15 @@ struct cmd_options {
     uint32_t pubkey_sz;
     uint32_t header_sz;
     uint32_t signature_sz;
+    uint8_t partition_id;
 };
 
 static struct cmd_options CMD = {
     .sign = SIGN_AUTO,
     .encrypt  = ENC_OFF,
     .hash_algo = HASH_SHA256,
-    .header_sz = IMAGE_HEADER_SIZE
+    .header_sz = IMAGE_HEADER_SIZE,
+    .partition_id = HDR_IMG_TYPE_APP
 };
 
 static uint8_t *load_key(uint8_t **key_buffer, uint32_t *key_buffer_sz,
@@ -494,9 +497,8 @@ static int make_header_ex(int is_diff, uint8_t *pubkey, uint32_t pubkey_sz,
         &attrib.st_ctime);
 
     /* Append Image type field */
-    image_type = (uint16_t)CMD.sign;
-    if (!CMD.self_update)
-        image_type |= HDR_IMG_TYPE_APP;
+    image_type = (uint16_t)CMD.sign & HDR_IMG_TYPE_AUTH_MASK;
+    image_type |= CMD.partition_id;
     if (is_diff)
         image_type |= HDR_IMG_TYPE_DIFF;
     header_append_tag(header, &header_idx, HDR_IMG_TYPE, HDR_IMG_TYPE_LEN,
@@ -1253,6 +1255,17 @@ int main(int argc, char** argv)
         }
         else if (strcmp(argv[i], "--wolfboot-update") == 0) {
             CMD.self_update = 1;
+            CMD.partition_id = 0;
+        }
+        else if (strcmp(argv[i], "--id") == 0) {
+            long id = strtol(argv[++i], NULL, 10);
+            if ((id < 0 || id > 15) || ((id == 0) && (argv[i][0] != '0'))) {
+                fprintf(stderr, "Invalid partition id: %s\n", argv[i]);
+                exit(16);
+            }
+            CMD.partition_id = (uint8_t)id;
+            if (id == 0)
+                CMD.self_update = 1;
         }
         else if (strcmp(argv[i], "--sha-only") == 0) {
             CMD.sha_only = 1;
@@ -1347,6 +1360,10 @@ int main(int argc, char** argv)
     if (CMD.encrypt) {
         printf("Encrypted output:     %s\n", CMD.output_encrypted_image_file);
     }
+    printf("Target partition id : %hu ", CMD.partition_id);
+    if (CMD.partition_id == HDR_IMG_TYPE_WOLFBOOT)
+        printf("(bootloader)");
+    printf("\n");
 
     /* get header and signature sizes */
     if (CMD.sign == SIGN_ED25519) {

--- a/tools/keytools/sign.c
+++ b/tools/keytools/sign.c
@@ -1157,12 +1157,6 @@ cleanup:
     return ret;
 }
 
-static const char Hashes_str[] = "[--sha256 | --sha384 | --sha3]";
-static const char Enc_str[] = "[--chacha | --aes128 | --aes256]";
-static const char Sign_algo_str[] = "[--ed25519 | --ed447 | --ecc256 | --ecc384 | --ecc521 | --rsa2048 | --rsa2048enc | --rsa4096 | --rsa4096enc | --no-CMD.sign]";
-
-
-
 int main(int argc, char** argv)
 {
     int ret = 0;
@@ -1185,18 +1179,9 @@ int main(int argc, char** argv)
 
     /* Check arguments and print usage */
     if (argc < 4 || argc > 12) {
-        printf("Usage: %s %s %s [--wolfboot-update] [--encrypt enc_key.bin] %s"
-               " [--delta image_vX_signed.bin] "
-               "image key.der fw_version\n",
-               argv[0], Hashes_str, Sign_algo_str, Enc_str);
-        printf("  - or - \n");
-        printf("       %s %s [--wolfboot-update] image pub_key.der fw_version\n",
-                argv[0], Hashes_str);
-        printf("  - or - \n");
-        printf("       %s %s %s [--manual-CMD.sign] image pub_key.der"
-               "fw_version signature.sig\n",
-                argv[0], Hashes_str, Sign_algo_str);
-        return 0;
+        printf("Usage: %s [options] image key version\n", argv[0]);
+        printf("For full usage manual, see 'docs/Signing.md'\n");
+        exit(1);
     }
 
     /* Parse Arguments */

--- a/tools/keytools/sign.py
+++ b/tools/keytools/sign.py
@@ -295,11 +295,8 @@ print("wolfcrypt-py version: " + wolfcrypt.__version__)
 
 
 if (argc < 4) or (argc > 12):
-    print("Usage: %s [--ed25519 | --ed448 | --ecc256 | --rsa2048 | --rsa4096 | --no-sign] [--sha256 | --sha384 | --sha3] [--wolfboot-update] [--encrypt key.bin] [--delta base_file.bin] image key.der fw_version\n" % sys.argv[0])
-    print("  - or - ")
-    print("       %s [--sha256 | --sha384 | --sha3] [--sha-only] [--wolfboot-update] [--encrypt key.bin] [--delta base_file.bin] image pub_key.der fw_version\n" % sys.argv[0])
-    print("  - or - ")
-    print("       %s [--ed25519 | --ed448 | --ecc256 | --rsa2048 | --rsa4096 ] [--sha256 | --sha384 | --sha3] [--manual-sign] [--chacha | --aes128 | --aes256 ] [--encrypt key.bin] [--delta base_file.bin] image pub_key.der fw_version signature.sig\n" % sys.argv[0])
+    print("Usage: "+argv[0]+" [options] image key version");
+    print("For full usage manual, see 'docs/Signing.md'");
     sys.exit(1)
 
 i = 1

--- a/tools/keytools/sign.py
+++ b/tools/keytools/sign.py
@@ -83,6 +83,7 @@ aes256=False
 delta=False
 encrypt_key_file=None
 delta_base_file=None
+partition_id = HDR_IMG_TYPE_APP
 
 
 argc = len(sys.argv)
@@ -130,8 +131,7 @@ def make_header(image_file, fw_version, extra_fields=[]):
     if (sign == 'rsa4096'):
         img_type = HDR_IMG_TYPE_AUTH_RSA4096
 
-    if (not self_update):
-        img_type |= HDR_IMG_TYPE_APP
+    img_type |= partition_id
 
     if (delta and len(extra_fields) > 0):
         img_type |= HDR_IMG_TYPE_DIFF
@@ -291,6 +291,9 @@ def make_header(image_file, fw_version, extra_fields=[]):
 print("wolfBoot KeyTools (Python version)")
 print("wolfcrypt-py version: " + wolfcrypt.__version__)
 
+
+
+
 if (argc < 4) or (argc > 12):
     print("Usage: %s [--ed25519 | --ed448 | --ecc256 | --rsa2048 | --rsa4096 | --no-sign] [--sha256 | --sha384 | --sha3] [--wolfboot-update] [--encrypt key.bin] [--delta base_file.bin] image key.der fw_version\n" % sys.argv[0])
     print("  - or - ")
@@ -325,6 +328,15 @@ while (i < len(argv)):
         hash_algo='sha3'
     elif (argv[i] == '--wolfboot-update'):
         self_update = True
+        partition_id = HDR_IMG_TYPE_WOLFBOOT
+    elif (argv[i] == '--id'):
+        i+=1
+        partition_id = int(argv[i])
+        if partition_id < 0 or partition_id > 15:
+            print("Invalid partition id: " + argv[i])
+            sys.exit(16)
+        if partition_id == 0:
+            self_update = True
     elif (argv[i] == '--sha-only'):
         sha_only = True
     elif (argv[i] == '--manual-sign'):
@@ -443,6 +455,10 @@ if not encrypt:
     print ("Not Encrypted")
 else:
     print ("Encrypted using:      " + encrypt_key_file)
+nickname = ""
+if partition_id == 0:
+    nickname = "(bootloader)"
+print ("Target partition id:  " + str(partition_id) +" "+ nickname)
 
 if sign == 'none':
     kf = None


### PR DESCRIPTION
sign[.py] allows to specify the partition ID from command line. 

Currently, the firmware update function verifies/updates only the image with ID=1. ID=0 is used for wolfBoot self update.

With the new option `--id N` it's also possible to specify other IDs, from 2 to 15. (Selecting 0 will automatically switch to bootloader self-update)

Signing.md manual updated accordingly, and restructured to cope with increasing amount of options.