### PR TITLE
Fixed XMEMCPY symbol in test applications

### DIFF
--- a/src/libwolfboot.c
+++ b/src/libwolfboot.c
@@ -57,7 +57,7 @@
     #define ENCRYPT_TMP_SECRET_OFFSET (WOLFBOOT_PARTITION_SIZE - (TRAILER_SKIP))
 #endif
 
-#if defined(WOLFBOOT_TPM) && !defined(__WOLFBOOT)
+#if !defined(__WOLFBOOT)
     #define XMEMSET memset
     #define XMEMCPY memcpy
     #define XMEMCMP memcmp


### PR DESCRIPTION
More test application still needing XMEMCPY definitions (not only in TPM mode)