### PR TITLE
Encrypted self-update

### DIFF
--- a/hal/spi/spi_drv_stm32.c
+++ b/hal/spi/spi_drv_stm32.c
@@ -43,7 +43,7 @@ void RAMFUNCTION spi_cs_on(int pin)
 }
 
 
-static void spi_flash_pin_setup(void)
+static void RAMFUNCTION spi_flash_pin_setup(void)
 {
     uint32_t reg;
     RCC_GPIO_CLOCK_ER |= SPI_PIO_CS_CEN;
@@ -71,7 +71,7 @@ static void spi_tpm2_pin_setup(void)
 #endif
 }
 
-static void spi1_pins_setup(void)
+static void RAMFUNCTION spi1_pins_setup(void)
 {
     uint32_t reg;
     RCC_GPIO_CLOCK_ER |= SPI_PIO_CEN;
@@ -132,7 +132,7 @@ static void spi_pins_release(void)
 
 }
 
-static void spi1_reset(void)
+static void RAMFUNCTION spi1_reset(void)
 {
     APB2_CLOCK_RST |= SPI1_APB2_CLOCK_ER_VAL;
     APB2_CLOCK_RST &= ~SPI1_APB2_CLOCK_ER_VAL;
@@ -161,7 +161,7 @@ void RAMFUNCTION spi_write(const char byte)
 }
 
 
-void spi_init(int polarity, int phase)
+void RAMFUNCTION spi_init(int polarity, int phase)
 {
     static int initialized = 0;
     if (!initialized) {

--- a/hal/spi/spi_drv_stm32.h
+++ b/hal/spi/spi_drv_stm32.h
@@ -72,15 +72,26 @@
 #define APB2_CLOCK_ER     (*(volatile uint32_t *)(0x40021034))
 #define APB2_CLOCK_RST    (*(volatile uint32_t *)(0x40021024))
 #define RCC_GPIO_CLOCK_ER (*(volatile uint32_t *)(0x4002102C))
+#define GPIOA_BASE (0x50000000)
 #define GPIOB_BASE (0x50000400)
-#define SPI_GPIO    GPIOB_BASE
+
 #define SPI_CS_GPIO GPIOB_BASE
-#define SPI_CS_FLASH 8 /* Flash CS connected to GPIOB8 */
 #define SPI1_PIN_AF    0 /* Alternate function for SPI pins */
-#define SPI1_CLOCK_PIN 3 /* SPI_SCK: PB3  */
-#define SPI1_MISO_PIN  4 /* SPI_MISO PB4  */
-#define SPI1_MOSI_PIN  5 /* SPI_MOSI PB5  */
-#endif
+
+#ifndef SPI_ALT_CONFIGURATION
+    #define SPI_GPIO       GPIOB_BASE
+    #define SPI_CS_FLASH   8 /* Flash CS connected to GPIOB8 */
+    #define SPI1_CLOCK_PIN 3 /* SPI_SCK: PB3  */
+    #define SPI1_MISO_PIN  4 /* SPI_MISO PB4  */
+    #define SPI1_MOSI_PIN  5 /* SPI_MOSI PB5  */
+#else
+    #define SPI_GPIO       GPIOA_BASE
+    #define SPI_CS_FLASH   6 /* Flash CS connected to GPIOB6 */
+    #define SPI1_CLOCK_PIN 5 /* SPI_SCK: PA5  */
+    #define SPI1_MISO_PIN  6 /* SPI_MISO PA6  */
+    #define SPI1_MOSI_PIN  7 /* SPI_MOSI PA7  */
+#endif /* SPI_ALT_CONFIGURATION */
+#endif /* PLATFORM_stm32l0 */
 
 #define SPI_PIO_BASE    SPI_GPIO
 #define SPI_CS_PIO_BASE SPI_CS_GPIO

--- a/hal/stm32l0_chacha_ram.ld
+++ b/hal/stm32l0_chacha_ram.ld
@@ -1,7 +1,7 @@
 MEMORY
 {
     FLASH (rx) : ORIGIN = 0x00000000, LENGTH = ##WOLFBOOT_PARTITION_BOOT_ADDRESS##
-    RAM (rwx) : ORIGIN = 0x20000000, LENGTH = 0x00030000
+    RAM (rwx) : ORIGIN = 0x20000000, LENGTH = 20K
 }
 
 SECTIONS
@@ -10,10 +10,8 @@ SECTIONS
     {
         _start_text = .;
         KEEP(*(.isr_vector))
-;        *(EXCLUDE_FILE(*chacha*) .text*)
-;       *(EXCLUDE_FILE(*chacha*) .rodata*)
-	*(.text*)
-	*(.rodata*)
+        *(EXCLUDE_FILE(*chacha.o).text*)
+        *(EXCLUDE_FILE(*chacha.o).rodata*)
         . = ALIGN(4);
         _end_text = .;
     } > FLASH
@@ -22,7 +20,6 @@ SECTIONS
         . = ALIGN(4);
         *(.ARM.exidx*)
     } > FLASH
-
     _stored_data = .;
     .data : AT (_stored_data)
     {
@@ -30,9 +27,10 @@ SECTIONS
         KEEP(*(.data*))
         . = ALIGN(4);
         KEEP(*(.ramcode))
-;        KEEP(*(.text.wc_Chacha*))
-;	KEEP(*(.rodata.sigma))
-;	KEEP(*(.rodata.tau))
+        KEEP(*(.text.wc_Chacha*))
+        KEEP(*(.text.rotlFixed*))
+        KEEP(*(.rodata.sigma))
+        KEEP(*(.rodata.tau))
         . = ALIGN(4);
         _end_data = .;
     } > RAM

--- a/include/hal.h
+++ b/include/hal.h
@@ -70,8 +70,7 @@ void hal_prepare_boot(void);
     #define ext_flash_unlock() do{}while(0)
     #define ext_flash_read spi_flash_read
     #define ext_flash_write spi_flash_write
-
-    static int ext_flash_erase(uintptr_t address, int len)
+    static inline int ext_flash_erase(uintptr_t address, int len)
     {
         uint32_t end = address + len - 1;
         uint32_t p;

--- a/options.mk
+++ b/options.mk
@@ -41,7 +41,7 @@ ifeq ($(SIGN),ECC256)
   else ifneq ($(SPMATH),1)
     STACK_USAGE=5008
   else
-    STACK_USAGE=3960
+    STACK_USAGE=5880
   endif
   ifeq ($(shell test $(IMAGE_HEADER_SIZE) -lt 256; echo $$?),0)
     IMAGE_HEADER_SIZE=256
@@ -112,7 +112,7 @@ ifeq ($(SIGN),ED25519)
   ifeq ($(WOLFTPM),1)
     STACK_USAGE=6680
   else
-    STACK_USAGE?=1180
+    STACK_USAGE?=5000
   endif
   ifeq ($(shell test $(IMAGE_HEADER_SIZE) -lt 256; echo $$?),0)
     IMAGE_HEADER_SIZE=256
@@ -411,3 +411,15 @@ endif
 
 CFLAGS+=-DIMAGE_HEADER_SIZE=$(IMAGE_HEADER_SIZE)
 OBJS+=$(WOLFCRYPT_OBJS)
+
+# check if both encryption and self update are on
+#
+ifeq ($(RAM_CODE),1)
+  ifeq ($(ENCRYPT),1)
+    ifneq ($(ENCRYPT_WITH_CHACHA),1)
+       LSCRIPT_IN=NONE
+    else
+       LSCRIPT_IN=hal/$(TARGET)_chacha_ram.ld
+    endif
+  endif
+endif

--- a/src/libwolfboot.c
+++ b/src/libwolfboot.c
@@ -828,7 +828,7 @@ static uint8_t encrypt_iv_nonce[ENCRYPT_NONCE_SIZE];
 
 ChaCha chacha;
 
-int chacha_init(void)
+int RAMFUNCTION chacha_init(void)
 {
     uint8_t *key = (uint8_t *)(WOLFBOOT_PARTITION_BOOT_ADDRESS +
         ENCRYPT_TMP_SECRET_OFFSET);
@@ -916,7 +916,7 @@ void aes_set_iv(uint8_t *nonce, uint32_t iv_ctr)
 #endif
 
 
-static inline uint8_t part_address(uintptr_t a)
+static uint8_t RAMFUNCTION part_address(uintptr_t a)
 {
     if ( 1 &&
 #if WOLFBOOT_PARTITION_UPDATE_ADDRESS != 0
@@ -933,7 +933,7 @@ static inline uint8_t part_address(uintptr_t a)
     return PART_NONE;
 }
 
-int ext_flash_encrypt_write(uintptr_t address, const uint8_t *data, int len)
+int RAMFUNCTION ext_flash_encrypt_write(uintptr_t address, const uint8_t *data, int len)
 {
     uint8_t block[ENCRYPT_BLOCK_SIZE];
     uint8_t part;
@@ -987,7 +987,7 @@ int ext_flash_encrypt_write(uintptr_t address, const uint8_t *data, int len)
     return ext_flash_write(address, ENCRYPT_CACHE, len);
 }
 
-int ext_flash_decrypt_read(uintptr_t address, uint8_t *data, int len)
+int RAMFUNCTION ext_flash_decrypt_read(uintptr_t address, uint8_t *data, int len)
 {
     uint32_t iv_counter = 0;
     uint8_t block[ENCRYPT_BLOCK_SIZE];

--- a/src/spi_flash.c
+++ b/src/spi_flash.c
@@ -77,7 +77,7 @@ static uint8_t RAMFUNCTION read_status(void)
     return status;
 }
 
-static void spi_cmd(uint8_t cmd)
+static void RAMFUNCTION spi_cmd(uint8_t cmd)
 {
     spi_cs_on(SPI_CS_FLASH);
     spi_write(cmd);
@@ -85,7 +85,7 @@ static void spi_cmd(uint8_t cmd)
     spi_cs_off(SPI_CS_FLASH);
 }
 
-static void flash_write_enable(void)
+static void RAMFUNCTION flash_write_enable(void)
 {
     uint8_t status;
     do {
@@ -94,7 +94,7 @@ static void flash_write_enable(void)
     } while ((status & ST_WEL) == 0);
 }
 
-static void flash_write_disable(void)
+static void RAMFUNCTION flash_write_disable(void)
 {
     spi_cmd(WRDI);
 }
@@ -107,7 +107,7 @@ static void RAMFUNCTION wait_busy(void)
     } while(status & ST_BUSY);
 }
 
-static int spi_flash_write_page(uint32_t address, const void *data, int len)
+static int RAMFUNCTION spi_flash_write_page(uint32_t address, const void *data, int len)
 {
     const uint8_t *buf = data;
     int j = 0;
@@ -132,7 +132,7 @@ static int spi_flash_write_page(uint32_t address, const void *data, int len)
     return j;
 }
 
-static int spi_flash_write_sb(uint32_t address, const void *data, int len)
+static int RAMFUNCTION spi_flash_write_sb(uint32_t address, const void *data, int len)
 {
     const uint8_t *buf = data;
     uint8_t verify = 0;
@@ -198,7 +198,7 @@ uint16_t spi_flash_probe(void)
 }
 
 
-void spi_flash_sector_erase(uint32_t address)
+void RAMFUNCTION spi_flash_sector_erase(uint32_t address)
 {
     address &= (~(SPI_FLASH_SECTOR_SIZE - 1));
 
@@ -230,7 +230,7 @@ int RAMFUNCTION spi_flash_read(uint32_t address, void *data, int len)
     return i;
 }
 
-int spi_flash_write(uint32_t address, const void *data, int len)
+int RAMFUNCTION spi_flash_write(uint32_t address, const void *data, int len)
 {
     if (chip_write_mode == SST_SINGLEBYTE)
         return spi_flash_write_sb(address, data, len);

--- a/src/string.c
+++ b/src/string.c
@@ -169,7 +169,8 @@ int strncmp(const char *s1, const char *s2, size_t n)
 }
 
 #if  !defined(__IAR_SYSTEMS_ICC__) && !defined(PLATFORM_X86_64_EFI)
-void *memcpy(void *dst, const void *src, size_t n)
+#include "image.h"
+void RAMFUNCTION *memcpy(void *dst, const void *src, size_t n)
 {
     size_t i;
     const char *s = (const char *)src;

--- a/src/update_flash.c
+++ b/src/update_flash.c
@@ -48,9 +48,8 @@ static uint8_t buffer[FLASHBUFFER_SIZE];
 
 static void RAMFUNCTION wolfBoot_erase_bootloader(void)
 {
-    uint32_t *start = (uint32_t *)&_start_text;
-    uint32_t len = WOLFBOOT_PARTITION_BOOT_ADDRESS - (uint32_t)start;
-    hal_flash_erase((uint32_t)start, len);
+    uint32_t len = WOLFBOOT_PARTITION_BOOT_ADDRESS - ARCH_FLASH_OFFSET;
+    hal_flash_erase(ARCH_FLASH_OFFSET, len);
 
 }
 
@@ -68,8 +67,9 @@ static void RAMFUNCTION wolfBoot_self_update(struct wolfBoot_image *src)
         while (pos < src->fw_size) {
             uint8_t buffer[FLASHBUFFER_SIZE];
             if (src_offset + pos < (src->fw_size + IMAGE_HEADER_SIZE + FLASHBUFFER_SIZE))  {
+		uint32_t opos = pos + ((uint32_t)&_start_text);
                 ext_flash_check_read((uintptr_t)(src->hdr) + src_offset + pos, (void *)buffer, FLASHBUFFER_SIZE);
-                hal_flash_write(pos + (uint32_t)&_start_text, buffer, FLASHBUFFER_SIZE);
+                hal_flash_write(opos, buffer, FLASHBUFFER_SIZE);
             }
             pos += FLASHBUFFER_SIZE;
         }

--- a/test-app/led.c
+++ b/test-app/led.c
@@ -102,6 +102,11 @@ void boot_led_on(void)
     GPIOA_BSRR |= (1 << pin);
 }
 
+void boot_led_off(void)
+{
+    uint32_t pin = LED_BOOT_PIN;
+    GPIOA_BSRR |= (1 << (pin + 16));
+}
 
 #endif /* PLATFORM_stm32l0 */
 

--- a/tools/scripts/prepare_encrypted_update.sh
+++ b/tools/scripts/prepare_encrypted_update.sh
@@ -6,14 +6,21 @@ if [ -f "./tools/keytools/sign" ]; then
 fi
 
 # SIZE is WOLFBOOT_PARTITION_SIZE - 49 (44B: key + nonce, 5B: "pBOOT")
-SIZE=131023
+#SIZE=131023
+SIZE=65487
 VERSION=8
 APP=test-app/image_v"$VERSION"_signed_and_encrypted.bin
 
 # Create test key
 echo -n "0123456789abcdef0123456789abcdef0123456789ab" > enc_key.der
 
-$SIGN_TOOL --ecc256 --encrypt enc_key.der test-app/image.bin ecc256.der $VERSION
+$SIGN_TOOL --ecc256 --encrypt enc_key.der test-app/image.bin wolfboot_signing_private_key.der $VERSION
 dd if=/dev/zero bs=$SIZE count=1 2>/dev/null | tr "\000" "\377" > update.bin
 dd if=$APP of=update.bin bs=1 conv=notrunc
+
 printf "pBOOT"  >> update.bin
+
+#Make a 1MB rom image for SPI
+rm -f update.rom
+dd if=/dev/zero bs=1M count=1 2>/dev/null | tr "\000" "\377" > update.rom
+dd if=update.bin of=update.rom bs=1 conv=notrunc


### PR DESCRIPTION
Fixed encrypted self-update (bootloader update).
The combination between `ENCRYPT` and `RAM_CODE` requires some architecture specific changes. This PR introduces a custom linker script for l0 `hal/stm32l0_chacha_ram.ld` that moves the symbols from chacha into RAM. 

A description of the procedure along with instruction to port on other targets is provided in `docs/encrypted_partitions.md`

The self-update procedure has been tested on STM32L0 with external SPI flash, Chacha encryption, and confirmed also to work (via ZD14514).

