### PR TITLE
Add -fomit-frame-pointer to CFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,8 +52,8 @@ CFLAGS+= \
 # Setup default optimizations (for GCC)
 ifeq ($(USE_GCC_HEADLESS),1)
   CFLAGS+=-Wall -Wextra -Wno-main -ffreestanding -Wno-unused -nostartfiles
-  CFLAGS+=-ffunction-sections -fdata-sections
-  LDFLAGS+=-T $(LSCRIPT) -Wl,-gc-sections -Wl,-Map=wolfboot.map -ffreestanding -nostartfiles
+  CFLAGS+=-ffunction-sections -fdata-sections -fomit-frame-pointer
+  LDFLAGS+=-T $(LSCRIPT) -Wl,-gc-sections -Wl,-Map=wolfboot.map -ffreestanding -nostartfiles -fomit-frame-pointer
 endif
 
 MAIN_TARGET=factory.bin


### PR DESCRIPTION
`sp_armthumb.c` won't compile with `-O0` optimization without -fomit-frame-pointer (see #241)