### PR TITLE
Fixed bug in encrypted-delta update

### DIFF
--- a/src/spi_flash.c
+++ b/src/spi_flash.c
@@ -111,6 +111,8 @@ static int RAMFUNCTION spi_flash_write_page(uint32_t address, const void *data, 
 {
     const uint8_t *buf = data;
     int j = 0;
+    if (len < 1)
+        return -1;
     while (len > 0) {
         wait_busy();
         flash_write_enable();
@@ -129,7 +131,7 @@ static int RAMFUNCTION spi_flash_write_page(uint32_t address, const void *data, 
         spi_cs_off(SPI_CS_FLASH);
     }
     wait_busy();
-    return j;
+    return 0;
 }
 
 static int RAMFUNCTION spi_flash_write_sb(uint32_t address, const void *data, int len)
@@ -137,6 +139,7 @@ static int RAMFUNCTION spi_flash_write_sb(uint32_t address, const void *data, in
     const uint8_t *buf = data;
     uint8_t verify = 0;
     int j = 0;
+
     wait_busy();
     if (len < 1)
         return -1;

--- a/src/uart_flash.c
+++ b/src/uart_flash.c
@@ -91,7 +91,7 @@ int  ext_flash_write(uintptr_t address, const uint8_t *data, int len)
         if (wait_ack() != 0)
             return -1;
     }
-    return i;
+    return 0;
 }
 
 int  ext_flash_read(uintptr_t address, uint8_t *data, int len)
@@ -118,7 +118,7 @@ int  ext_flash_read(uintptr_t address, uint8_t *data, int len)
             return 0;
         uart_tx(CMD_ACK);
     }
-    return len;
+    return 0;
 }
 
 int  ext_flash_erase(uintptr_t address, int len)


### PR DESCRIPTION
Variable for return value was reused in delta+encrypt, leading to a double write at the wrong offset, causing to store corrupted patch images in the swap partion. 

This is the root cause for the bit flipping in SPI flash memory reported in ZD 15030.

This PR should fix the issue reported and encrypted delta updates should be working again.