### PR TITLE
Prevent ext_flash_decrypt_read from writing more data than requested

### DIFF
--- a/src/libwolfboot.c
+++ b/src/libwolfboot.c
@@ -1036,7 +1036,7 @@ int RAMFUNCTION ext_flash_decrypt_read(uintptr_t address, uint8_t *data, int len
         XMEMCPY(data, dec_block + row_offset, step);
         address += step;
         data += step;
-        sz -= step;
+        sz = len - step;
         iv_counter++;
     }
     if (ext_flash_read(address, data, sz) != sz)


### PR DESCRIPTION
Found a potential buffer overflow in wolfBoot.
If row_offset in ext_flash_decrypt_read is different than 0, ext_flash_decrypt_read will write len + ENCRYPT_BLOCK_SIZE - row_offset bytes to the buffer given to ext_flash_decrypt_read. If this buffer has the same size than len, ext_flash_decrypt_read will overwrite the data after this buffer.
I encountered this issue during an encrypted delta upgrade.

Note that ext_flash_decrypt_read will always write at least ENCRYPT_BLOCK_SIZE bytes to the given buffer. If the buffer is smaller than ENCRYPT_BLOCK_SIZE, a buffer overflow will occur.