### PR TITLE
github test: Specify image version so GLIB_C 2.34 is available

### DIFF
--- a/.github/workflows/test-renode-multi-mem.yml
+++ b/.github/workflows/test-renode-multi-mem.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build_and_test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test-renode-multi-sha.yml
+++ b/.github/workflows/test-renode-multi-sha.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build_and_test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test-renode-nrf52.yml
+++ b/.github/workflows/test-renode-nrf52.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build_and_test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
The version of arm-none-eabi-gcc specified in the actions tests need GLIB_C 2.34. This PR specifies the Ubuntu version of the container to accommodate this.