### PR TITLE
fix assumed keysize error

### DIFF
--- a/tools/keytools/keygen.c
+++ b/tools/keytools/keygen.c
@@ -217,7 +217,7 @@ static uint32_t get_pubkey_size(uint32_t keyType)
 {
     uint32_t size = 0;
 
-    switch (ktype) {
+    switch (keyType) {
         case KEYGEN_ED25519:
             size = KEYSTORE_PUBKEY_SIZE_ED25519;
             break;

--- a/tools/keytools/keygen.c
+++ b/tools/keytools/keygen.c
@@ -339,6 +339,8 @@ static void keygen_ecc(const char *priv_fname, uint16_t ecc_key_size)
         exit(3);
     }
 
+    wc_ecc_free(&k);
+
     fpriv = fopen(priv_fname, "wb");
     if (fpriv == NULL) {
         fprintf(stderr, "Unable to open file '%s' for writing: %s", priv_fname,  strerror(errno));
@@ -490,6 +492,7 @@ static void key_generate(uint32_t ktype, const char *kfilename)
 static void key_import(uint32_t ktype, const char *fname)
 {
     int ret = 0;
+    int initRet = 0;
     uint8_t buf[KEYSLOT_MAX_PUBKEY_SIZE];
     FILE* file;
     int readLen = 0;
@@ -538,12 +541,15 @@ static void key_import(uint32_t ktype, const char *fname)
     if (ktype == KEYGEN_ECC256 || ktype == KEYGEN_ECC384 ||
         ktype == KEYGEN_ECC521) {
         if ((uint32_t)readLen > keySz) {
-            ret = wc_EccPublicKeyDecode(buf, &keySzOut, eccKey, readLen);
+            initRet = ret = wc_EccPublicKeyDecode(buf, &keySzOut, eccKey, readLen);
 
             if (ret == 0) {
                 ret = wc_ecc_export_public_raw(eccKey, buf, &qxSz,
                     buf + keySz / 2, &qySz);
             }
+
+            if (initRet == 0)
+                wc_ecc_free(eccKey);
 
             readLen = keySz;
         }

--- a/tools/keytools/keygen.c
+++ b/tools/keytools/keygen.c
@@ -213,6 +213,39 @@ const char KName[][8] = {
     "RSA3072"
 };
 
+static uint32_t get_pubkey_size(uint32_t keyType)
+{
+    uint32_t size = 0;
+
+    switch (ktype) {
+        case KEYGEN_ED25519:
+            size = KEYSTORE_PUBKEY_SIZE_ED25519;
+            break;
+        case KEYGEN_ED448:
+            size = KEYSTORE_PUBKEY_SIZE_ED448;
+            break;
+        case KEYGEN_ECC256:
+            size = KEYSTORE_PUBKEY_SIZE_ECC256;
+            break;
+        case KEYGEN_ECC384:
+            size = KEYSTORE_PUBKEY_SIZE_ECC384;
+            break;
+        case KEYGEN_RSA2048:
+            size = KEYSTORE_PUBKEY_SIZE_RSA2048;
+            break;
+        case KEYGEN_RSA3072:
+            size = KEYSTORE_PUBKEY_SIZE_RSA3072;
+            break;
+        case KEYGEN_RSA4096:
+            size = KEYSTORE_PUBKEY_SIZE_RSA4096;
+            break;
+        default:
+            size = 0;
+    }
+
+    return size;
+}
+
 void keystore_add(uint32_t ktype, uint8_t *key, uint32_t sz, const char *keyfile)
 {
     static int id_slot = 0;
@@ -233,31 +266,8 @@ void keystore_add(uint32_t ktype, uint8_t *key, uint32_t sz, const char *keyfile
     sl.slot_id = id_slot;
     sl.key_type = ktype;
     sl.part_id_mask = 0xFFFFFFFF;
-    switch (ktype){
-        case KEYGEN_ED25519:
-            sl.pubkey_size = KEYSTORE_PUBKEY_SIZE_ED25519;
-            break;
-        case KEYGEN_ED448:
-            sl.pubkey_size = KEYSTORE_PUBKEY_SIZE_ED448;
-            break;
-        case KEYGEN_ECC256:
-            sl.pubkey_size = KEYSTORE_PUBKEY_SIZE_ECC256;
-            break;
-        case KEYGEN_ECC384:
-            sl.pubkey_size = KEYSTORE_PUBKEY_SIZE_ECC384;
-            break;
-        case KEYGEN_RSA2048:
-            sl.pubkey_size = KEYSTORE_PUBKEY_SIZE_RSA2048;
-            break;
-        case KEYGEN_RSA3072:
-            sl.pubkey_size = KEYSTORE_PUBKEY_SIZE_RSA3072;
-            break;
-        case KEYGEN_RSA4096:
-            sl.pubkey_size = KEYSTORE_PUBKEY_SIZE_RSA4096;
-            break;
-        default:
-            sl.pubkey_size = 0;
-    }
+
+    sl.pubkey_size = get_pubkey_size(ktype);
 
     memcpy(sl.pubkey, key, sz);
     fwrite(&sl, sl.pubkey_size, 1, fpub_image);
@@ -519,24 +529,7 @@ static void key_import(uint32_t ktype, const char *fname)
     fclose(file);
 
     /* parse the key if it has a header */
-    switch (ktype) {
-        case KEYGEN_ECC256:
-            keySz = KEYSTORE_PUBKEY_SIZE_ECC256;
-            break;
-        case KEYGEN_ECC384:
-            keySz = KEYSTORE_PUBKEY_SIZE_ECC384;
-            break;
-        case KEYGEN_ECC521:
-            keySz = KEYSTORE_PUBKEY_SIZE_ECC521;
-            break;
-        case KEYGEN_RSA2048:
-        case KEYGEN_RSA3072:
-        case KEYGEN_RSA4096:
-        case KEYGEN_ED25519:
-        case KEYGEN_ED448:
-        default:
-            break;
-    }
+    keySz = get_pubkey_size(ktype);
 
     if (ktype == KEYGEN_ECC256 || ktype == KEYGEN_ECC384 ||
         ktype == KEYGEN_ECC521) {

--- a/tools/keytools/keygen.py
+++ b/tools/keytools/keygen.py
@@ -88,6 +88,26 @@ def sign_key_size(name):
     else:
         return 0
 
+def sign_key_size_literal(name):
+    if name == 'ed25519':
+        return 32
+    elif name == 'ed448':
+        return 57
+    elif name == 'ecc256':
+        return 64
+    elif name == 'ecc384':
+        return 96
+    elif name == 'ecc521':
+        return 132
+    elif name == 'rsa2048':
+        return 320
+    elif name == 'rsa3072':
+        return 448
+    elif name == 'rsa4096':
+        return 576
+    else:
+        return 0
+
 def keystore_add(slot, pub, sz = 0):
     ktype = sign_key_type(sign)
     if (sz == 0):
@@ -262,6 +282,12 @@ if pubkey_files != None:
         print ("Input public key:     " + key_file)
         with open(key_file, 'rb') as f:
             key = f.read(4096)
+            # if it's an ecc key and it's length is longer than the raw key we
+            # need to parse it
+            if (sign == 'ecc256' or sign == 'ecc384' or sign == 'ecc521') and len(key) > sign_key_size_literal(sign):
+                eccKey = ciphers.EccPublic(key)
+                key = eccKey.encode_key_raw()
+                key = key[0] + key[1]
             keystore_add(pub_slot_index, key)
     pub_slot_index = len(pubkey_files)
 


### PR DESCRIPTION
the key_import and keystore_add functions seem to be written when only 2048 size rsa keys were supported since key_import only reads blocks of 2048 size, which will return 0 and write no key for non RSA keys, and keystore_add takes the size of the buffer at face value instead of checking for a valid keysize. this change makes key_import read the keyfile regardless of size and keystore_add check the size of the key buffer and use the real public key size since ecc keys also include the private part of the key after the 2 public parts.

Reproducer:

```
make keytools
tools/keytools/keygen --rsa2048 -g rsa.der
openssl rsa -pubout -inform der -in rsa.der -outform der -out rsaPub.der
tools/keytools/keygen --rsa2048 -i rsaPub.der
```

The result is a `src/keystore.c` that contains a zero sized public key.

ZD 15412