### PR TITLE
update stm32u5 hal to read and write whole words

### DIFF
--- a/hal/stm32u5.c
+++ b/hal/stm32u5.c
@@ -358,7 +358,6 @@ int RAMFUNCTION hal_flash_write(uint32_t address, const uint8_t *data, int len)
     int iStart = 0;
     uint32_t *dst;
     uint32_t qword[4];
-    uint8_t* qword_tmp;
     int offset;
     volatile uint32_t *sr, *cr;
 


### PR DESCRIPTION
the stm32u5 does not allow unaligned byte reads, which is a problem when writing the partition state which is always 1 byte off from the magic word. to get around, we read the word from the destination, modify it with the byte(s) we want to write and then write the whole word back
ZD 15279