### PR TITLE
NVM_FLASH_WRITEONCE refactoring

### DIFF
--- a/include/wolfboot/wolfboot.h
+++ b/include/wolfboot/wolfboot.h
@@ -210,11 +210,15 @@ extern "C" {
 #define IMG_STATE_UPDATING  0x70
 #define IMG_STATE_TESTING   0x10
 #define IMG_STATE_SUCCESS   0x00
+#define FLASH_BYTE_ERASED   0xFF
+#define FLASH_WORD_ERASED   0xFFFFFFFFUL
 #else
 #define IMG_STATE_NEW       0x00
 #define IMG_STATE_UPDATING  0x8F
 #define IMG_STATE_TESTING   0xEF
 #define IMG_STATE_SUCCESS   0xFF
+#define FLASH_BYTE_ERASED   0x00
+#define FLASH_WORD_ERASED   0x00000000UL
 #endif
 
 void wolfBoot_update_trigger(void);

--- a/src/libwolfboot.c
+++ b/src/libwolfboot.c
@@ -255,7 +255,7 @@ int RAMFUNCTION hal_set_partition_magic(uint32_t addr)
 
 static uint8_t* RAMFUNCTION get_trailer_at(uint8_t part, uint32_t at)
 {
-    uint32_t sel_sec = 0
+    uint32_t sel_sec = 0;
 #ifdef NVM_FLASH_WRITEONCE
         nvm_select_fresh_sector(part);
 #endif

--- a/src/libwolfboot.c
+++ b/src/libwolfboot.c
@@ -881,13 +881,13 @@ static int RAMFUNCTION hal_set_key(const uint8_t *k, const uint8_t *nonce)
     int ret = 0;
     int sel_sec = 0;
 #ifdef NVM_FLASH_WRITEONCE
-    sel_sec = nvm_select_fresh_sector(part);
+    sel_sec = nvm_select_fresh_sector(PART_BOOT);
     addr_align -= (sel_sec * WOLFBOOT_SECTOR_SIZE);
 #endif
     hal_flash_unlock();
     /* casting to unsigned long to abide compilers on 64bit architectures */
     XMEMCPY(ENCRYPT_CACHE,
-            (void*)(unsigned long)(addr_align ,
+            (void*)(unsigned long)(addr_align) ,
                 WOLFBOOT_SECTOR_SIZE);
     ret = hal_flash_erase(addr_align, WOLFBOOT_SECTOR_SIZE);
     if (ret != 0)
@@ -913,7 +913,7 @@ int RAMFUNCTION wolfBoot_get_encrypt_key(uint8_t *k, uint8_t *nonce)
         WOLFBOOT_PARTITION_BOOT_ADDRESS);
     int sel_sec = 0;
 #ifdef NVM_FLASH_WRITEONCE
-    sel_sec = nvm_select_fresh_sector(part);
+    sel_sec = nvm_select_fresh_sector(PART_BOOT);
     mem -= (sel_sec * WOLFBOOT_SECTOR_SIZE);
 #endif
     XMEMCPY(k, mem, ENCRYPT_KEY_SIZE);
@@ -928,7 +928,7 @@ int RAMFUNCTION wolfBoot_erase_encrypt_key(void)
         WOLFBOOT_PARTITION_BOOT_ADDRESS;
     int sel_sec = 0;
 #ifdef NVM_FLASH_WRITEONCE
-    sel_sec = nvm_select_fresh_sector(part);
+    sel_sec = nvm_select_fresh_sector(PART_BOOT);
     mem -= (sel_sec * WOLFBOOT_SECTOR_SIZE);
 #endif
     XMEMSET(ff, 0xFF, ENCRYPT_KEY_SIZE + ENCRYPT_NONCE_SIZE);

--- a/src/libwolfboot.c
+++ b/src/libwolfboot.c
@@ -312,7 +312,7 @@ static void RAMFUNCTION set_partition_magic(uint8_t part)
             ext_flash_check_write(PART_BOOT_ENDFLAGS - sizeof(uint32_t),
                 (void *)&wolfboot_magic_trail, sizeof(uint32_t));
         } else {
-            partition_magic_write(PART_BOOT_ENDFLAGS - sizeof(uint32_t));
+            partition_magic_write(part, PART_BOOT_ENDFLAGS - sizeof(uint32_t));
         }
     }
     else if (part == PART_UPDATE) {
@@ -320,7 +320,7 @@ static void RAMFUNCTION set_partition_magic(uint8_t part)
             ext_flash_check_write(PART_UPDATE_ENDFLAGS - sizeof(uint32_t),
                 (void *)&wolfboot_magic_trail, sizeof(uint32_t));
         } else {
-            partition_magic_write(PART_UPDATE_ENDFLAGS - sizeof(uint32_t));
+            partition_magic_write(part, PART_UPDATE_ENDFLAGS - sizeof(uint32_t));
         }
     }
 }

--- a/src/update_flash.c
+++ b/src/update_flash.c
@@ -354,9 +354,9 @@ out:
 
 /* Reserve space for two sectors in case of NVM_FLASH_WRITEONCE, for redundancy */
 #ifndef NVM_FLASH_WRITEONCE
-    #define MAX_UPDATE_SIZE (WOLFBOOT_PARTITION_SIZE - WOLFBOOT_SECTOR_SIZE)
+    #define MAX_UPDATE_SIZE (size_t)((WOLFBOOT_PARTITION_SIZE - WOLFBOOT_SECTOR_SIZE))
 #else
-    #define MAX_UPDATE_SIZE (WOLFBOOT_PARTITION_SIZE - (2 *WOLFBOOT_SECTOR_SIZE))
+    #define MAX_UPDATE_SIZE (size_t)((WOLFBOOT_PARTITION_SIZE - (2 *WOLFBOOT_SECTOR_SIZE)))
 #endif
 
 static int RAMFUNCTION wolfBoot_update(int fallback_allowed)

--- a/src/update_flash.c
+++ b/src/update_flash.c
@@ -351,6 +351,14 @@ out:
 #    pragma GCC push_options
 #    pragma GCC optimize("O0")
 #endif
+
+/* Reserve space for two sectors in case of NVM_FLASH_WRITEONCE, for redundancy */
+#ifndef NVM_FLASH_WRITEONCE
+    #define MAX_UPDATE_SIZE (WOLFBOOT_PARTITION_SIZE - WOLFBOOT_SECTOR_SIZE)
+#else
+    #define MAX_UPDATE_SIZE (WOLFBOOT_PARTITION_SIZE - (2 *WOLFBOOT_SECTOR_SIZE))
+#endif
+
 static int RAMFUNCTION wolfBoot_update(int fallback_allowed)
 {
     uint32_t total_size = 0;
@@ -391,6 +399,8 @@ static int RAMFUNCTION wolfBoot_update(int fallback_allowed)
     {
         if (((update_type & 0x000F) != HDR_IMG_TYPE_APP) ||
                 ((update_type & 0xFF00) != HDR_IMG_TYPE_AUTH))
+            return -1;
+        if (update.fw_size > MAX_UPDATE_SIZE - 1)
             return -1;
         if (!update.hdr_ok || (wolfBoot_verify_integrity(&update) < 0)
                 || (wolfBoot_verify_authenticity(&update) < 0)) {

--- a/test-app/ARM.ld
+++ b/test-app/ARM.ld
@@ -13,7 +13,7 @@ SECTIONS
         *(.init)
         *(.fini)
         *(.text*)
-        *(.rodata*)
+        KEEP(*(.rodata*))
         . = ALIGN(4);
         _end_text = .;
     } > FLASH

--- a/test-app/app_nrf52.c
+++ b/test-app/app_nrf52.c
@@ -43,6 +43,8 @@
 #define UART0_TXD_MAXCOUNT *((volatile uint32_t *)(UART0_BASE + 0x548))
 #define UART0_BAUDRATE     *((volatile uint32_t *)(UART0_BASE + 0x524))
 
+
+__attribute__((section(".rodata")))
 static const char extradata[1024 * 16] = "hi!";
 
 static void gpiotoggle(uint32_t pin)

--- a/test-app/app_nrf52.c
+++ b/test-app/app_nrf52.c
@@ -43,6 +43,8 @@
 #define UART0_TXD_MAXCOUNT *((volatile uint32_t *)(UART0_BASE + 0x548))
 #define UART0_BAUDRATE     *((volatile uint32_t *)(UART0_BASE + 0x524))
 
+static const char extradata[1024 * 16] = "hi!";
+
 static void gpiotoggle(uint32_t pin)
 {
     uint32_t reg_val = GPIO_OUT;
@@ -77,6 +79,7 @@ void main(void)
     int i;
     uint32_t version = 0;
     uint8_t *v_array = (uint8_t *)&version;
+    (void)extradata;
     GPIO_PIN_CNF[pin] = 1; /* Output */
 
     version = wolfBoot_current_firmware_version();

--- a/test-app/app_nrf52.c
+++ b/test-app/app_nrf52.c
@@ -44,7 +44,6 @@
 #define UART0_BAUDRATE     *((volatile uint32_t *)(UART0_BASE + 0x524))
 
 
-__attribute__((section(".rodata")))
 static const char extradata[1024 * 16] = "hi!";
 
 static void gpiotoggle(uint32_t pin)


### PR DESCRIPTION
- Using two sectors to keep partition/sector flags
- Keep two redundant set of flags, update one at a time
- Erase is done when the sector is old
- Flags update is faster because Erase is done in advance
- Accessing trailer information (including encryption keys) is done by selecting the newest information

Tested via renode, using nrf52 with NVM_FLASH_WRITEONCE flag on.