### PR TITLE
Support for SP math with AARCH64 when hardware supports it

### DIFF
--- a/arch.mk
+++ b/arch.mk
@@ -35,6 +35,7 @@ ifeq ($(ARCH),AARCH64)
   CFLAGS+=-DNO_QNX
   ifeq ($(SPMATH),1)
     MATH_OBJS += ./lib/wolfssl/wolfcrypt/src/sp_c32.o
+    MATH_OBJS += ./lib/wolfssl/wolfcrypt/src/sp_arm64.o
   endif
 endif
 

--- a/include/user_settings.h
+++ b/include/user_settings.h
@@ -86,13 +86,7 @@
 #       define WOLFSSL_SP
 #       define WOLFSSL_SP_MATH
 #       define WOLFSSL_SP_SMALL
-#       define SP_WORD_SIZE 32
 #       define WOLFSSL_HAVE_SP_ECC
-
-        /* SP Math needs to understand long long */
-#       ifndef ULLONG_MAX
-#           define ULLONG_MAX 18446744073709551615ULL
-#       endif
 #   endif
 
 /* ECC options disabled to reduce size */
@@ -139,7 +133,6 @@
 #       define WOLFSSL_SP
 #       define WOLFSSL_SP_SMALL
 #       define WOLFSSL_SP_MATH
-#       define SP_WORD_SIZE 32
 #       define WOLFSSL_SP_NO_3072
 #       define WOLFSSL_SP_NO_4096
 #   endif
@@ -158,7 +151,6 @@
 #       define WOLFSSL_SP
 #       define WOLFSSL_SP_SMALL
 #       define WOLFSSL_SP_MATH
-#       define SP_WORD_SIZE 32
 #       define WOLFSSL_SP_NO_2048
 #       define WOLFSSL_SP_NO_4096
 #   endif
@@ -177,7 +169,6 @@
 #       define WOLFSSL_SP
 #       define WOLFSSL_SP_SMALL
 #       define WOLFSSL_SP_MATH
-#       define SP_WORD_SIZE 32
 #       define WOLFSSL_SP_4096
 #       define WOLFSSL_SP_NO_2048
 #       define WOLFSSL_SP_NO_3072
@@ -196,6 +187,22 @@
 #   define WOLFSSL_SHA384
 #   ifdef NO_RSA
 #       define NO_SHA256
+#   endif
+#endif
+
+/* If SP math is enabled determine word size */
+#if defined(WOLFSSL_HAVE_SP_ECC) || defined(WOLFSSL_HAVE_SP_RSA)
+#   ifdef __aarch64__
+#       define HAVE___UINT128_T
+#       define WOLFSSL_SP_ARM64_ASM
+#       define SP_WORD_SIZE 64
+#   else
+#       define SP_WORD_SIZE 32
+#   endif
+
+        /* SP Math needs to understand long long */
+#   ifndef ULLONG_MAX
+#       define ULLONG_MAX 18446744073709551615ULL
 #   endif
 #endif
 

--- a/options.mk
+++ b/options.mk
@@ -48,7 +48,7 @@ ifeq ($(SIGN),ECC256)
       ifneq ($(SPMATH),1)
         STACK_USAGE=5008
       else
-        STACK_USAGE=5880
+        STACK_USAGE=7600
       endif
     endif
   endif
@@ -77,7 +77,7 @@ ifeq ($(SIGN),ECC384)
       ifneq ($(SPMATH),1)
         STACK_USAGE=11248
       else
-        STACK_USAGE=5880
+        STACK_USAGE=11216
       endif
     endif
   endif
@@ -192,7 +192,7 @@ ifeq ($(SIGN),RSA2048)
       ifneq ($(SPMATH),1)
         STACK_USAGE=35952
       else
-        STACK_USAGE=12288
+        STACK_USAGE=17568
       endif
     endif
   endif


### PR DESCRIPTION
If `__aarch64__` is defined then we know it is a 64-bit ARMv8 and we'll use the SP math from sp_arm64.c with inline assembly. Otherwise we'll use the sp_c32.c small C only version.