### PR TITLE
before calling wolfBoot_delta_update, check if the

### DIFF
--- a/.github/workflows/test-powerfail-simulator.yml
+++ b/.github/workflows/test-powerfail-simulator.yml
@@ -137,6 +137,6 @@ jobs:
           make test-sim-internal-flash-with-delta-update
       
       # DELTA update currently fails when patch is large enough
-      #- name: Run update-revert test with power failures (DELTA)
-          #run: |
-          #tools/scripts/sim-update-powerfail-resume.sh
+      - name: Run update-revert test with power failures (DELTA)
+          run: |
+          tools/scripts/sim-update-powerfail-resume.sh

--- a/tools/scripts/sim-update-powerfail-resume.sh
+++ b/tools/scripts/sim-update-powerfail-resume.sh
@@ -1,11 +1,9 @@
 #!/bin/bash
-
 V=`./wolfboot.elf update_trigger get_version 2>/dev/null`
 if [ "x$V" != "x1" ]; then
     echo "Failed first boot with update_trigger"
     exit 1
 fi
-
 
 ./wolfboot.elf powerfail 15000 get_version 2>/dev/null
 ./wolfboot.elf powerfail 18000 get_version 2>/dev/null
@@ -17,17 +15,5 @@ if [ "x$V" != "x2" ]; then
     exit 1
 fi
 
-./wolfboot.elf powerfail 11000 get_version 2>/dev/null
-./wolfboot.elf powerfail 14000 get_version 2>/dev/null
-./wolfboot.elf powerfail 1e000 get_version 2>/dev/null
-
-V=`./wolfboot.elf get_version 2>/dev/null`
-if [ "x$V" != "x1" ]; then
-    echo "Failed fallback (V: $V)"
-    exit 1
-fi
-
 echo Test successful.
 exit 0
-
-


### PR DESCRIPTION
0th sector has been changed with the update partition still being in IMG_STATE_UPDATING state. the state still being IMG_STATE_UPDATING means that a delta update started and that the version may have been switched over, in which case wolfBoot_current_firmware_version() >= wolfBoot_update_firmware_version() no longer tells us if we need to perform an inverse operation on it's own.

also removes part of the update powerfail test that does checks for the previous version without triggering a rollback