### PR TITLE
Encrypt Key Erasure on Power Failure

### DIFF
--- a/include/wolfboot/wolfboot.h
+++ b/include/wolfboot/wolfboot.h
@@ -272,6 +272,7 @@ int wolfBoot_ram_decrypt(uint8_t *src, uint8_t *dst);
 int wolfBoot_get_diffbase_hdr(uint8_t part, uint8_t **ptr);
 #endif
 
+int wolfBoot_swap_encrypt_key(const uint8_t *key, const uint8_t *nonce);
 int wolfBoot_set_encrypt_key(const uint8_t *key, const uint8_t *nonce);
 int wolfBoot_get_encrypt_key(uint8_t *key, uint8_t *nonce);
 int wolfBoot_erase_encrypt_key(void);


### PR DESCRIPTION
swap the encryption key before it gets erased by the update process along with the wolfboot magic number. check for the magic number when fetching the key and pull it from swap if it's present. move the wolfBoot_set_encrypt_key calls inside the flash locks
ZD 15415