### PR TITLE
NVM_FLASH_WRITEONCE Fixed wrong partition erase

### DIFF
--- a/src/libwolfboot.c
+++ b/src/libwolfboot.c
@@ -219,7 +219,7 @@ static int RAMFUNCTION trailer_write(uint8_t part, uint32_t addr, uint8_t val) {
     if (*((uint32_t *)(addr_write + NVM_CACHE_SIZE - sizeof(uint32_t)))
             != FLASH_WORD_ERASED)
     {
-        hal_flash_erase(addr_read, NVM_CACHE_SIZE);
+        hal_flash_erase(addr_write, NVM_CACHE_SIZE);
     }
 #if FLASHBUFFER_SIZE != WOLFBOOT_SECTOR_SIZE
     addr_off = 0;


### PR DESCRIPTION
When using NVM_FLASH_WRITEONCE, before writing to the active trailer sector, we check that the sector has been previously erased. This check was erasing the wrong partition trailer, leaving the system without a trailer for a few lines of code, but potentially vulnerable to powerfailure events.

Reported by @jpbland1 