### PR TITLE
Documentation and code comment cleanups

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,8 +280,8 @@ USE_LOCAL_WOLFSSL=/usr/local pip3 install .
 
 2. Key algorithm mismatch:
 
-The error `Key algorithm mismatch. Remove old keys via 'make distclean'` indicates the current `.config` `SIGN` algorithm does not match what is in the generated `src/keystore.c` file.
-Use `make keysclean` or `make distclean` to delete keys and regenerate.
+The error `Key algorithm mismatch. Remove old keys via 'make keysclean'` indicates the current `.config` `SIGN` algorithm does not match what is in the generated `src/keystore.c` file.
+Use `make keysclean` to delete keys and regenerate.
 
 
 ## Release Notes

--- a/docs/Signing.md
+++ b/docs/Signing.md
@@ -100,8 +100,8 @@ file is in this format.
 file is in this format.
 
   * `--no-sign` Disable secure boot signature verification. No signature
-    verification is performed in the bootloader, and the KEY.DER argument is
-    ignored.
+    verification is performed in the bootloader, and the KEY.DER argument should
+    not be supplied.
 
 #### Hash digest options
 

--- a/docs/Targets.md
+++ b/docs/Targets.md
@@ -1515,7 +1515,9 @@ make test-sim-internal-flash-with-update
 # it should print 2
 ./wolfboot.elf success get_version
 ```
-## renesas-rx72n
+
+
+## Renesas RX72N
 
 This example for `Renesas RX72N` demonstrates simple secure firmware update by wolfBoot. A sample application v1 is
 securely updated to v2. Both versions behave the same except displaying its version of v1 or v2.
@@ -1543,9 +1545,10 @@ Flash Allocation:
 
 ```
 
-Detailed steps can be found at [Readme](../IDE/Renesas/e2studio/RX72N/Readme.md).
+Detailed steps can be found at [Readme.md](../IDE/Renesas/e2studio/RX72N/Readme.md).
 
-## renesas-ra6m4
+
+## Renesas RA6M4
 
 This example for `Renesas RA6M4` demonstrates a simple secure firmware update by wolfBoot. A sample application v1 is
 securely updated to v2. Both versions behave the same except displaying its version of v1 or v2.
@@ -1571,7 +1574,7 @@ Flash Allocation:
 0x000F0000: Swap sector
 ```
 
-Detailed steps can be found at [Readme](../IDE/Renesas/e2studio/RA6M4/Readme.md).
+Detailed steps can be found at [Readme.md](../IDE/Renesas/e2studio/RA6M4/Readme.md).
 
 
 ## Intel x86_64 with Intel FSP support
@@ -1691,7 +1694,7 @@ Install PPI: F894643D-C449-42D1-8EA8-85BDD8C65BDE
 Notify: PPI Guid: F894643D-C449-42D1-8EA8-85BDD8C65BDE, Peim notify entry point: FFE40AB2
 Memory Discovered Notify invoked ...
 FSP TOLM = 0x3F000000
-Migrate FSP-M UPD from 7F548 to 3EFF4000 
+Migrate FSP-M UPD from 7F548 to 3EFF4000
 FspMemoryInitApi() - [Status: 0x00000000] - End
 success
 top reserved 0_3EF00000h
@@ -1770,8 +1773,8 @@ Reading MBR...
 Found GPT PTE at sector 1
 Found valid boot signature in MBR
 Valid GPT partition table
-Current LBA: 0x1 
-Backup LBA: 0x1FFFF 
+Current LBA: 0x1
+Backup LBA: 0x1FFFF
 Max number of partitions: 128
 Software limited: only allowing up to 16 partitions per disk.
 Disk size: 66043392
@@ -1793,7 +1796,7 @@ Linux version 5.17.15 (arch@wb-hg-2) (x86_64-linux-gcc.br_real (Buildroot toolch
 
 ### Running on 64-bit Qemu with swtpm (TPM emulator)
 
-The example configuration for this setup can be found in 
+The example configuration for this setup can be found in
 `config/examples/x86_fsp_qemu_tpm.config`.
 
 First step: [clone and install swtpm](https://github.com/stefanberger/swtpm), a TPM emulator that can be connected to qemu

--- a/include/loader.h
+++ b/include/loader.h
@@ -74,6 +74,7 @@ void wolfBoot_start(void);
 
 #if defined(ARCH_ARM) && defined(WOLFBOOT_ARMORED)
 
+/* attempt to jump 5 times to self, causing loop that cannot be glitched past */
 #define wolfBoot_panic() \
     asm volatile("b ."); \
     asm volatile("b .-2"); \

--- a/tools/keytools/keygen.c
+++ b/tools/keytools/keygen.c
@@ -111,7 +111,7 @@ const char Cfile_Banner[]="/* Keystore file for wolfBoot, automatically generate
              #endif
              "#ifdef WOLFBOOT_NO_SIGN\n\t#define NUM_PUBKEYS 0\n#else\n\n"
              "#if (KEYSTORE_PUBKEY_SIZE != KEYSTORE_PUBKEY_SIZE_%s)\n\t"
-             "#error Key algorithm mismatch. Remove old keys via 'make distclean'\n"
+             "#error Key algorithm mismatch. Remove old keys via 'make keysclean'\n"
              "#else\n";
 
 const char Store_hdr[] = "#define NUM_PUBKEYS %d\nconst struct keystore_slot PubKeys[NUM_PUBKEYS] = {\n\n";
@@ -646,8 +646,8 @@ int main(int argc, char** argv)
         }
         else if (strcmp(argv[i], "-keystoreDir") == 0) {
             i++;
-            sprintf(pubkeyfile,"%s%s", argv[i], "/keystore.c"); 
-            sprintf(pubkeyimg, "%s%s", argv[i], "/keystore.der"); 
+            sprintf(pubkeyfile,"%s%s", argv[i], "/keystore.c");
+            sprintf(pubkeyimg, "%s%s", argv[i], "/keystore.der");
             i++;
             continue;
         }

--- a/tools/keytools/keygen.py
+++ b/tools/keytools/keygen.py
@@ -139,7 +139,7 @@ Cfile_Banner="/* Keystore file for wolfBoot, automatically generated. Do not edi
              "\n#include <stdint.h>\n#include \"wolfboot/wolfboot.h\"\n" \
              "#ifdef WOLFBOOT_NO_SIGN\n\t#define NUM_PUBKEYS 0\n#else\n\n" \
              "#if (KEYSTORE_PUBKEY_SIZE != KEYSTORE_PUBKEY_SIZE_%s)\n\t" \
-             "#error Key algorithm mismatch. Remove old keys via 'make distclean'\n" \
+             "#error Key algorithm mismatch. Remove old keys via 'make keysclean'\n" \
              "#else\n"
 
 
@@ -211,7 +211,7 @@ if (type(args.storeDir) == list):
 else:
     pubkey_cfile = "src/keystore.c"
     keystore_imgfile = "keystore.der"
-    
+
 key_files = args.keyfile
 pubkey_files = args.pubfile
 


### PR DESCRIPTION
* Update documentation for signing with `--no-sign`, as the key argument should not be supplied.
* Recommend `make keysclean` instead of distclean on keys mismatch.
* Renesas headings/readme link and white-space.