### PR TITLE
Fixes to sign.c running on windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ include tools/config.mk
 ## Initializers
 WOLFBOOT_ROOT?=$(PWD)
 CFLAGS:=-D"__WOLFBOOT"
-CFLAGS+=-Werror -Wextra
+CFLAGS+=-Werror -Wextra -Wno-array-bounds
 LSCRIPT:=config/target.ld
 LSCRIPT_FLAGS:=
 LDFLAGS:=

--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ keytools_check: keytools FORCE
 
 $(PRIVATE_KEY):
 	$(Q)$(MAKE) keytools_check
-	$(Q)(test $(SIGN) = NONE) || ($(KEYGEN_TOOL) $(KEYGEN_OPTIONS) -g $(PRIVATE_KEY)) || true
+	$(Q)(test $(SIGN) = NONE) || ("$(KEYGEN_TOOL)" $(KEYGEN_OPTIONS) -g $(PRIVATE_KEY)) || true
 	$(Q)(test $(SIGN) = NONE) && (echo "// SIGN=NONE" >  src/keystore.c) || true
 
 keytools:
@@ -174,8 +174,8 @@ tpmtools:
 
 test-app/image_v1_signed.bin: $(BOOT_IMG)
 	@echo "\t[SIGN] $(BOOT_IMG)"
-	$(Q)(test $(SIGN) = NONE) || $(SIGN_TOOL) $(SIGN_OPTIONS) $(BOOT_IMG) $(PRIVATE_KEY) 1
-	$(Q)(test $(SIGN) = NONE) && $(SIGN_TOOL) $(SIGN_OPTIONS) $(BOOT_IMG) 1 || true
+	$(Q)(test $(SIGN) = NONE) || "$(SIGN_TOOL)" $(SIGN_OPTIONS) $(BOOT_IMG) $(PRIVATE_KEY) 1
+	$(Q)(test $(SIGN) = NONE) && "$(SIGN_TOOL)" $(SIGN_OPTIONS) $(BOOT_IMG) 1 || true
 
 test-app/image.elf: wolfboot.elf
 	$(Q)$(MAKE) -C test-app WOLFBOOT_ROOT="$(WOLFBOOT_ROOT)" image.elf

--- a/docs/Signing.md
+++ b/docs/Signing.md
@@ -24,6 +24,8 @@ If the C version of the key tools exists they will be used by wolfBoot's makefil
 
 Use the `wolfBootSignTool.vcxproj` Visual Studio project to build the `sign.exe` and `keygen.exe` tools for use on Windows.
 
+If you see any error about missing `target.h` this is a generated file based on your .config using the make process. It is needed for `WOLFBOOT_SECTOR_SIZE` used in delta updates.
+
 ### Python key tools
 
 **Please note that the Python tools are deprecated and will be removed in future versions.**

--- a/src/delta.c
+++ b/src/delta.c
@@ -187,19 +187,19 @@ int wb_diff(WB_DIFF_CTX *ctx, uint8_t *patch, uint32_t len)
     int found;
     uint8_t *pa, *pb;
     uint16_t match_len;
-    uint32_t blk_start;
-    uint32_t p_off = 0;
+    uintptr_t blk_start;
+    uintptr_t p_off = 0;
     if (ctx->off_b >= ctx->size_b)
         return 0;
     if (len < BLOCK_HDR_SIZE)
         return -1;
 
     while ((ctx->off_b + BLOCK_HDR_SIZE < ctx->size_b) && (len > p_off + BLOCK_HDR_SIZE)) {
-        uint32_t page_start = ctx->off_b / WOLFBOOT_SECTOR_SIZE;
-        uint32_t pa_start;
+        uintptr_t page_start = ctx->off_b / WOLFBOOT_SECTOR_SIZE;
+        uintptr_t pa_start;
         found = 0;
         if (p_off + BLOCK_HDR_SIZE >  len)
-            return p_off;
+            return (int)p_off;
 
         /* 'A' Patch base is valid for addresses in blocks ahead.
          * For matching previous blocks, 'B' is used as base instead.
@@ -211,15 +211,15 @@ int wb_diff(WB_DIFF_CTX *ctx, uint8_t *patch, uint32_t len)
 
         pa_start = (WOLFBOOT_SECTOR_SIZE + 1) * page_start;
         pa = ctx->src_a + pa_start;
-        while (((uint32_t)(pa - ctx->src_a) < ctx->size_a ) && (p_off < len)) {
-            if ((uint32_t)(ctx->size_a - (pa - ctx->src_a)) < BLOCK_HDR_SIZE)
+        while (((pa - ctx->src_a) < ctx->size_a ) && (p_off < len)) {
+            if ((uintptr_t)(ctx->size_a - (pa - ctx->src_a)) < BLOCK_HDR_SIZE)
                 break;
             if ((ctx->size_b - ctx->off_b) < BLOCK_HDR_SIZE)
                 break;
             if ((WOLFBOOT_SECTOR_SIZE - (ctx->off_b % WOLFBOOT_SECTOR_SIZE)) < BLOCK_HDR_SIZE)
                 break;
             if ((memcmp(pa, (ctx->src_b + ctx->off_b), BLOCK_HDR_SIZE) == 0)) {
-                uint32_t b_start;
+                uintptr_t b_start;
                 /* Identical areas of BLOCK_HDR_SIZE bytes match between the images.
                  * initialize match_len; blk_start is the relative offset within
                  * the src image.
@@ -261,13 +261,13 @@ int wb_diff(WB_DIFF_CTX *ctx, uint8_t *patch, uint32_t len)
         }
         if (!found) {
             /* Try matching an earlier section in the resulting image */
-            uint32_t pb_end = page_start * WOLFBOOT_SECTOR_SIZE;
+            uintptr_t pb_end = page_start * WOLFBOOT_SECTOR_SIZE;
             pb = ctx->src_b;
-            while (((uint32_t)(pb - ctx->src_b) < pb_end) && (p_off < len)) {
+            while (((uintptr_t)(pb - ctx->src_b) < pb_end) && (p_off < len)) {
                 /* Check image boundary */
                 if ((ctx->size_b - ctx->off_b) < BLOCK_HDR_SIZE)
                     break;
-                if ((uint32_t)(ctx->size_b - (pb - ctx->src_b)) < BLOCK_HDR_SIZE)
+                if ((uintptr_t)(ctx->size_b - (pb - ctx->src_b)) < BLOCK_HDR_SIZE)
                     break;
 
                 /* Don't try matching backwards if the distance between the two
@@ -334,7 +334,7 @@ int wb_diff(WB_DIFF_CTX *ctx, uint8_t *patch, uint32_t len)
         }
         ctx->off_b++;
     }
-    return (p_off);
+    return (int)p_off;
 }
 
 #endif /* DELTA_UPDATES */

--- a/src/delta.c
+++ b/src/delta.c
@@ -211,7 +211,7 @@ int wb_diff(WB_DIFF_CTX *ctx, uint8_t *patch, uint32_t len)
 
         pa_start = (WOLFBOOT_SECTOR_SIZE + 1) * page_start;
         pa = ctx->src_a + pa_start;
-        while (((pa - ctx->src_a) < ctx->size_a ) && (p_off < len)) {
+        while (((uintptr_t)(pa - ctx->src_a) < (uintptr_t)ctx->size_a) && (p_off < len)) {
             if ((uintptr_t)(ctx->size_a - (pa - ctx->src_a)) < BLOCK_HDR_SIZE)
                 break;
             if ((ctx->size_b - ctx->off_b) < BLOCK_HDR_SIZE)

--- a/tools/keytools/keygen.c
+++ b/tools/keytools/keygen.c
@@ -26,6 +26,10 @@
 /* Must also define DEBUG_WOLFSSL in user_settings.h */
 //#define DEBUG_SIGNTOOL
 
+#ifdef _WIN32
+#define _CRT_SECURE_NO_WARNINGS
+#define _CRT_NONSTDC_NO_DEPRECATE /* unlink */
+#endif
 #include <stdio.h>
 #include <stdint.h>
 #include <stdarg.h>
@@ -554,7 +558,7 @@ static void key_import(uint32_t ktype, const char *fname)
         exit(6);
     }
 
-    readLen = fread(buf, 1, sizeof(buf), file);
+    readLen = (int)fread(buf, 1, sizeof(buf), file);
 
     if (readLen <= 0) {
         printf("Fatal error: could not find valid key in file %s\n", fname);

--- a/tools/keytools/sign.c
+++ b/tools/keytools/sign.c
@@ -26,6 +26,10 @@
 /* Must also define DEBUG_WOLFSSL in user_settings.h */
 //#define DEBUG_SIGNTOOL
 
+#ifdef _WIN32
+#define _CRT_SECURE_NO_WARNINGS
+#define _CRT_NONSTDC_NO_DEPRECATE /* unlink */
+#endif
 #include <stdio.h>
 #include <stdarg.h>
 #include <stdlib.h>

--- a/tools/keytools/sign.c
+++ b/tools/keytools/sign.c
@@ -37,6 +37,9 @@
 #include <sys/types.h>
 #include <fcntl.h>
 #include <stddef.h>
+/* target.h is a generated file based on .config (see target.h.in)
+ * Provides: WOLFBOOT_SECTOR_SIZE */
+#include <target.h>
 #include <delta.h>
 
 #include "wolfboot/version.h"
@@ -1393,7 +1396,7 @@ static int base_diff(const char *f_base, uint8_t *pubkey, uint32_t pubkey_sz, in
         goto cleanup;
     }
     fseek(f3, MAX_SRC_SIZE -1, SEEK_SET);
-    io_sz = fwrite(&ff, 1, 1, f3);
+    io_sz = (int)fwrite(&ff, 1, 1, f3);
     if (io_sz != 1) {
         goto cleanup;
     }


### PR DESCRIPTION
Use generic buffer API to ensure that the files are open with the right flags.

Non-POSIX systems would require `open()` to use an extra O_BINARY flag to ensure the file is properly processed and sizes calculated accordingly. As file descriptors are only needed in mmap() mode, the win32 interface is reworked to use `fopen()` instead.

Thanks to Erik Chang for reporting this issue.