### PR TITLE
Override IMAGE_HEADER_SIZE via configuration value

### DIFF
--- a/stage1/x86_fsp.mk
+++ b/stage1/x86_fsp.mk
@@ -34,21 +34,15 @@ wolfboot_raw.bin: ../wolfboot.elf
 wolfboot_raw.o: wolfboot_raw.bin
 	$(OBJCOPY) -I binary -O elf32-i386 -B i386 --rename-section .data=.wolfboot $^ $@
 
-sig_fsp_m.o: fsp_m.o $(SIGN_KEY) ../$(FSP_M_BIN)
-	$(SIGN_TOOL) $(SIGN_OPTIONS) ../$(FSP_M_BIN) $(SIGN_KEY) 1
-	@dd if=$(X86FSP_PATH)/fsp_m_v1_signed.bin of=$(X86FSP_PATH)/fsp_m_signature.bin bs=256 count=1
-	$(OBJCOPY) -I binary -O elf32-i386 -B i386 --rename-section .data=.sig_fsp_m $(X86FSP_PATH)/fsp_m_signature.bin sig_fsp_m.o
-	@rm -f $(X86FSP_PATH)/fsp_m_v1_signed.bin $(X86FSP_PATH)/fsp_m_signature.bin
-
 sig_fsp_s.o: fsp_s.o $(SIGN_KEY) ../$(FSP_S_BIN)
 	$(SIGN_TOOL) $(SIGN_OPTIONS) ../$(FSP_S_BIN) $(SIGN_KEY) 1
-	@dd if=$(X86FSP_PATH)/fsp_s_v1_signed.bin of=$(X86FSP_PATH)/fsp_s_signature.bin bs=256 count=1
+	@dd if=$(X86FSP_PATH)/fsp_s_v1_signed.bin of=$(X86FSP_PATH)/fsp_s_signature.bin bs=$(IMAGE_HEADER_SIZE) count=1
 	$(OBJCOPY) -I binary -O elf32-i386 -B i386 --rename-section .data=.sig_fsp_s $(X86FSP_PATH)/fsp_s_signature.bin sig_fsp_s.o
 	@rm -f $(X86FSP_PATH)/fsp_s_v1_signed.bin $(X86FSP_PATH)/fsp_s_signature.bin
 
 sig_wolfboot_raw.o: wolfboot_raw.bin $(SIGN_KEY)
 	$(SIGN_TOOL) $(SIGN_OPTIONS) wolfboot_raw.bin $(SIGN_KEY) 1
-	@dd if=wolfboot_raw_v1_signed.bin of=wolfboot_raw_signature.bin bs=256 count=1
+	@dd if=wolfboot_raw_v1_signed.bin of=wolfboot_raw_signature.bin bs=$(IMAGE_HEADER_SIZE) count=1
 	$(OBJCOPY) -I binary -O elf32-i386 -B i386 --rename-section .data=.sig_wolfboot_raw wolfboot_raw_signature.bin sig_wolfboot_raw.o
 
 

--- a/tools/keytools/sign.c
+++ b/tools/keytools/sign.c
@@ -674,6 +674,13 @@ static uint8_t *load_key(uint8_t **key_buffer, uint32_t *key_buffer_sz,
         goto failure;
     }
 
+    if (CMD.header_sz < IMAGE_HEADER_SIZE) {
+        printf("image header size overridden by config value (%u bytes)\n", IMAGE_HEADER_SIZE);
+        CMD.header_sz = IMAGE_HEADER_SIZE;
+    } else {
+        printf("image header size calculated at runtime (%u bytes)\n", IMAGE_HEADER_SIZE);
+    }
+
 #ifdef DEBUG_SIGNTOOL
     printf("Pubkey %d\n", *pubkey_sz);
     WOLFSSL_BUFFER(*pubkey, *pubkey_sz);
@@ -1724,6 +1731,7 @@ int main(int argc, char** argv)
         else
             ret = base_diff(CMD.delta_base_file, pubkey, pubkey_sz, 16);
     }
+
 
     if (kbuf)
         free(kbuf);


### PR DESCRIPTION
If the calculated header_sz is smaller than the value requested via .config (or via IMAGE_HEADER_SIZE=x when compiling keytools), override the value calculated with the preset.