### PR TITLE
Delta updates: 32-bit fields for patch size

### DIFF
--- a/src/image.c
+++ b/src/image.c
@@ -1192,15 +1192,15 @@ int wolfBoot_open_image_address(struct wolfBoot_image *img, uint8_t *image)
     uint32_t *magic = (uint32_t *)(image);
     if (*magic != WOLFBOOT_MAGIC) {
         wolfBoot_printf("Boot header magic 0x%08x invalid at %p\n",
-            *magic, image);
+            (unsigned int)*magic, image);
         return -1;
     }
     img->fw_size = wolfBoot_image_size(image);
-    wolfBoot_printf("Image size %d\n", img->fw_size);
+    wolfBoot_printf("Image size %d\n", (unsigned int)img->fw_size);
 #ifdef WOLFBOOT_FIXED_PARTITIONS
     if (img->fw_size > (WOLFBOOT_PARTITION_SIZE - IMAGE_HEADER_SIZE)) {
         wolfBoot_printf("Image size %d > max %d\n",
-            img->fw_size, (WOLFBOOT_PARTITION_SIZE - IMAGE_HEADER_SIZE));
+            (unsigned int)img->fw_size, (WOLFBOOT_PARTITION_SIZE - IMAGE_HEADER_SIZE));
         img->fw_size = 0;
         return -1;
     }

--- a/src/libwolfboot.c
+++ b/src/libwolfboot.c
@@ -958,14 +958,14 @@ int wolfBoot_get_delta_info(uint8_t part, int inverse, uint32_t **img_offset,
         }
         if (wolfBoot_find_header((uint8_t *)(image + IMAGE_HEADER_OFFSET),
                     HDR_IMG_DELTA_INVERSE_SIZE, (uint8_t **)img_size)
-                        != sizeof(uint16_t)) {
+                        != sizeof(uint32_t)) {
             return -1;
         }
     } else {
         *img_offset = 0x0000000;
         if (wolfBoot_find_header((uint8_t *)(image + IMAGE_HEADER_OFFSET),
                     HDR_IMG_DELTA_SIZE, (uint8_t **)img_size)
-                        != sizeof(uint16_t)) {
+                        != sizeof(uint32_t)) {
             return -1;
         }
     }

--- a/tools/keytools/sign.c
+++ b/tools/keytools/sign.c
@@ -709,8 +709,8 @@ failure:
 
 static int make_header_ex(int is_diff, uint8_t *pubkey, uint32_t pubkey_sz,
         const char *image_file, const char *outfile,
-        uint32_t delta_base_version, uint16_t patch_len, uint32_t patch_inv_off,
-        uint16_t patch_inv_len)
+        uint32_t delta_base_version, uint32_t patch_len, uint32_t patch_inv_off,
+        uint32_t patch_inv_len)
 {
     uint32_t header_idx;
     uint8_t *header;
@@ -781,7 +781,7 @@ static int make_header_ex(int is_diff, uint8_t *pubkey, uint32_t pubkey_sz,
             header_idx++;
         header_append_tag(header, &header_idx, HDR_IMG_DELTA_BASE, 4,
                 &delta_base_version);
-        header_append_tag(header, &header_idx, HDR_IMG_DELTA_SIZE, 2,
+        header_append_tag(header, &header_idx, HDR_IMG_DELTA_SIZE, 4,
                 &patch_len);
 
         /* Append pad bytes, so fields are 4-byte aligned */
@@ -789,7 +789,7 @@ static int make_header_ex(int is_diff, uint8_t *pubkey, uint32_t pubkey_sz,
             header_idx++;
         header_append_tag(header, &header_idx, HDR_IMG_DELTA_INVERSE, 4,
                 &patch_inv_off);
-        header_append_tag(header, &header_idx, HDR_IMG_DELTA_INVERSE_SIZE, 2,
+        header_append_tag(header, &header_idx, HDR_IMG_DELTA_INVERSE_SIZE, 4,
                 &patch_inv_len);
     }
 
@@ -1246,8 +1246,8 @@ static int make_header(uint8_t *pubkey, uint32_t pubkey_sz,
 
 static int make_header_delta(uint8_t *pubkey, uint32_t pubkey_sz,
         const char *image_file, const char *outfile,
-        uint32_t delta_base_version, uint16_t patch_len,
-        uint32_t patch_inv_off, uint16_t patch_inv_len)
+        uint32_t delta_base_version, uint32_t patch_len,
+        uint32_t patch_inv_off, uint32_t patch_inv_len)
 {
     return make_header_ex(1, pubkey, pubkey_sz, image_file, outfile,
             delta_base_version, patch_len,
@@ -1269,7 +1269,7 @@ static int base_diff(const char *f_base, uint8_t *pubkey, uint32_t pubkey_sz, in
     uint8_t ff = 0xff;
     int r;
     uint32_t blksz = WOLFBOOT_SECTOR_SIZE;
-    uint16_t patch_sz, patch_inv_sz;
+    uint32_t patch_sz, patch_inv_sz;
     uint32_t patch_inv_off;
     uint32_t delta_base_version = 0;
     char *base_ver_p, *base_ver_e;
@@ -1492,6 +1492,7 @@ static int base_diff(const char *f_base, uint8_t *pubkey, uint32_t pubkey_sz, in
     }
     printf("Successfully created output file %s\n", wolfboot_delta_file);
     /* Create delta file, with header, from the resulting patch */
+
     ret = make_header_delta(pubkey, pubkey_sz, wolfboot_delta_file, CMD.output_diff_file,
             delta_base_version, patch_sz, patch_inv_off, patch_inv_sz);
 


### PR DESCRIPTION
Delta updates: patch size was limited to 65535, due to the fields `HDR_IMG_DELTA_SIZE` and `HDR_IMG_DELTA_INVERSE_SIZE` being 2 Bytes long (`uint16_t`).

This PR increases the size for these two fields to four bytes each (`uint32_t`). The maximum patch size for delta updates is now 16MB, due to the position compression in the delta format (24 bit).