### PR TITLE
Add new `CORTEX_M3` option (default is M4 with UMAAL)

### DIFF
--- a/arch.mk
+++ b/arch.mk
@@ -199,22 +199,36 @@ ifeq ($(ARCH),ARM)
       endif
     endif
   else
-    # default Cortex M3/M4
+  ifeq ($(CORTEX_M3),1)
+    CFLAGS+=-mcpu=cortex-m3
+    LDFLAGS+=-mcpu=cortex-m3
     ifeq ($(NO_ASM),1)
       ifeq ($(SPMATH),1)
         MATH_OBJS += ./lib/wolfssl/wolfcrypt/src/sp_c32.o
       endif
-      CFLAGS+=-mcpu=cortex-m3
-      LDFLAGS+=-mcpu=cortex-m3
     else
-      CFLAGS+=-mcpu=cortex-m3 -fomit-frame-pointer
-      LDFLAGS+=-mcpu=cortex-m3
+      ifeq ($(SPMATH),1)
+        CFLAGS+=-DWOLFSSL_SP_ASM -DWOLFSSL_SP_ARM_CORTEX_M_ASM -DWOLFSSL_SP_NO_UMAAL
+        MATH_OBJS += ./lib/wolfssl/wolfcrypt/src/sp_cortexm.o
+      endif
+    endif
+  else
+    # default Cortex M4
+    CFLAGS+=-mcpu=cortex-m4
+    LDFLAGS+=-mcpu=cortex-m4
+    ifeq ($(NO_ASM),1)
+      ifeq ($(SPMATH),1)
+        MATH_OBJS += ./lib/wolfssl/wolfcrypt/src/sp_c32.o
+      endif
+    else
+      CFLAGS+=-fomit-frame-pointer # required with debug builds only
       ifeq ($(SPMATH),1)
         CFLAGS+=-DWOLFSSL_SP_ASM -DWOLFSSL_SP_ARM_CORTEX_M_ASM
         MATH_OBJS += ./lib/wolfssl/wolfcrypt/src/sp_cortexm.o
       endif
     endif
   endif
+endif
 endif
 endif
 endif

--- a/tools/config.mk
+++ b/tools/config.mk
@@ -19,6 +19,7 @@ ifeq ($(ARCH),)
   CORTEX_M0?=0
   CORTEX_M33?=0
   CORTEX_M7?=0
+  CORTEX_M3?=0
   NO_ASM?=0
   EXT_FLASH?=0
   SPI_FLASH?=0

--- a/tools/test.mk
+++ b/tools/test.mk
@@ -961,7 +961,7 @@ test-size-all:
 	make keysclean
 	make test-size SIGN=ECC384 NO_ASM=1 LIMIT=15172
 	make keysclean
-	make test-size SIGN=ED448 LIMIT=13418
+	make test-size SIGN=ED448 LIMIT=13420
 	make keysclean
 	make test-size SIGN=RSA3072 LIMIT=11386
 	make keysclean


### PR DESCRIPTION
Add new `CORTEX_M3` option (default ARCH=ARM is Cortex-M4). The M3 does not support UMAAL.