### PR TITLE
Fixes for building keytools with MSYS2

### DIFF
--- a/.github/workflows/test-keytools-msys2.yml
+++ b/.github/workflows/test-keytools-msys2.yml
@@ -1,0 +1,39 @@
+name: Wolfboot keytools with MSYS2
+
+on:
+  push:
+    branches: [ 'master', 'main', 'release/**' ]
+  pull_request:
+    branches: [ '*' ]
+
+jobs:
+
+  build:
+    runs-on: windows-latest
+
+    steps:
+      - name: Setup MSYS2
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          update: true
+          install: base-devel git
+          pacboy: toolchain:p
+
+      - name: git config
+        shell: bash
+        run: |
+          git config --global core.autocrlf input
+
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - name: Build tools
+        shell: msys2 {0}
+        run: |
+          make distclean
+          cp config/examples/sim.config .config
+          make include/target.h
+          make -C tools/keytools
+          make -C tools/bin-assemble

--- a/tools/keytools/sign.c
+++ b/tools/keytools/sign.c
@@ -1693,7 +1693,7 @@ int main(int argc, char** argv)
     char* tmpstr;
     const char* sign_str = "AUTO";
     const char* hash_str = "SHA256";
-    uint8_t  buf[1024];
+    uint8_t  buf[PATH_MAX-32]; /* leave room to avoid "directive output may be truncated" */
     uint8_t *pubkey = NULL;
     uint32_t pubkey_sz = 0;
     uint8_t *kbuf=NULL, *key_buffer;

--- a/tools/keytools/user_settings.h
+++ b/tools/keytools/user_settings.h
@@ -110,4 +110,6 @@
 #define NO_CRYPT_TEST
 #define NO_CRYPT_BENCHMARK
 
+#define XSNPRINTF /* not used */
+
 #endif /* !H_USER_SETTINGS_ */

--- a/tools/test.mk
+++ b/tools/test.mk
@@ -942,29 +942,29 @@ test-all: clean
 
 
 test-size-all:
-	make test-size SIGN=NONE LIMIT=4778
+	make test-size SIGN=NONE LIMIT=4776
 	make keysclean
-	make test-size SIGN=ED25519 LIMIT=11462
+	make test-size SIGN=ED25519 LIMIT=11380
 	make keysclean
-	make test-size SIGN=ECC256  LIMIT=22322
+	make test-size SIGN=ECC256  LIMIT=17620
 	make keysclean
-	make test-size SIGN=ECC256 NO_ASM=1 LIMIT=13758
+	make test-size SIGN=ECC256 NO_ASM=1 LIMIT=13572
 	make keysclean
-	make test-size SIGN=RSA2048 LIMIT=11242
+	make test-size SIGN=RSA2048 LIMIT=10584
 	make keysclean
-	make test-size SIGN=RSA2048 NO_ASM=1 LIMIT=11218
+	make test-size SIGN=RSA2048 NO_ASM=1 LIMIT=10376
 	make keysclean
-	make test-size SIGN=RSA4096 LIMIT=11602
+	make test-size SIGN=RSA4096 LIMIT=11884
 	make keysclean
-	make test-size SIGN=RSA4096 NO_ASM=1 LIMIT=11522
+	make test-size SIGN=RSA4096 NO_ASM=1 LIMIT=10660
 	make keysclean
-	make test-size SIGN=ECC384 LIMIT=17618
+	make test-size SIGN=ECC384 LIMIT=17280
 	make keysclean
-	make test-size SIGN=ECC384 NO_ASM=1 LIMIT=15190
+	make test-size SIGN=ECC384 NO_ASM=1 LIMIT=15024
 	make keysclean
-	make test-size SIGN=ED448 LIMIT=13470
+	make test-size SIGN=ED448 LIMIT=13464
 	make keysclean
-	make test-size SIGN=RSA3072 LIMIT=11442
+	make test-size SIGN=RSA3072 LIMIT=11236
 	make keysclean
-	make test-size SIGN=RSA3072 NO_ASM=1 LIMIT=11314
+	make test-size SIGN=RSA3072 NO_ASM=1 LIMIT=10472
 	make keysclean


### PR DESCRIPTION
Added CI for building key tools with MSYS2. Updated wolfSSL submodule to https://github.com/wolfSSL/wolfssl/pull/6881 and adjusted size tests to actual + 32 bytes (extra) rounded to 32-bit.