### PR TITLE
wolfBoot_get_blob_type: fix return type

### DIFF
--- a/include/wolfboot/wolfboot.h
+++ b/include/wolfboot/wolfboot.h
@@ -271,7 +271,7 @@ void wolfBoot_update_trigger(void);
 void wolfBoot_success(void);
 uint32_t wolfBoot_image_size(uint8_t *image);
 uint32_t wolfBoot_get_blob_version(uint8_t *blob);
-uint32_t wolfBoot_get_blob_type(uint8_t *blob);
+uint16_t wolfBoot_get_blob_type(uint8_t *blob);
 uint32_t wolfBoot_get_blob_diffbase_version(uint8_t *blob);
 
 /* Get partition ID from manifest header */

--- a/src/libwolfboot.c
+++ b/src/libwolfboot.c
@@ -1075,9 +1075,9 @@ uint32_t wolfBoot_get_blob_version(uint8_t *blob)
  *
  * @return The type of the blob, or 0 if the blob is invalid.
  */
-uint32_t wolfBoot_get_blob_type(uint8_t *blob)
+uint16_t wolfBoot_get_blob_type(uint8_t *blob)
 {
-    uint32_t *volatile type_field = NULL;
+    uint16_t *volatile type_field = NULL;
     uint32_t *magic = NULL;
     uint8_t *img_bin = blob;
 #if defined(EXT_ENCRYPTED) && defined(MMU)

--- a/tools/unit-tests/unit-image.c
+++ b/tools/unit-tests/unit-image.c
@@ -236,7 +236,7 @@ static uint16_t _find_header(uint8_t *haystack, uint16_t type, uint8_t **ptr)
     return 0;
 }
 
-uint32_t wolfBoot_get_blob_type(uint8_t *addr)
+uint16_t wolfBoot_get_blob_type(uint8_t *addr)
 {
     return HDR_IMG_TYPE_APP;
 }


### PR DESCRIPTION
zd16115.

On big-endian machines, the type mismatch would always result in the conversion of the lower two bytes.