### PR TITLE
Fixes for sealing/unsealing

### DIFF
--- a/docs/TPM.md
+++ b/docs/TPM.md
@@ -15,7 +15,7 @@ In wolfBoot we support TPM based root of trust, sealing/unsealing, cryptographic
 | `MEASURED_PCR_A=16` | `WOLFBOOT_MEASURED_PCR_A=16` | The PCR index to use. See [docs/measured_boot.md](/docs/measured_boot.md). |
 | `WOLFBOOT_TPM_SEAL=1` | `WOLFBOOT_TPM_SEAL` | Enables support for sealing/unsealing based on PCR policy signed externally. |
 | `WOLFBOOT_TPM_SEAL_NV_BASE=0x01400300` | `WOLFBOOT_TPM_SEAL_NV_BASE` | To override the default sealed blob storage location in the platform hierarchy. |
-| `WOLFBOOT_TPM_SEAL_AUTH=secret` | `WOLFBOOT_TPM_SEAL_AUTH` | Password for sealing/unsealing secrets |
+| `WOLFBOOT_TPM_SEAL_AUTH=secret` | `WOLFBOOT_TPM_SEAL_AUTH` | Password for sealing/unsealing secrets, if omitted the PCR policy will be used |
 
 ## Root of Trust (ROT)
 

--- a/include/tpm.h
+++ b/include/tpm.h
@@ -52,6 +52,8 @@ extern WOLFTPM2_KEY     wolftpm_srk;
 int  wolfBoot_tpm2_init(void);
 void wolfBoot_tpm2_deinit(void);
 
+int wolfBoot_tpm2_clear(void);
+
 #if defined(WOLFBOOT_TPM_VERIFY) || defined(WOLFBOOT_TPM_SEAL)
 int wolfBoot_load_pubkey(const uint8_t* pubkey_hint, WOLFTPM2_KEY* pubKey,
     TPM_ALG_ID* pAlg);
@@ -83,6 +85,7 @@ int wolfBoot_unseal_auth(const uint8_t* pubkey_hint, const uint8_t* policy, uint
 int wolfBoot_unseal_blob(const uint8_t* pubkey_hint, const uint8_t* policy, uint16_t policySz,
     WOLFTPM2_KEYBLOB* seal_blob, uint8_t* secret, int* secret_sz, const uint8_t* auth, int authSz);
 
+int wolfBoot_delete_seal(int index);
 int wolfBoot_read_blob(uint32_t nvIndex, WOLFTPM2_KEYBLOB* blob,
     const uint8_t* auth, uint32_t authSz);
 int wolfBoot_store_blob(TPMI_RH_NV_AUTH authHandle, uint32_t nvIndex,

--- a/src/tpm.c
+++ b/src/tpm.c
@@ -591,8 +591,12 @@ int wolfBoot_store_blob(TPMI_RH_NV_AUTH authHandle, uint32_t nvIndex,
     memset(&nv, 0, sizeof(nv));
 
     nv.handle.hndl = nvIndex;
-    nv.handle.auth.size = authSz;
-    memcpy(nv.handle.auth.buffer, auth, authSz);
+    if (authSz > 0) {
+        if (auth == NULL)
+            return BAD_FUNC_ARG;
+        nv.handle.auth.size = authSz;
+        memcpy(nv.handle.auth.buffer, auth, authSz);
+    }
 
     parent.hndl = authHandle;
 
@@ -667,8 +671,12 @@ int wolfBoot_read_blob(uint32_t nvIndex, WOLFTPM2_KEYBLOB* blob,
     memset(&nv, 0, sizeof(nv));
 
     nv.handle.hndl = nvIndex;
-    nv.handle.auth.size = authSz;
-    memcpy(nv.handle.auth.buffer, auth, authSz);
+    if (authSz > 0) {
+        if (auth == NULL)
+            return BAD_FUNC_ARG;
+        nv.handle.auth.size = authSz;
+        memcpy(nv.handle.auth.buffer, auth, authSz);
+    }
     wolfTPM2_SetAuthHandle(&wolftpm_dev, 0, &nv.handle);
 
     pos = 0;
@@ -722,8 +730,12 @@ int wolfBoot_delete_blob(TPMI_RH_NV_AUTH authHandle, uint32_t nvIndex,
     memset(&nv, 0, sizeof(nv));
 
     nv.handle.hndl = nvIndex;
-    nv.handle.auth.size = authSz;
-    memcpy(nv.handle.auth.buffer, auth, authSz);
+    if (authSz > 0) {
+        if (auth == NULL)
+            return BAD_FUNC_ARG;
+        nv.handle.auth.size = authSz;
+        memcpy(nv.handle.auth.buffer, auth, authSz);
+    }
 
     parent.hndl = authHandle;
 
@@ -820,6 +832,12 @@ int wolfBoot_seal_blob(const uint8_t* pubkey_hint,
     wolfTPM2_UnsetAuthSession(&wolftpm_dev, 1, &wolftpm_session);
 
     return rc;
+}
+
+int wolfBoot_delete_seal(int index)
+{
+    return wolfBoot_delete_blob(TPM_RH_PLATFORM,
+            WOLFBOOT_TPM_SEAL_NV_BASE + index, NULL, 0);
 }
 
 /* Index (0-X) determines location in NV from WOLFBOOT_TPM_SEAL_NV_BASE to
@@ -991,15 +1009,15 @@ int wolfBoot_unseal_blob(const uint8_t* pubkey_hint,
         rc = wolfTPM2_PolicyAuthorize(&wolftpm_dev, policy_session.handle.hndl,
             &authKey.pub, &checkTicket, pcrDigest, pcrDigestSz,
             policyRef, policyRefSz);
-    }
-    else {
-        /* A failure here means the signed policy did not match expected policy.
-         * Use this PCR mask and policy digest with the sign tool --policy=
-         * argument to sign */
-        wolfBoot_printf("Policy signature failed!\n");
-        wolfBoot_printf("Expected PCR Mask (0x%08x) and PCR Policy (%d)\n",
-            pcrMask, policyDigestSz);
-        wolfBoot_print_hexstr(policyDigest, policyDigestSz, 0);
+        if (rc != 0) {
+            /* A failure here means the signed policy did not match expected
+             * policy. Use this PCR mask and policy digest with the sign tool
+             * --policy= argument to sign */
+            wolfBoot_printf("Policy signature failed!\n");
+            wolfBoot_printf("Expected PCR Mask (0x%08x) and PCR Policy (%d)\n",
+                            pcrMask, policyDigestSz);
+            wolfBoot_print_hexstr(policyDigest, policyDigestSz, 0);
+        }
     }
 
     /* done with authorization public key */
@@ -1235,6 +1253,20 @@ void wolfBoot_tpm2_deinit(void)
 #endif /* WOLFBOOT_TPM_KEYSTORE */
 
     wolfTPM2_Cleanup(&wolftpm_dev);
+}
+
+/**
+ * @brief Clear the content of the TPM2 device.
+ *
+ * This function clears the TPM2 device and remove all stored secrets.
+ *
+ * @return BAD_FUNC_ARG if any of the underlying functions has passed an invalid
+ *          argument, e.g. wolftpm_dev is not initialized
+ * @return TPM_RC_SUCCESS in case of success
+ */
+int wolfBoot_tpm2_clear(void)
+{
+    return wolfTPM2_Clear(&wolftpm_dev);
 }
 
 


### PR DESCRIPTION
Fixes for sealing/unsealing
* Fix for sealing policy, which was not being set on creation.
* Fix to clear the userWithAuth bit requiring policy
* Updated wolfTPM submodule with changes in https://github.com/wolfSSL/wolfTPM/pull/327
* Upstream TigerLake fixes. Adds TPM clear and NV delete.