### PR TITLE
DUALBANK: fork_bootloader should only execute once

### DIFF
--- a/docs/HAL.md
+++ b/docs/HAL.md
@@ -114,3 +114,24 @@ by the bootloader at the end of every write and erase operations on the external
 If the IAP interface of the external memory requires it, this function
 is called before every write and erase operations to unlock write access to the
 device. On some drivers, this function may be empty.
+
+
+### Additional functions required by `DUALBANK_SWAP` option
+
+If the target device supports hardware-assisted bank swapping, it is appropriate
+to provide two additional functions in the port:
+
+`void hal_flash_dualbank_swap(void)`
+
+Called by the bootloader when the two banks must be swapped. On some architectures
+this operation implies a reboot, so this function may also never return.
+
+
+`void fork_bootloader(void)`
+
+This function is called to provide a second copy of the bootloader. Wolfboot will
+clone itself if the content does not already match. `fork_bootloader()`
+implementation in new ports must return immediately without performing any actions
+if the content of the bootloader partition in the two banks already match.
+
+

--- a/hal/stm32f7.c
+++ b/hal/stm32f7.c
@@ -461,6 +461,10 @@ void RAMFUNCTION fork_bootloader(void)
     uint32_t r = 0, w = 0;
     int i;
 
+    /* Return if content already matches */
+    if (memcmp(data, (void *)WOLFBOOT_COPY_BOOTLOADER, BOOTLOADER_SIZE) == 0)
+        return;
+
     /* Read the wolfBoot image in RAM */
     memcpy(bootloader_copy_mem, data, BOOTLOADER_SIZE);
 

--- a/hal/stm32l5.c
+++ b/hal/stm32l5.c
@@ -376,6 +376,10 @@ static void RAMFUNCTION fork_bootloader(void)
     uint32_t r = 0, w = 0;
     int i;
 
+    /* Return if content already matches */
+    if (memcmp(data, (void *)FLASH_BANK2_BASE, BOOTLOADER_SIZE) == 0)
+        return;
+
     /* Read the wolfBoot image in RAM */
     memcpy(bootloader_copy_mem, data, BOOTLOADER_SIZE);
 

--- a/hal/stm32u5.c
+++ b/hal/stm32u5.c
@@ -241,7 +241,7 @@ static void clock_pll_off(void)
     DMB();
 }
 
-/* This implementation will setup MSI 48 MHz as PLL Source Mux, PLLCLK as 
+/* This implementation will setup MSI 48 MHz as PLL Source Mux, PLLCLK as
  * System Clock Source */
 static void clock_pll_on(int powersave)
 {
@@ -489,6 +489,10 @@ static void RAMFUNCTION fork_bootloader(void)
     uint32_t dst  = FLASH_BANK2_BASE;
     uint32_t r = 0, w = 0;
     int i;
+
+    /* Return if content already matches */
+    if (memcmp(data, (void *)FLASH_BANK2_BASE, BOOTLOADER_SIZE) == 0)
+        return;
 
     /* Read the wolfBoot image in RAM */
     memcpy(bootloader_copy_mem, data, BOOTLOADER_SIZE);


### PR DESCRIPTION
fork_bootloader() should perform a physical copy of the bootloader to its partition in the second bank only if the content of the two partitions does not already match.

This patch provides a fix for `fork_bootloader()` for the following targets:
- stm32F7
- stm32U5
- stm32L5

Reported in #406 