### PR TITLE
Added support for custom TLVs in manifest header

### DIFF
--- a/.github/workflows/test-keytools.yml
+++ b/.github/workflows/test-keytools.yml
@@ -237,4 +237,30 @@ jobs:
         run: |
           ./tools/keytools/keygen --id 1,3,5,10,11,13,14 --ecc256 -g wolfboot_signing_private_key.der | grep "mask" | grep "00006c2a"
 
+     # Custom TLVs
+      - name: make clean
+        run: |
+          make distclean
+
+      - name: Select config
+        run: |
+          cp config/examples/sim.config .config && make include/target.h
+
+      - name: Build tools
+        run: |
+          make -C tools/keytools && make -C tools/bin-assemble
+
+      - name: Build wolfboot with ECC256/SHA256
+        run: |
+          make SIGN=ECC256 HASH=SHA256
+
+      - name: Sign app with custom numeric TLV included
+        run: |
+          ./tools/keytools/sign --ecc256 --sha256 --custom-tlv 0x45 4 0x6f616943 test-app/image.elf wolfboot_signing_private_key.der 2
+          grep "Ciao" test-app/image_v2_signed.bin
+      
+      - name: Sign app with custom buffer TLV included
+        run: |
+          ./tools/keytools/sign --ecc256 --sha256 --custom-tlv-buffer 0x46 48656C6C6F20776F726C64 test-app/image.elf wolfboot_signing_private_key.der 3
+          grep "Hello world" test-app/image_v3_signed.bin
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ For more detailed information about firmware update implementation, see [Firmwar
 ### Additional features
    - [Remote external flash interface](docs/remote_flash.md)
    - [External encrypted partitions](docs/encrypted_partitions.md)
+   - [Delta updates](docs/firmware_update.md#incremental-updates-aka-delta-updates)
 
 ## Building
 

--- a/docs/Signing.md
+++ b/docs/Signing.md
@@ -186,8 +186,13 @@ Provides a value to be set with a custom tag
    Values can be decimal or hex numbers (prefixed by '0x').  The tag is a 16-bit number.
    Valid tags are in the range between 0x0030 and 0xFEFE.
 
-   The extra numeric field (can be 1, 2, 4, or 8 bytes long) is stored in the manifest
-   header and can be retrieved at runtime by wolfBoot, using `wolfBoot_find_header()`.
+   * `--custom-tlv-buffer tag value`: Adds a TLV entry with arbitrary length to the manifest
+   header, corresponding to the type identified by `tag`, and assigns the value `value`. The
+   tag is a 16-bit number. Valid tags are in the range between 0x0030 and 0xFEFE. The length
+   is implicit, and is the length of the value.
+   Value argument is in the form of a hex string, e.g. `--custom-tlv-buffer 0x0030 AABBCCDDEE`
+   will add a TLV entry with tag 0x0030, length 5 and value 0xAABBCCDDEE.
+
 
 #### Three-steps signing using external provisioning tools
 

--- a/docs/Signing.md
+++ b/docs/Signing.md
@@ -177,6 +177,18 @@ Provides a PCR mask and digest to be signed and included in the header. The sign
   A copy of the final signed policy (including 4 byte PCR mask) will be output to `[inputname].sig`.
   Note: This may require increasing the `IMAGE_HEADER_SIZE` as two signatures will be stored in the header.
 
+#### Adding custom fields to the manifest header
+
+Provides a value to be set with a custom tag
+
+   * `--custom-tlv tag len val`: Adds a TLV entry to the manifest header, corresponding
+   to the type identified by `tag`, with lenght `len` bytes, and assigns the value `val`.
+   Values can be decimal or hex numbers (prefixed by '0x').  The tag is a 16-bit number.
+   Valid tags are in the range between 0x0030 and 0xFEFE.
+
+   The extra numeric field (can be 1, 2, 4, or 8 bytes long) is stored in the manifest
+   header and can be retrieved at runtime by wolfBoot, using `wolfBoot_find_header()`.
+
 #### Three-steps signing using external provisioning tools
 
 If the private key is not accessible, while it's possible to sign payloads using

--- a/tools/keytools/sign.c
+++ b/tools/keytools/sign.c
@@ -2008,15 +2008,21 @@ int main(int argc, char** argv)
             tag = (uint16_t)arg2num(argv[i + 1], 2);
             len = (uint16_t)arg2num(argv[i + 2], 2);
 
-            if ((tag < 0x0030) || (tag > 0xFEFE)) {
+            if (tag < 0x0030) {
                 fprintf(stderr, "Invalid custom tag: %s\n", argv[i + 1]);
                 exit(16);
             }
+            if ( ((tag & 0xFF00) == 0xFF00) || ((tag & 0xFF) == 0xFF) ) {
+                fprintf(stderr, "Invalid custom tag: %s\n", argv[i + 1]);
+                exit(16);
+            }
+
             if ((len != 1) && (len != 2) && (len != 4) && (len != 8)) {
                 fprintf(stderr, "Invalid custom tag len: %s\n", argv[i + 2]);
                 fprintf(stderr, "Accepted len: 1, 2, 4 or 8\n");
                 exit(16);
             }
+
             CMD.custom_tlv[p].tag = tag;
             CMD.custom_tlv[p].len = len;
             CMD.custom_tlv[p].val = arg2num(argv[i+3], len);
@@ -2031,12 +2037,20 @@ int main(int argc, char** argv)
                 fprintf(stderr, "Too many custom TLVs.\n");
                 exit(16);
             }
-            if (argc < (i + 3)) {
+            if (argc < (i + 2)) {
                 fprintf(stderr, "Invalid custom TLV fields. \n");
                 exit(16);
             }
             tag = (uint16_t)arg2num(argv[i + 1], 2);
             len = (uint16_t)strlen(argv[i + 2]) / 2;
+            if (tag < 0x0030) {
+                fprintf(stderr, "Invalid custom tag: %s\n", argv[i + 1]);
+                exit(16);
+            }
+            if ( ((tag & 0xFF00) == 0xFF00) || ((tag & 0xFF) == 0xFF) ) {
+                fprintf(stderr, "Invalid custom tag: %s\n", argv[i + 1]);
+                exit(16);
+            }
             if (len > 255) {
                 fprintf(stderr, "custom tlv buffer size too big: %s\n", argv[i + 2]);
                 exit(16);


### PR DESCRIPTION
Added support in `sign.c` for custom TLVs in the manifest header. Numeric values are supported (valid len: 1, 2, 4 or 8). 
[edit: custom length buffers are also supported via `--custom-tlv-buffer`]

The numbers are stored in little-endian format (according to the current format of the other fields). The TLVs are part of the signed image, so their value is secured against modifications.

The custom fields stored in the TLV can be retrieved at runtime in wolfboot by using `wolfBoot_find_header()`.
Documentation is updated accordingly.