### PR TITLE
Fix lms and xmss build.

### DIFF
--- a/options.mk
+++ b/options.mk
@@ -421,6 +421,12 @@ ifeq ($(SIGN),XMSS)
   endif
 endif
 
+# Only needed if using 3rd party integration. This can be
+# removed when wc_lms and wc_xmss become default in wolfboot.
+ifneq (,$(filter $(SIGN), LMS XMSS))
+  CFLAGS  +=-DWOLFSSL_EXPERIMENTAL_SETTINGS
+endif
+
 ifeq ($(RAM_CODE),1)
   CFLAGS+= -D"RAM_CODE"
 endif

--- a/tools/keytools/Makefile
+++ b/tools/keytools/Makefile
@@ -33,6 +33,11 @@ ifeq ($(SIGN),XMSS)
             -DXMSS_PARAMS=\"$(XMSS_PARAMS)\"
 endif
 
+# Only needed if using 3rd party integration. This can be
+# removed when wc_lms and wc_xmss become default in wolfboot.
+ifneq (,$(filter $(SIGN), LMS XMSS))
+  CFLAGS  +=-DWOLFSSL_EXPERIMENTAL_SETTINGS
+endif
 
 # option variables
 DEBUG_FLAGS     = -g -DDEBUG -DDEBUG_SIGNTOOL -DDEBUG_WOLFSSL -DDEBUG_WOLFSSL_VERBOSE


### PR DESCRIPTION
Add WOLFSSL_EXPERIMENTAL_SETTINGS to lms/xmss builds to stay in sync with wolfssl master.

The renode lms/xmss tests are using wolfssl master.