### PR TITLE
Added support for custom-tlv-string

### DIFF
--- a/.github/workflows/test-keytools.yml
+++ b/.github/workflows/test-keytools.yml
@@ -264,3 +264,9 @@ jobs:
           ./tools/keytools/sign --ecc256 --sha256 --custom-tlv-buffer 0x46 48656C6C6F20776F726C64 test-app/image.elf wolfboot_signing_private_key.der 3
           grep "Hello world" test-app/image_v3_signed.bin
 
+      - name: Sign app with custom string TLV included
+        run: |
+          ./tools/keytools/sign --ecc256 --sha256 --custom-tlv-string 0x46 "Hello world" test-app/image.elf wolfboot_signing_private_key.der 3
+          grep "Hello world" test-app/image_v3_signed.bin
+                   
+

--- a/docs/Signing.md
+++ b/docs/Signing.md
@@ -196,6 +196,12 @@ Provides a value to be set with a custom tag
    Value argument is in the form of a hex string, e.g. `--custom-tlv-buffer 0x0030 AABBCCDDEE`
    will add a TLV entry with tag 0x0030, length 5 and value 0xAABBCCDDEE.
 
+   * `--custom-tlv-string tag ascii-string`: Adds a TLV entry with arbitrary length to the manifest
+   header, corresponding to the type identified by `tag`, and assigns the value of `ascii-string`. The
+   tag is a 16-bit number. Valid tags are in the range between 0x0030 and 0xFEFE. The length
+   is implicit, and is the length of the `ascii-string`. `ascii-string` argument is in the form of a string,
+   e.g. `--custom-tlv-string 0x0030 "Version-1"` will add a TLV entry with tag 0x0030,
+   length 9 and value Version-1.
 
 #### Three-steps signing using external provisioning tools
 

--- a/tools/keytools/sign.c
+++ b/tools/keytools/sign.c
@@ -2072,6 +2072,44 @@ int main(int argc, char** argv)
             }
             CMD.custom_tlvs++;
             i += 2;
+        } else if (strcmp(argv[i], "--custom-tlv-string") == 0) {
+            int p = CMD.custom_tlvs;
+            uint16_t tag, len;
+            uint32_t j;
+            if (p >= MAX_CUSTOM_TLVS) {
+                fprintf(stderr, "Too many custom TLVs.\n");
+                exit(16);
+            }
+            if (argc < (i + 2)) {
+                fprintf(stderr, "Invalid custom TLV fields. \n");
+                exit(16);
+            }
+			tag = (uint16_t)arg2num(argv[i + 1], 2);
+			len = (uint16_t)strlen(argv[i + 2]);
+            if (tag < 0x0030) {
+                fprintf(stderr, "Invalid custom tag: %s\n", argv[i + 1]);
+                exit(16);
+            }
+            if ( ((tag & 0xFF00) == 0xFF00) || ((tag & 0xFF) == 0xFF) ) {
+                fprintf(stderr, "Invalid custom tag: %s\n", argv[i + 1]);
+                exit(16);
+            }
+            if (len > 255) {
+                fprintf(stderr, "custom tlv buffer size too big: %s\n", argv[i + 2]);
+                exit(16);
+            }
+            CMD.custom_tlv[p].tag = tag;
+            CMD.custom_tlv[p].len = len;
+            CMD.custom_tlv[p].buffer = malloc(len);
+            if (CMD.custom_tlv[p].buffer == NULL) {
+                fprintf(stderr, "Error malloc for custom tlv buffer %d\n", len);
+                exit(16);
+            }
+            for (j = 0; j < len; j++) {
+                CMD.custom_tlv[p].buffer[j] = (uint8_t)argv[i+2][j];
+            }
+            CMD.custom_tlvs++;
+            i += 2;
         }
         else {
             i--;

--- a/tools/keytools/sign.c
+++ b/tools/keytools/sign.c
@@ -2084,8 +2084,8 @@ int main(int argc, char** argv)
                 fprintf(stderr, "Invalid custom TLV fields. \n");
                 exit(16);
             }
-			tag = (uint16_t)arg2num(argv[i + 1], 2);
-			len = (uint16_t)strlen(argv[i + 2]);
+            tag = (uint16_t)arg2num(argv[i + 1], 2);
+            len = (uint16_t)strlen(argv[i + 2]);
             if (tag < 0x0030) {
                 fprintf(stderr, "Invalid custom tag: %s\n", argv[i + 1]);
                 exit(16);


### PR DESCRIPTION
Added the ability to create a custom-tlv using an ASCII string to the **keytools/sign tool**.

Example usage:

`sign --custom-tlv-string 0x0030 "0.99.910(6)" --no-sign --sha256 ${projectBaseDir}/release/zephyr.bin 6`

This will create a custom TLV tag as if you'd used --custom-tlv-buffer 0x0030 302E39392E393130283629
Tag: 0030 Len: 11 Val: 302E39392E393130283629 

The above invocation of the sign tool generates the following header in the binary:

![image](https://github.com/wolfSSL/wolfBoot/assets/63172439/da4fceca-97f0-460f-936b-201bf7194e23)


Showing that the two commands are equivalent see the following:

Invocation:
`sign --custom-tlv-string 0x0030 "0.99.910(6)" --custom-tlv-buffer 0x0031 302E39392E393130283629 --no-sign --sha256 ${projectBaseDir}/release/zephyr.bin 6`

```
Custom TLVS: 2
TLV 0
----
Tag: 0030 Len: 11 Val: 302E39392E393130283629
-----
TLV 1
----
Tag: 0031 Len: 11 Val: 302E39392E393130283629
-----
```
And the resulting header in the binary:

![image](https://github.com/wolfSSL/wolfBoot/assets/63172439/e167c8ad-c157-4e5a-9e99-345d17d3be04)


_**Note: This PR came out of a support ticket at https://wolfssl.zendesk.com/hc/en-us/requests/17637**_