### PR TITLE
Update wolfPKCS11 to v1.3.0

### DIFF
--- a/docs/STM32-TZ.md
+++ b/docs/STM32-TZ.md
@@ -10,7 +10,7 @@ are accessible from any software staged in non-secure domain.
 
 ### Compiling wolfBoot with wolfCrypt in TrustZone-M secure domain
 
-When wolfBoot is compiled with the options `TZEN=1` and `WOLFCRYPT_TZ_ENGINE=1`,
+When wolfBoot is compiled with the options `TZEN=1` and `WOLFCRYPT_TZ=1`,
 a more complete set of components of the wolfCrypt crypto library are built-in
 the bootloader, and they can be accessed by applications or OSs running in 
 non-secure domain through non-secure callable APIs.
@@ -19,7 +19,7 @@ This feature is used to isolate the core crypto operations from the applications
 
 ### PKCS11 API in non-secure world
 
-The `WOLFCRYPT_TZ_PKCS11` provides a standard PKCS11 interface,
+The `WOLFCRYPT_TZ_PKCS11` option provides a standard PKCS11 interface,
 including a storage for PKCS11 objects in a dedicated flash area in secure mode.
 
 This means that applications, TLS libraries and operating systems running in 

--- a/include/user_settings.h
+++ b/include/user_settings.h
@@ -255,19 +255,20 @@ extern int tolower(int c);
 
 #if defined(SECURE_PKCS11)
 #   define HAVE_PWDBASED
-#	define HAVE_PBKDF2
-#	define WOLFPKCS11_CUSTOM_STORE
-# 	define WOLFBOOT_SECURE_PKCS11
-#	define WOLFPKCS11_USER_SETTINGS
-# 	define WOLFPKCS11_NO_TIME
-# 	define WOLFSSL_AES_COUNTER
+#   define HAVE_PBKDF2
+#   define WOLFPKCS11_CUSTOM_STORE
+#   define WOLFBOOT_SECURE_PKCS11
+#   define WOLFPKCS11_USER_SETTINGS
+#   define WOLFPKCS11_NO_TIME
+#   define WOLFSSL_AES_COUNTER
 #   define WOLFSSL_AES_DIRECT
 #   define WOLFSSL_AES_GCM
-# 	define ENCRYPT_WITH_AES128
+#   define ENCRYPT_WITH_AES128
 #   define WOLFSSL_AES_128
-# 	define HAVE_SCRYPT
-# 	define HAVE_AESGCM
-	typedef unsigned long time_t;
+#   define HAVE_SCRYPT
+#   define HAVE_AESGCM
+#   define HAVE_PKCS8
+    typedef unsigned long time_t;
 #endif
 
 #ifndef HAVE_PWDBASED


### PR DESCRIPTION
Tested TrustZone-M + PKCS11 with latest wolfPKCS11 release (v1.3.0).

Added PKCS8 option.

Fixed documentation as suggested in #419 