### PR TITLE
Add support for more flash sizes in W25QxxxJV series

### DIFF
--- a/docs/Targets.md
+++ b/docs/Targets.md
@@ -1227,6 +1227,7 @@ WolfBoot currently supports the NXP RT1050, RT1060/1062, and RT1064 devices.
 MCUXpresso SDK is required by wolfBoot to access device drivers on this platform.
 A package can be obtained from the [MCUXpresso SDK Builder](https://mcuxpresso.nxp.com/en/welcome), by selecting a target and keeping the default choice of components.
 
+* For the RT1040 use `EVKB-IMXRT1040`. See configuration example in `config/examples/imx-rt1040.config`.
 * For the RT1050 use `EVKB-IMXRT1050`. See configuration example in `config/examples/imx-rt1050.config`.
 * For the RT1060 use `EVKB-IMXRT1060`. See configuration example in `config/examples/imx-rt1060.config`.
 * For the RT1064 use `EVK-IMXRT1064`. See configuration example in `config/examples/imx-rt1064.config`.
@@ -1239,7 +1240,7 @@ DCP support (hardware acceleration for SHA256 operations) can be enabled by usin
 
 Firmware can be directly uploaded to the target by copying `factory.bin` to the virtual USB drive associated to the device, or by loading the image directly into flash using a JTAG/SWD debugger.
 
-The RT1050 EVKB board comes wired to use the 64MB HyperFlash. If you'd like to use QSPI there is a rework that can be performed (see AN12183). The default onboard QSPI 8MB ISSI IS25WP064A (`CONFIG_FLASH_IS25WP064A`). To use a Winbond W25Q64JV define `CONFIG_FLASH_W25Q64JV`.
+The RT1050 EVKB board comes wired to use the 64MB HyperFlash. If you'd like to use QSPI there is a rework that can be performed (see AN12183). The default onboard QSPI 8MB ISSI IS25WP064A (`CONFIG_FLASH_IS25WP064A`). To use a 64Mbit Winbond W25Q64JV define `CONFIG_FLASH_W25Q64JV` (16Mbit, 32Mbit, 128Mbit, 256Mbit and 512Mbit versions are also available). These options are also available for the RT1040 target.
 
 You can also get the SDK and CMSIS bundles using these repositories:
 * https://github.com/nxp-mcuxpresso/mcux-sdk

--- a/hal/imx_rt.c
+++ b/hal/imx_rt.c
@@ -282,12 +282,39 @@ const flexspi_nor_config_t __attribute__((section(".flash_config"))) qspiflash_c
 /** Flash configuration in the .flash_config section of flash **/
 #if defined(CPU_MIMXRT1042XJM5B) || defined(CPU_MIMXRT1052DVJ6B)
 
-    #ifdef CONFIG_FLASH_W25Q64JV
+    #if defined(CONFIG_FLASH_W25Q16JV)
+        /* Winbond W25Q16JV */
+        #define CONFIG_FLASH_SIZE (2 * 1024 * 1024) /* 2MBytes  */
+        #define WRITE_STATUS_CMD  0x31
+        #define QE_ENABLE         0x02 /* S9 */
+    #elif defined(CONFIG_FLASH_W25Q32JV)
+        /* Winbond W25Q32JV */
+        #define CONFIG_FLASH_SIZE (4 * 1024 * 1024) /* 4MBytes  */
+        #define WRITE_STATUS_CMD  0x31
+        #define QE_ENABLE         0x02 /* S9 */
+    #elif defined(CONFIG_FLASH_W25Q64JV)
         /* Winbond W25Q64JV */
-        #define WRITE_STATUS_CMD 0x31
-        #define QE_ENABLE        0x02 /* S9 */
+        #define CONFIG_FLASH_SIZE (8 * 1024 * 1024) /* 8MBytes  */
+        #define WRITE_STATUS_CMD  0x31
+        #define QE_ENABLE         0x02 /* S9 */
+    #elif defined(CONFIG_FLASH_W25Q128JV)
+        /* Winbond W25Q128JV */
+        #define CONFIG_FLASH_SIZE (16 * 1024 * 1024) /* 16MBytes  */
+        #define WRITE_STATUS_CMD  0x31
+        #define QE_ENABLE         0x02 /* S9 */
+    #elif defined(CONFIG_FLASH_W25Q256JV)
+        /* Winbond W25Q256JV */
+        #define CONFIG_FLASH_SIZE (32 * 1024 * 1024) /* 32MBytes  */
+        #define WRITE_STATUS_CMD  0x31
+        #define QE_ENABLE         0x02 /* S9 */
+    #elif defined(CONFIG_FLASH_W25Q512JV)
+        /* Winbond W25Q512JV */
+        #define CONFIG_FLASH_SIZE (64 * 1024 * 1024) /* 64MBytes  */
+        #define WRITE_STATUS_CMD  0x31
+        #define QE_ENABLE         0x02 /* S9 */
     #elif defined(CONFIG_FLASH_IS25WP064A)
         /* ISSI IS25WP064A (on EVKB with rework see AN12183) */
+        #define CONFIG_FLASH_SIZE (8 * 1024 * 1024) /* 8MBytes  */
         #define WRITE_STATUS_CMD 0x1
         #define QE_ENABLE        0x40 /* S6 */
     #elif !defined(CONFIG_HYPERFLASH)
@@ -428,7 +455,6 @@ const flexspi_nor_config_t __attribute__((section(".flash_config"))) qspiflash_c
     };
     #else /* QSPI */
 
-    #define CONFIG_FLASH_SIZE              (8 * 1024 * 1024) /* 8MBytes  */
     #define CONFIG_FLASH_PAGE_SIZE         256UL             /* 256Bytes  */
     #define CONFIG_FLASH_SECTOR_SIZE       (4 * 1024)        /* 4Bytes */
     #define CONFIG_FLASH_BLOCK_SIZE        (64 * 1024)       /* 64KBytes */


### PR DESCRIPTION
Add support for more flash sizes in the W25QxxxJV series, specifically 2Mbit, 4Mbit, 8Mbit, 32Mbit and 64 Mbit. All the different versions have the same page, sector and block sizes.