### PR TITLE
Add support for MIMXRT1061CVJ5B

### DIFF
--- a/arch.mk
+++ b/arch.mk
@@ -419,6 +419,11 @@ ifeq ($(TARGET),imx_rt)
     CFLAGS+=-I$(MCUXPRESSO)/boards/evkmimxrt1060/xip/
   endif
 
+  ifeq ($(MCUXPRESSO_CPU),MIMXRT1061CVJ5B)
+    ARCH_FLASH_OFFSET=0x60000000
+    CFLAGS+=-I$(MCUXPRESSO)/boards/evkmimxrt1060/xip/
+  endif
+
   ifeq ($(MCUXPRESSO_CPU),MIMXRT1052DVJ6B)
     ARCH_FLASH_OFFSET=0x60000000
     CFLAGS+=-I$(MCUXPRESSO)/boards/evkbimxrt1050/xip/

--- a/docs/Targets.md
+++ b/docs/Targets.md
@@ -1220,7 +1220,7 @@ address `0x8000`.
 
 The NXP iMX-RT10xx family of devices contain a Cortex-M7 with a DCP coprocessor for SHA256 acceleration.
 
-WolfBoot currently supports the NXP RT1050, RT1060/1062, and RT1064 devices.
+WolfBoot currently supports the NXP RT1040, RT1050, RT1060/1061/1062, and RT1064 devices.
 
 ### Building wolfBoot
 
@@ -1240,7 +1240,7 @@ DCP support (hardware acceleration for SHA256 operations) can be enabled by usin
 
 Firmware can be directly uploaded to the target by copying `factory.bin` to the virtual USB drive associated to the device, or by loading the image directly into flash using a JTAG/SWD debugger.
 
-The RT1050 EVKB board comes wired to use the 64MB HyperFlash. If you'd like to use QSPI there is a rework that can be performed (see AN12183). The default onboard QSPI 8MB ISSI IS25WP064A (`CONFIG_FLASH_IS25WP064A`). To use a 64Mbit Winbond W25Q64JV define `CONFIG_FLASH_W25Q64JV` (16Mbit, 32Mbit, 128Mbit, 256Mbit and 512Mbit versions are also available). These options are also available for the RT1040 target.
+The RT1050 EVKB board comes wired to use the 64MB HyperFlash. If you'd like to use QSPI there is a rework that can be performed (see AN12183). The default onboard QSPI 8MB ISSI IS25WP064A (`CONFIG_FLASH_IS25WP064A`). To use a 64Mbit Winbond W25Q64JV define `CONFIG_FLASH_W25Q64JV` (16Mbit, 32Mbit, 128Mbit, 256Mbit and 512Mbit versions are also available). These options are also available for the RT1042 and RT1061 target.
 
 You can also get the SDK and CMSIS bundles using these repositories:
 * https://github.com/nxp-mcuxpresso/mcux-sdk

--- a/hal/imx_rt.c
+++ b/hal/imx_rt.c
@@ -34,19 +34,22 @@
 #include "fsl_lpuart.h"
 #endif
 
+#ifdef CPU_MIMXRT1064DVL6A
+#include "evkmimxrt1064_flexspi_nor_config.h"
+#define USE_GET_CONFIG
+#endif
 #ifdef CPU_MIMXRT1062DVL6A
 #include "evkmimxrt1060_flexspi_nor_config.h"
 #define USE_GET_CONFIG
 #endif
-#ifdef CPU_MIMXRT1042XJM5B
-#include "evkmimxrt1040_flexspi_nor_config.h"
+#ifdef CPU_MIMXRT1061CVJ5B
+#include "evkmimxrt1060_flexspi_nor_config.h"
 #endif
 #ifdef CPU_MIMXRT1052DVJ6B
 #include "evkbimxrt1050_flexspi_nor_config.h"
 #endif
-#ifdef CPU_MIMXRT1064DVL6A
-#include "evkmimxrt1064_flexspi_nor_config.h"
-#define USE_GET_CONFIG
+#ifdef CPU_MIMXRT1042XJM5B
+#include "evkmimxrt1040_flexspi_nor_config.h"
 #endif
 
 #include "xip/fsl_flexspi_nor_boot.h"
@@ -280,7 +283,7 @@ const flexspi_nor_config_t __attribute__((section(".flash_config"))) qspiflash_c
 
 
 /** Flash configuration in the .flash_config section of flash **/
-#if defined(CPU_MIMXRT1042XJM5B) || defined(CPU_MIMXRT1052DVJ6B)
+#if defined(CPU_MIMXRT1061CVJ5B) || defined(CPU_MIMXRT1052DVJ6B) || defined(CPU_MIMXRT1042XJM5B)
 
     #if defined(CONFIG_FLASH_W25Q16JV)
         /* Winbond W25Q16JV */
@@ -576,7 +579,7 @@ const flexspi_nor_config_t __attribute__((section(".flash_config"))) qspiflash_c
 
 
 #ifndef __FLASH_BASE
-#if defined(CPU_MIMXRT1042XJM5B) || defined(CPU_MIMXRT1052DVJ6B) || defined(CPU_MIMXRT1062DVL6A)
+#if defined(CPU_MIMXRT1062DVL6A) || defined(CPU_MIMXRT1061CVJ5B) || defined(CPU_MIMXRT1052DVJ6B) || defined(CPU_MIMXRT1042XJM5B)
 #define __FLASH_BASE 0x60000000
 #elif defined(CPU_MIMXRT1064DVL6A)
 #define __FLASH_BASE 0x70000000
@@ -695,7 +698,7 @@ static void clock_init(void)
             CCM_CBCDR_AHB_PODF(2) |
             CCM_CBCDR_IPG_PODF(2);
 
-#if defined(CPU_MIMXRT1062DVL6A) || defined(CPU_MIMXRT1064DVL6A)
+#if defined(CPU_MIMXRT1064DVL6A) || defined(CPU_MIMXRT1062DVL6A) || defined(CPU_MIMXRT1061CVJ5B)
         /* Configure FLEXSPI2 CLOCKS */
         CCM->CBCMR =
             (CCM->CBCMR &


### PR DESCRIPTION
Adds support for `MIMXRT1061CVJ5B`. Tested on custom PCB with `MIMXRT1061CVJ5B` and `W25Q128JV` QSPI flash.