### PR TITLE
CMake: Add BUILD_IMAGE option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,7 +126,8 @@ add_option(
     "no"
     "yes;no")
 add_option("DEBUG_UART" "Enable trace debugging over a UART (default: disabled)" "no" "yes;no")
-add_option("BUILD_TEST_APPS" "Build the wolfBoot test apps (default: disabled)" "no" "yes;no")
+add_option("BUILD_TEST_APPS" "Build the wolfBoot image and test apps (default: disabled)" "no" "yes;no")
+add_option("BUILD_IMAGE" "Build the wolfBoot image (default: disabled)" "no" "yes;no")
 add_option("PYTHON_KEYTOOLS" "Use wolfCrypt-py for key generation and signing (default: disabled)"
            "no" "yes;no")
 add_option(
@@ -650,9 +651,8 @@ set(WOLFBOOT_LSCRIPT_TEMPLATE hal/${WOLFBOOT_TARGET}.ld)
 # wolfcrypt
 add_subdirectory(lib)
 
-if(BUILD_TEST_APPS)
-    # test applications
-    message(STATUS "Building wolfboot test apps")
+if(BUILD_TEST_APPS OR BUILD_IMAGE)
+    message(STATUS "Building wolfBoot image")
     add_subdirectory(test-app)
 endif()
 

--- a/test-app/CMakeLists.txt
+++ b/test-app/CMakeLists.txt
@@ -104,38 +104,41 @@ else()
     gen_wolfboot_platform_target(${PLATFORM_NAME} bootloader_linker_script)
 endif()
 
-add_executable(image)
+if(BUILD_TEST_APPS)
+    message(STATUS "Building wolfBoot test apps")
+    add_executable(image)
 
-target_sources(image PRIVATE ${APP_SOURCES})
+    target_sources(image PRIVATE ${APP_SOURCES})
 
-target_include_directories(image PRIVATE
-    ../
-    ../include
-    ${CMAKE_CURRENT_BINARY_DIR})
+    target_include_directories(image PRIVATE
+        ../
+        ../include
+        ${CMAKE_CURRENT_BINARY_DIR})
 
-target_link_libraries(image wolfboot target)
+    target_link_libraries(image wolfboot target)
 
-target_compile_definitions(image PRIVATE PLATFORM_${WOLFBOOT_TARGET}
-                                            ${TEST_APP_COMPILE_DEFINITIONS} ${WOLFBOOT_DEFS})
+    target_compile_definitions(image PRIVATE PLATFORM_${WOLFBOOT_TARGET}
+                                                ${TEST_APP_COMPILE_DEFINITIONS} ${WOLFBOOT_DEFS})
 
-target_compile_options(image PRIVATE -Wall -Wstack-usage=1024 -ffreestanding -Wno-unused
-                                        -nostartfiles)
+    target_compile_options(image PRIVATE -Wall -Wstack-usage=1024 -ffreestanding -Wno-unused
+                                            -nostartfiles)
 
-if(WOLFBOOT_TARGET STREQUAL "sim")
-    target_link_options(image PRIVATE -Wl,-gc-sections -Wl,-Map=image.map)
-else()
-    target_link_options(image PRIVATE -T${APP_LSCRIPT} -Wl,-gc-sections -Wl,-Map=image.map)
-endif()
+    if(WOLFBOOT_TARGET STREQUAL "sim")
+        target_link_options(image PRIVATE -Wl,-gc-sections -Wl,-Map=image.map)
+    else()
+        target_link_options(image PRIVATE -T${APP_LSCRIPT} -Wl,-gc-sections -Wl,-Map=image.map)
+    endif()
 
-if(WOLFBOOT_TARGET IN_LIST ARM_TARGETS)
-    message(STATUS "Binary output products will be generated")
-    gen_bin_target_outputs(image)
+    if(WOLFBOOT_TARGET IN_LIST ARM_TARGETS)
+        message(STATUS "Binary output products will be generated")
+        gen_bin_target_outputs(image)
 
-    # add boot address to cache
-    unset(${PLATFORM_NAME}_BOOT_ADDRESS CACHE)
-    set(${PLATFORM_NAME}_BOOT_ADDRESS ${WOLFBOOT_PARTITION_BOOT_ADDRESS} CACHE INTERNAL "")
+        # add boot address to cache
+        unset(${PLATFORM_NAME}_BOOT_ADDRESS CACHE)
+        set(${PLATFORM_NAME}_BOOT_ADDRESS ${WOLFBOOT_PARTITION_BOOT_ADDRESS} CACHE INTERNAL "")
 
-    gen_wolfboot_factory_image(${PLATFORM_NAME} image)
-else()
-    gen_wolfboot_signed_image(image)
+        gen_wolfboot_factory_image(${PLATFORM_NAME} image)
+    else()
+        gen_wolfboot_signed_image(image)
+    endif()
 endif()


### PR DESCRIPTION
Fix for https://github.com/wolfSSL/wolfBoot/issues/426

Add `BUILD_IMAGE` option to CMake to build wolfboot.bin without having to compile test apps

```mkdir build && cd build && cmake -DWOLFBOOT_TARGET=stm32h7 -DWOLFBOOT_PARTITION_BOOT_ADDRESS=0x8020000 -DWOLFBOOT_SECTOR_SIZE=0x20000 -DWOLFBOOT_PARTITION_SIZE=0xD0000 -DWOLFBOOT_PARTITION_UPDATE_ADDRESS=0x80F0000 -DWOLFBOOT_PARTITION_SWAP_ADDRESS=0x81C0000 -DBUILD_IMAGE=yes .. && make```