### PR TITLE
Fix building PKCS11 TrustZone with any authentication algorithm

### DIFF
--- a/include/otp_keystore.h
+++ b/include/otp_keystore.h
@@ -58,10 +58,6 @@ struct KEYSTORE_HDR_PACKED wolfBoot_otp_hdr {
 
 static const char KEYSTORE_HDR_MAGIC[8] = "WOLFBOOT";
 
-#if !defined(KEYSTORE_ANY) && (KEYSTORE_PUBKEY_SIZE != KEYSTORE_PUBKEY_SIZE_ECC256)
-	#error Key algorithm mismatch. Remove old keys via 'make keysclean'
-#else
-
 #define KEYSTORE_MAX_PUBKEYS ((OTP_SIZE - OTP_HDR_SIZE) / SIZEOF_KEYSTORE_SLOT)
 
 #if (OTP_SIZE == 0)
@@ -71,8 +67,6 @@ static const char KEYSTORE_HDR_MAGIC[8] = "WOLFBOOT";
 #if (KEYSTORE_MAX_PUBKEYS < 1)
     #error "No space for any keystores in OTP with current algorithm"
 #endif
-
-#endif /* KEYSTORE_ANY */
 
 #endif /* FLASH_OTP_KEYSTORE */ 
 

--- a/include/user_settings.h
+++ b/include/user_settings.h
@@ -130,7 +130,7 @@ extern int tolower(int c);
 
 
 /* Curve */
-#   ifdef WOLFBOOT_SIGN_ECC256
+#   if defined(WOLFBOOT_SIGN_ECC256) || defined(WOLFCRYPT_SECURE_MODE)
 #       define HAVE_ECC256
 #   elif defined(WOLFBOOT_SIGN_ECC384)
 #       define HAVE_ECC384

--- a/options.mk
+++ b/options.mk
@@ -646,8 +646,6 @@ ifeq ($(WOLFCRYPT_TZ_PKCS11),1)
   CFLAGS+=-DWP11_HASH_PIN_COST=3
   OBJS+=src/pkcs11_store.o
   OBJS+=src/pkcs11_callable.o
-  WOLFCRYPT_OBJS+=./lib/wolfssl/wolfcrypt/src/aes.o
-  WOLFCRYPT_OBJS+=./lib/wolfssl/wolfcrypt/src/rsa.o
   WOLFCRYPT_OBJS+=./lib/wolfssl/wolfcrypt/src/pwdbased.o
   WOLFCRYPT_OBJS+=./lib/wolfssl/wolfcrypt/src/hmac.o
   WOLFCRYPT_OBJS+=./lib/wolfssl/wolfcrypt/src/dh.o
@@ -656,6 +654,16 @@ ifeq ($(WOLFCRYPT_TZ_PKCS11),1)
 		./lib/wolfPKCS11/src/slot.o \
 		./lib/wolfPKCS11/src/wolfpkcs11.o
   STACK_USAGE=16688
+  ifneq ($(ENCRYPT),1)
+      WOLFCRYPT_OBJS+=./lib/wolfssl/wolfcrypt/src/aes.o
+  endif
+  ifeq ($(findstring RSA,$(SIGN)),)
+      WOLFCRYPT_OBJS+=./lib/wolfssl/wolfcrypt/src/rsa.o
+  endif
+  ifeq ($(findstring ECC,$(SIGN)),)
+      WOLFCRYPT_OBJS+=./lib/wolfssl/wolfcrypt/src/ecc.o
+  endif
+  WOLFCRYPT_OBJS+=$(MATH_OBJS) ./lib/wolfssl/wolfcrypt/src/wolfmath.o
 endif
 
 OBJS+=$(PUBLIC_KEY_OBJS)

--- a/options.mk
+++ b/options.mk
@@ -663,7 +663,11 @@ ifeq ($(WOLFCRYPT_TZ_PKCS11),1)
   ifeq ($(findstring ECC,$(SIGN)),)
       WOLFCRYPT_OBJS+=./lib/wolfssl/wolfcrypt/src/ecc.o
   endif
-  WOLFCRYPT_OBJS+=$(MATH_OBJS) ./lib/wolfssl/wolfcrypt/src/wolfmath.o
+  ifeq ($(findstring RSA,$(SIGN)),)
+    ifeq ($(findstring ECC,$(SIGN)),)
+      WOLFCRYPT_OBJS+=$(MATH_OBJS) ./lib/wolfssl/wolfcrypt/src/wolfmath.o
+    endif
+  endif
 endif
 
 OBJS+=$(PUBLIC_KEY_OBJS)


### PR DESCRIPTION
While testing trustzone + LMS, I've noticed that some objects did not get included properly in the crypto engine, unless they were part of wolfboot authentication via SIGN=.

This should allow to compile PKCS11 engine regardless of the algorithm selected by wolfBoot for the authentication.