### PR TITLE
Set VTOR_NS instead of VTOR upon staging when TrustZone is enabled

### DIFF
--- a/src/boot_arm.c
+++ b/src/boot_arm.c
@@ -326,10 +326,12 @@ void isr_empty(void)
  *  - Call the application entry point
  *
  */
-#define VTOR (*(volatile uint32_t *)(0xE000ED08))
 
 #ifdef TZEN
 #include "hal.h"
+#define VTOR (*(volatile uint32_t *)(0xE002ED08))
+#else
+#define VTOR (*(volatile uint32_t *)(0xE000ED08))
 #endif
 
 


### PR DESCRIPTION
To correctly set up the vector table offset, use the VTOR_NS version before staging a non-secure application or RTOS. This ensures that the interrupts will trigger in the non-secure application.