### PR TITLE
Fix build OTP options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,7 +191,7 @@ $(PRIVATE_KEY):
 	$(Q)$(MAKE) keytools_check
 	$(Q)(test $(SIGN) = NONE) || ("$(KEYGEN_TOOL)" $(KEYGEN_OPTIONS) -g $(PRIVATE_KEY)) || true
 	$(Q)(test $(SIGN) = NONE) && (echo "// SIGN=NONE" >  src/keystore.c) || true
-	$(Q)(test $(FLASH_OTP_KEYSTORE) = 0) || (make -C tools/keytools/otp) || true
+	$(Q)(test "$(FLASH_OTP_KEYSTORE)" = "1") && (make -C tools/keytools/otp) || true
 
 keytools: include/target.h
 	@echo "Building key tools"

--- a/include/image.h
+++ b/include/image.h
@@ -74,7 +74,7 @@ int wolfBot_get_dts_size(void *dts_addr);
 
 
 
-#if defined(WOLFBOOT_ARMORED)
+#if (defined(WOLFBOOT_ARMORED) && defined(__WOLFBOOT))
 
 #if !defined(ARCH_ARM) || !defined(__GNUC__)
 #   error WOLFBOOT_ARMORED only available with arm-gcc compiler


### PR DESCRIPTION
- ARMORED option is not needed in otp_primer
- do not attempt to compile otp_primer if the option is not declared