### PR TITLE
KeyTool improvements to allow ASN.1/DER private keys with ECC

### DIFF
--- a/docs/Signing.md
+++ b/docs/Signing.md
@@ -49,10 +49,11 @@ Two options are supported:
 
 - `-g privkey.der` to generate a new keypair, add the public key to the keystore and save the private key in a new file `privkey.der`
 - `-i existing.der` to import an existing public key from `existing.der`
+- `--der` save generated private key in DER format.
 
 Arguments are not exclusive, and can be repeated more than once to populate a keystore with multiple keys.
 
-One option must be specified to select the algorithm enabled in the keystore (e.g. `--ed25519` or `--rsa3072`. See the section "Public key signature options" for the sign tool for the available options.
+One option must be specified to select the algorithm enabled in the keystore (e.g. `--ed25519` or `--rsa3072`). See the section "Public key signature options" for the sign tool for the available options.
 
 The files generate by the keygen tool is the following:
 
@@ -174,6 +175,9 @@ is provided:
   * `--delta BASE_SIGNED_IMG.BIN` This option creates a binary diff file between
     `BASE_SIGNED_IMG.BIN` and the new image signed starting from `IMAGE.BIN`. The
 result is stored in a file ending in `_signed_diff.bin`.
+
+The compression scheme used is Bentley–McIlroy.
+
 
 #### Policy signing (for sealing/unsealing with a TPM)
 

--- a/tools/keytools/user_settings.h
+++ b/tools/keytools/user_settings.h
@@ -110,6 +110,10 @@
 #define NO_CRYPT_TEST
 #define NO_CRYPT_BENCHMARK
 
-#define XSNPRINTF /* not used */
+#ifdef DEBUG_WOLFSSL
+    #define XSNPRINTF snprintf
+#else
+    #define XSNPRINTF /* not used */
+#endif
 
 #endif /* !H_USER_SETTINGS_ */


### PR DESCRIPTION
* Added keygen `--der` option to allow ECC private key as ASN.1/DER. 
* Added sign tool ECC key load support for ASN.1/DER private key (default is raw pub x/y, priv d). 
* Refactored sign tool RSA/ECC logic to consolidate code and allow proper "auto" detection for different RSA key sizes.
* Fix for building key tools with debug and missing `XSNPRINTF`.