### PR TITLE
Fix DCache not being invalidated after erasing/writing to flash on i.MX RT10xx

### DIFF
--- a/arch.mk
+++ b/arch.mk
@@ -382,6 +382,7 @@ ifeq ($(TARGET),imx_rt)
       -I$(MCUXPRESSO_DRIVERS) \
       -I$(MCUXPRESSO_DRIVERS)/drivers \
       -I$(MCUXPRESSO)/drivers \
+      -I$(MCUXPRESSO)/drivers/cache/armv7-m7 \
       -I$(MCUXPRESSO)/drivers/common \
       -I$(MCUXPRESSO)/drivers/flexspi \
       -I$(MCUXPRESSO)/drivers/lpuart \
@@ -405,7 +406,8 @@ ifeq ($(TARGET),imx_rt)
       -I$(MCUXPRESSO)/utilities/debug_console
     OBJS+=\
       $(MCUXPRESSO_DRIVERS)/drivers/fsl_clock.o \
-      $(MCUXPRESSO)/drivers/flexspi/fsl_flexspi.o
+      $(MCUXPRESSO)/drivers/flexspi/fsl_flexspi.o \
+      $(MCUXPRESSO)/drivers/cache/armv7-m7/fsl_cache.o
     ifeq ($(DEBUG_UART),1)
       OBJS+= $(MCUXPRESSO)/drivers/lpuart/fsl_lpuart.o
     endif
@@ -415,7 +417,8 @@ ifeq ($(TARGET),imx_rt)
       -I$(MCUXPRESSO_DRIVERS)/utilities/debug_console
     OBJS+=\
       $(MCUXPRESSO_DRIVERS)/drivers/fsl_clock.o \
-      $(MCUXPRESSO_DRIVERS)/drivers/fsl_flexspi.o
+      $(MCUXPRESSO_DRIVERS)/drivers/fsl_flexspi.o \
+      $(MCUXPRESSO_DRIVERS)/drivers/fsl_cache.o
     ifeq ($(DEBUG_UART),1)
       OBJS+= $(MCUXPRESSO_DRIVERS)/drivers/fsl_lpuart.o
     endif

--- a/arch.mk
+++ b/arch.mk
@@ -451,10 +451,8 @@ ifeq ($(TARGET),imx_rt)
 
   ifeq ($(PKA),1)
     ifeq ($(MCUXSDK),1)
-      PKA_EXTRA_OBJS+= $(MCUXPRESSO)/drivers/cache/armv7-m7/fsl_cache.o
       PKA_EXTRA_OBJS+= $(MCUXPRESSO)/drivers/dcp/fsl_dcp.o
     else
-      PKA_EXTRA_OBJS+= $(MCUXPRESSO_DRIVERS)/drivers/fsl_cache.o
       PKA_EXTRA_OBJS+= $(MCUXPRESSO_DRIVERS)/drivers/fsl_dcp.o
     endif
     PKA_EXTRA_OBJS+=./lib/wolfssl/wolfcrypt/src/port/nxp/dcp_port.o

--- a/arch.mk
+++ b/arch.mk
@@ -434,6 +434,11 @@ ifeq ($(TARGET),imx_rt)
     CFLAGS+=-I$(MCUXPRESSO)/boards/evkmimxrt1060/xip/
   endif
 
+  ifeq ($(MCUXPRESSO_CPU),MIMXRT1062DVL6B)
+    ARCH_FLASH_OFFSET=0x60000000
+    CFLAGS+=-I$(MCUXPRESSO)/boards/evkbmimxrt1060/xip/
+  endif
+
   ifeq ($(MCUXPRESSO_CPU),MIMXRT1061CVJ5B)
     ARCH_FLASH_OFFSET=0x60000000
     CFLAGS+=-I$(MCUXPRESSO)/boards/evkmimxrt1060/xip/

--- a/hal/imx_rt.c
+++ b/hal/imx_rt.c
@@ -43,6 +43,10 @@
 #include "evkmimxrt1060_flexspi_nor_config.h"
 #define USE_GET_CONFIG
 #endif
+#ifdef CPU_MIMXRT1062DVL6B
+#include "evkbmimxrt1060_flexspi_nor_config.h"
+#define USE_GET_CONFIG
+#endif
 #ifdef CPU_MIMXRT1061CVJ5B
 #include "evkmimxrt1060_flexspi_nor_config.h"
 #endif
@@ -262,7 +266,7 @@ const flexspi_nor_config_t FLASH_CONFIG_SECTION qspiflash_config = {
 
 
 /** Flash configuration in the .flash_config section of flash **/
-#ifdef CPU_MIMXRT1062DVL6A
+#if defined(CPU_MIMXRT1062DVL6A) || defined(CPU_MIMXRT1062DVL6B)
     #define CONFIG_FLASH_SIZE              (8 * 1024 * 1024) /* 8MBytes   */
     #define CONFIG_FLASH_PAGE_SIZE         256UL             /* 256Bytes  */
     #define CONFIG_FLASH_SECTOR_SIZE       (4 * 1024)        /* 4KBytes   */
@@ -590,7 +594,10 @@ const flexspi_nor_config_t FLASH_CONFIG_SECTION qspiflash_config = {
 
 
 #ifndef __FLASH_BASE
-#if defined(CPU_MIMXRT1062DVL6A) || defined(CPU_MIMXRT1061CVJ5B) || defined(CPU_MIMXRT1052DVJ6B) || defined(CPU_MIMXRT1042XJM5B)
+#if defined(CPU_MIMXRT1062DVL6A) || defined(CPU_MIMXRT1062DVL6B) || \
+    defined(CPU_MIMXRT1061CVJ5B) || \
+    defined(CPU_MIMXRT1052DVJ6B) || \
+    defined(CPU_MIMXRT1042XJM5B)
 #define __FLASH_BASE 0x60000000
 #elif defined(CPU_MIMXRT1064DVL6A)
 #define __FLASH_BASE 0x70000000
@@ -709,7 +716,9 @@ static void clock_init(void)
             CCM_CBCDR_AHB_PODF(2) |
             CCM_CBCDR_IPG_PODF(2);
 
-#if defined(CPU_MIMXRT1064DVL6A) || defined(CPU_MIMXRT1062DVL6A) || defined(CPU_MIMXRT1061CVJ5B)
+#if defined(CPU_MIMXRT1064DVL6A) || \
+    defined(CPU_MIMXRT1062DVL6A) || defined(CPU_MIMXRT1062DVL6B) || \
+    defined(CPU_MIMXRT1061CVJ5B)
         /* Configure FLEXSPI2 CLOCKS */
         CCM->CBCMR =
             (CCM->CBCMR &

--- a/test-app/Makefile
+++ b/test-app/Makefile
@@ -262,6 +262,7 @@ ifeq ($(TARGET),imx_rt)
   ifeq ($(MCUXSDK),1)
     APP_OBJS+=\
       $(MCUXPRESSO)/drivers/igpio/fsl_gpio.o \
+      $(MCUXPRESSO)/drivers/cache/armv7-m7/fsl_cache.o \
       $(MCUXPRESSO)/drivers/common/fsl_common.o \
       $(MCUXPRESSO)/drivers/common/fsl_common_arm.o \
       $(MCUXPRESSO)/drivers/flexspi/fsl_flexspi.o \
@@ -271,6 +272,7 @@ ifeq ($(TARGET),imx_rt)
   else
     APP_OBJS+=\
       $(MCUXPRESSO_DRIVERS)/drivers/fsl_gpio.o \
+      $(MCUXPRESSO_DRIVERS)/drivers/fsl_cache.o \
       $(MCUXPRESSO_DRIVERS)/drivers/fsl_common.o \
       $(MCUXPRESSO_DRIVERS)/drivers/fsl_common_arm.o \
       $(MCUXPRESSO_DRIVERS)/drivers/fsl_flexspi.o \

--- a/test-app/Makefile
+++ b/test-app/Makefile
@@ -295,6 +295,11 @@ ifeq ($(TARGET),imx_rt)
               -I$(MCUXPRESSO)/boards/evkmimxrt1060/xip/
       APP_OBJS+=$(MCUXPRESSO_DRIVERS)/system_MIMXRT1062.o
     endif
+    ifeq ($(MCUXPRESSO_CPU),MIMXRT1062DVL6B)
+      CFLAGS+=-I$(MCUXPRESSO_DRIVERS)/project_template/ \
+              -I$(MCUXPRESSO)/boards/evkbmimxrt1060/xip/
+      APP_OBJS+=$(MCUXPRESSO_DRIVERS)/system_MIMXRT1062.o
+    endif
     ifeq ($(MCUXPRESSO_CPU),MIMXRT1064DVL6A)
       CFLAGS+=-I$(MCUXPRESSO_DRIVERS)/project_template/ \
               -I$(MCUXPRESSO)/boards/evkmimxrt1064/xip/

--- a/test-app/app_imx_rt.c
+++ b/test-app/app_imx_rt.c
@@ -64,7 +64,8 @@ void init_debug_console(void)
     DbgConsole_Init(UART_INSTANCE, UART_BAUDRATE, UART_TYPE, uartClkSrcFreq);
 }
 
-#if defined(CPU_MIMXRT1062DVL6A) || defined(CPU_MIMXRT1064DVL6A)
+#if defined(CPU_MIMXRT1064DVL6A) || \
+    defined(CPU_MIMXRT1062DVL6A) || defined(CPU_MIMXRT1062DVL6B)
 /* Pin settings (same for both 1062 and 1064) */
 void rt1060_init_pins(void)
 {
@@ -151,7 +152,8 @@ void rt1040_init_pins(void)
 void main(void)
 {
     imx_rt_init_boot_clock();
-#if defined(CPU_MIMXRT1062DVL6A) || defined(CPU_MIMXRT1064DVL6A)
+#if defined(CPU_MIMXRT1064DVL6A) || \
+    defined(CPU_MIMXRT1062DVL6A) || defined(MIMXRT1062DVL6B)
     rt1060_init_pins();
 #elif defined(CPU_MIMXRT1052DVJ6B)
     rt1050_init_pins();

--- a/test-app/imx_rt_clock_config.c
+++ b/test-app/imx_rt_clock_config.c
@@ -125,13 +125,13 @@ void imx_rt_init_boot_clock(void)
 #if !(defined(XIP_EXTERNAL_FLASH) && (XIP_EXTERNAL_FLASH == 1))
     /* Disable Flexspi clock gate. */
     CLOCK_DisableClock(kCLOCK_FlexSpi);
-    #ifdef CPU_MIMXRT1062DVL6A
+    #if defined(CPU_MIMXRT1062DVL6A) || defined(CPU_MIMXRT1062DVL6B)
         /* Set FLEXSPI_PODF. */
         CLOCK_SetDiv(kCLOCK_FlexspiDiv, 1);
         /* Set Flexspi clock source. */
         CLOCK_SetMux(kCLOCK_FlexspiMux, 3);
     #endif
-    #ifdef CPU_MIMXRT1062DVL6A
+    #if defined(CPU_MIMXRT1062DVL6A) || defined(CPU_MIMXRT1062DVL6B)
         /* Set FLEXSPI_PODF. */
         CLOCK_SetDiv(kCLOCK_FlexspiDiv, 2);
         /* Set Flexspi clock source. */
@@ -139,7 +139,7 @@ void imx_rt_init_boot_clock(void)
     #endif
 #endif
 
-#ifdef CPU_MIMXRT1062DVL6A
+#if defined(CPU_MIMXRT1062DVL6A) || defined(CPU_MIMXRT1062DVL6B)
     /* Disable Flexspi2 clock gate. */
     CLOCK_DisableClock(kCLOCK_FlexSpi2);
     /* Set FLEXSPI2_PODF. */
@@ -214,12 +214,12 @@ void imx_rt_init_boot_clock(void)
     /* Disable CAN clock gate. */
     CLOCK_DisableClock(kCLOCK_Can1);
     CLOCK_DisableClock(kCLOCK_Can2);
-#ifdef CPU_MIMXRT1062DVL6A
+#if defined(CPU_MIMXRT1062DVL6A) || defined(CPU_MIMXRT1062DVL6B)
     CLOCK_DisableClock(kCLOCK_Can3);
 #endif
     CLOCK_DisableClock(kCLOCK_Can1S);
     CLOCK_DisableClock(kCLOCK_Can2S);
-#ifdef CPU_MIMXRT1062DVL6A
+#if defined(CPU_MIMXRT1062DVL6A) || defined(CPU_MIMXRT1062DVL6B)
     CLOCK_DisableClock(kCLOCK_Can3S);
 #endif
     /* Set CAN_CLK_PODF. */
@@ -346,7 +346,7 @@ void imx_rt_init_boot_clock(void)
     CCM_ANALOG->PLL_ENET = (CCM_ANALOG->PLL_ENET & (~CCM_ANALOG_PLL_ENET_DIV_SELECT_MASK)) | CCM_ANALOG_PLL_ENET_DIV_SELECT(1);
     /* Enable Enet output. */
     CCM_ANALOG->PLL_ENET |= CCM_ANALOG_PLL_ENET_ENABLE_MASK;
-#ifdef CPU_MIMXRT1062DVL6A
+#if defined(CPU_MIMXRT1062DVL6A) || defined(CPU_MIMXRT1062DVL6B)
     /* Set Enet2 output divider. */
     CCM_ANALOG->PLL_ENET = (CCM_ANALOG->PLL_ENET & (~CCM_ANALOG_PLL_ENET_ENET2_DIV_SELECT_MASK)) | CCM_ANALOG_PLL_ENET_ENET2_DIV_SELECT(0);
     /* Enable Enet2 output. */
@@ -400,7 +400,7 @@ void imx_rt_init_boot_clock(void)
     IOMUXC_MQSConfig(IOMUXC_GPR,kIOMUXC_MqsPwmOverSampleRate32, 0);
     /* Set ENET1 Tx clock source. */
     IOMUXC_EnableMode(IOMUXC_GPR, kIOMUXC_GPR_ENET1RefClkMode, false);
-#ifdef CPU_MIMXRT1062DVL6A
+#if defined(CPU_MIMXRT1062DVL6A) || defined(CPU_MIMXRT1062DVL6B)
     /* Set ENET2 Tx clock source. */
 #if defined(FSL_IOMUXC_DRIVER_VERSION) && (FSL_IOMUXC_DRIVER_VERSION != (MAKE_VERSION(2, 0, 0)))
     IOMUXC_EnableMode(IOMUXC_GPR, kIOMUXC_GPR_ENET2RefClkMode, false);


### PR DESCRIPTION
We've encountered issues where erasing/writing to sectors in flash wasn't visible to the application when reading from flash afterwards. We've narrowed it down to being due to reads happening through the memory mapped flash region, which are cached in the DCache. Reads after erases/writes are therefore at risk of being outdated.

Also, it's stated in NXPs documentation that global interrupts should be disabled when erasing/writing to flash when running with XIP.

See https://wolfssl.zendesk.com/hc/en-us/requests/18238 for more details.

This PR shows the changes needed to fix this, but shouldn't necessarily be merged as-is, as I see you have already added `hal_cache_invalidate`, but it's not implemented for the i.MX platform yet.