### PR TITLE
Add logging for wolfBoot_update() and partition version information

### DIFF
--- a/include/printf.h
+++ b/include/printf.h
@@ -40,13 +40,14 @@
     #endif
     void uart_write(const char* buf, unsigned int sz);
 
-    /* turn on small printf support */
+    /* turn on small printf support in string.c */
     #if !defined(PRINTF_ENABLED) && !defined(NO_PRINTF_UART)
         #define PRINTF_ENABLED
     #endif
 #endif
 
-#ifdef PRINTF_ENABLED
+/* support for wolfBoot_printf logging */
+#if defined(PRINTF_ENABLED) && !defined(WOLFBOOT_NO_PRINTF)
 #   include <stdio.h>
 #   if defined(DEBUG_ZYNQ) && !defined(USE_QNX)
 #       include "xil_printf.h"
@@ -62,8 +63,12 @@
 #       define wolfBoot_printf(_f_, ...) uart_printf(_f_, ##__VA_ARGS__)
 #   elif defined(__CCRX__)
 #       define wolfBoot_printf printf
-#   else
+#   elif defined(WOLFBOOT_LOG_PRINTF)
+        /* allow output to stdout */
 #       define wolfBoot_printf(_f_, ...) printf(_f_, ##__VA_ARGS__)
+#   else
+        /* use stderr by default */
+#       define wolfBoot_printf(_f_, ...) fprintf(stderr, _f_, ##__VA_ARGS__)
 #   endif
 #else
 #   define wolfBoot_printf(_f_, ...) do{}while(0)

--- a/src/image.c
+++ b/src/image.c
@@ -861,11 +861,12 @@ int wolfBoot_open_image_address(struct wolfBoot_image *img, uint8_t *image)
         return -1;
     }
     img->fw_size = wolfBoot_image_size(image);
-    wolfBoot_printf("Image size %d\r\n", (unsigned int)img->fw_size);
+
 #ifdef WOLFBOOT_FIXED_PARTITIONS
     if (img->fw_size > (WOLFBOOT_PARTITION_SIZE - IMAGE_HEADER_SIZE)) {
         wolfBoot_printf("Image size %d > max %d\n",
-            (unsigned int)img->fw_size, (WOLFBOOT_PARTITION_SIZE - IMAGE_HEADER_SIZE));
+            (unsigned int)img->fw_size,
+            (WOLFBOOT_PARTITION_SIZE - IMAGE_HEADER_SIZE));
         img->fw_size = 0;
         return -1;
     }
@@ -880,6 +881,12 @@ int wolfBoot_open_image_address(struct wolfBoot_image *img, uint8_t *image)
 #endif
     img->hdr_ok = 1;
     img->fw_base = img->hdr + IMAGE_HEADER_SIZE;
+
+    wolfBoot_printf("%s partition: %p (size %d, version 0x%x)\n",
+        (img->part == PART_BOOT) ? "Boot" : "Update",
+        img->hdr,
+        (unsigned int)img->fw_size,
+        wolfBoot_get_blob_version(img->hdr));
 
     return 0;
 }
@@ -962,11 +969,9 @@ int wolfBoot_open_image(struct wolfBoot_image *img, uint8_t part)
 #endif
     if (part == PART_BOOT) {
         img->hdr = (void*)WOLFBOOT_PARTITION_BOOT_ADDRESS;
-        wolfBoot_printf("Boot partition: %p\n", img->hdr);
     }
     else if (part == PART_UPDATE) {
         img->hdr = (void*)WOLFBOOT_PARTITION_UPDATE_ADDRESS;
-        wolfBoot_printf("Update partition: %p\n", img->hdr);
     }
     else {
         return -1;

--- a/src/image.c
+++ b/src/image.c
@@ -886,7 +886,7 @@ int wolfBoot_open_image_address(struct wolfBoot_image *img, uint8_t *image)
         (img->part == PART_BOOT) ? "Boot" : "Update",
         img->hdr,
         (unsigned int)img->fw_size,
-        wolfBoot_get_blob_version(img->hdr));
+        wolfBoot_get_blob_version(image));
 
     return 0;
 }

--- a/src/libwolfboot.c
+++ b/src/libwolfboot.c
@@ -239,7 +239,7 @@ static int RAMFUNCTION nvm_select_fresh_sector(int part)
     sel = 0;
 
     /* Select the sector with more flags set. Partition flag is at offset '4'.
-     * Sector flags begin from offset '5'. 
+     * Sector flags begin from offset '5'.
      */
     for (off = 4; off < WOLFBOOT_SECTOR_SIZE; off++) {
         volatile uint8_t byte_0 = get_base_offset(base, off);
@@ -1018,6 +1018,8 @@ uint32_t wolfBoot_get_blob_version(uint8_t *blob)
     uint32_t *volatile version_field = NULL;
     uint32_t *magic = NULL;
     uint8_t *img_bin = blob;
+    if (blob == NULL)
+        return 0;
 #if defined(EXT_ENCRYPTED) && defined(MMU)
     if (!encrypt_initialized)
         if (crypto_init() < 0)
@@ -1870,15 +1872,16 @@ int wolfBoot_ram_decrypt(uint8_t *src, uint8_t *dst)
     uint32_t dst_offset = 0, iv_counter = 0;
     uint32_t magic, len;
 
-
     if (!encrypt_initialized) {
         if (crypto_init() < 0) {
+            wolfBoot_printf("Error initializing crypto!\n");
             return -1;
         }
     }
 
     /* Attempt to decrypt firmware header */
     if (decrypt_header(src) != 0) {
+        wolfBoot_printf("Error decrypting header at %p!\n", src);
         return -1;
     }
     len = *((uint32_t*)(dec_hdr + sizeof(uint32_t)));

--- a/src/update_flash.c
+++ b/src/update_flash.c
@@ -219,6 +219,7 @@ static int wolfBoot_swap_and_final_erase(int resume)
         + ENCRYPT_KEY_SIZE + ENCRYPT_NONCE_SIZE
 #endif
     ];
+
     /* open partitions (ignore failure) */
     wolfBoot_open_image(boot, PART_BOOT);
     wolfBoot_open_image(update, PART_UPDATE);


### PR DESCRIPTION
Proposed additional (optional) logging. 

Add logging for wolfBoot_update() and partition version information. Enabled with `DEBUG_UART` or other PRINTF_ENABLED logging.

@danielinux let me know if you'd like to see this wrapped with another macro like `WOLFBOOT_VERBOSE`?

Example Log:
```
wolfBoot HAL Init
SPI Probe: Manuf 0xC2, Product 0x20
Boot at 0xFFE00000 (size 115856, version 0x2)
Update at 0x200000 (size 115856, version 0x0)
Staring Update (fallback allowed 0)
Update at 0x200000 (size 115856, version 0x0)
Boot at 0xFFE00000 (size 115856, version 0x2)
Versions: Current 0x2, Update 0x3
Copy sector 0 (part 1->2)
Copy sector 0 (part 0->1)
Copy sector 0 (part 2->0)
Boot at 0xFFE00000 (size 115856, version 0x3)
Update at 0x200000 (size 115856, version 0x0)
Copy sector 1 (part 1->2)
Copy sector 1 (part 0->1)
Copy sector 1 (part 2->0)
Copy sector 2 (part 1->2)
Copy sector 2 (part 0->1)
Copy sector 2 (part 2->0)
Copy sector 3 (part 1->2)
Copy sector 3 (part 0->1)
Copy sector 3 (part 2->0)
Boot at 0xFFE00000 (size 115856, version 0x3)
Update at 0x200000 (size 115856, version 0x0)
Copy sector 58 (part 0->2)
Boot at 0xFFE00000 (size 115856, version 0x3)
Booting version: 0x3
```