### PR TITLE
Fix for error dereferencing type-punned pointer in update_flash.c `wolfBoot_swap_and_final_erase`

### DIFF
--- a/IDE/Renesas/e2studio/RA6M4/Readme.md
+++ b/IDE/Renesas/e2studio/RA6M4/Readme.md
@@ -229,13 +229,13 @@ Application Entry Address:         0x00010200
 Magic:    WOLF
 Version:  01
 Status:   FF
-Tail Mgc:
+Trailer Magic:
 
 === Update Partition[00080000] ===
 Magic:
 Version:  00
 Status:   FF
-Tail Mgc:
+Trailer Magic:
 Current Firmware Version : 1
 
 Calling wolfBoot_success()
@@ -250,16 +250,16 @@ Called wolfBoot_success()
 Magic:    WOLF
 Version:  01
 Status:   00
-Tail Mgc: BOOT
+Trailer Magic: BOOT
 
 === Update Partition[00080000] ===
 Magic:
 Version:  00
 Status:   FF
-Tail Mgc:
+Trailer Magic:
 ```
 
-You can see the state is Success("00") and Tail Magic number becomes "BOOT".
+You can see the state is Success("00") and Trailer Magic number becomes "BOOT".
 You can also see flashing each LED light in 1 second. Notable things about V1 application,
 it will also call wolfBoot_update_trigger() so that it tells wolfBoot that new version exists.
 We are going to generate and download V2 application into "Update partition".
@@ -302,13 +302,13 @@ Application Entry Address:         0x00010200
 Magic:    WOLF
 Version:  02
 Status:   00
-Tail Mgc: BOOT
+Trailer Magic: BOOT
 
 === Update Partition[00080000] ===
 Magic:    WOLF
 Version:  01
 Status:   FF
-Tail Mgc:
+Trailer Magic:
 Current Firmware Version : 2
 
 Calling wolfBoot_success()
@@ -317,14 +317,14 @@ Called wolfBoot_success()
 Magic:    WOLF
 Version:  02
 Status:   00
-Tail Mgc: BOOT
+Trailer Magic: BOOT
 
 === Update Partition[00080000] ===
 Magic:    WOLF
 Version:  01
 Status:   FF
-Tail Mgc:
+Trailer Magic:
 ```
 
-You can see "Current Firmware Version : 2". The state is Success("00") and Tail Magic number becomes "BOOT".
+You can see "Current Firmware Version : 2". The state is Success("00") and Tailer Magic number becomes "BOOT".
 You can also see flashing each LED light in 5 second at this new version.

--- a/IDE/Renesas/e2studio/RA6M4/Readme_wSCE.md
+++ b/IDE/Renesas/e2studio/RA6M4/Readme_wSCE.md
@@ -247,13 +247,13 @@ Application Entry Address:         0x00020200
 Magic:    WOLF
 Version:  01
 Status:   FF
-Tail Mgc:
+Trailer Magic:
 
 === Update Partition[00090000] ===
 Magic:
 Version:  00
 Status:   FF
-Tail Mgc:
+Trailer Magic:
 Current Firmware Version : 1
 
 Calling wolfBoot_success()
@@ -269,16 +269,16 @@ Called wolfBoot_success()
 Magic:    WOLF
 Version:  01
 Status:   00
-Tail Mgc: BOOT
+Trailer Magic: BOOT
 
 === Update Partition[00090000] ===
 Magic:
 Version:  00
 Status:   FF
-Tail Mgc:
+Trailer Magic:
 ```
 
-You can see the state is Success("00") and Tail Magic number becomes "BOOT".
+You can see the state is Success("00") and Trailer Magic number becomes "BOOT".
 You can also see flashing each LED light in 1 second. Notable things about V1 application,
 it will also call wolfBoot_update_trigger() so that it tells wolfBoot that new version exists.
 We are going to generate and download V2 application into "Update partition".
@@ -318,13 +318,13 @@ Application Entry Address:         0x00020200
 Magic:    WOLF
 Version:  02
 Status:   10
-Tail Mgc: BOOT
+Trailer Magic: BOOT
 
 === Update Partition[00090000] ===
 Magic:    WOLF
 Version:  01
 Status:   FF
-Tail Mgc:
+Trailer Magic:
 Current Firmware Version : 2
 
 Calling wolfBoot_success()
@@ -333,13 +333,13 @@ Called wolfBoot_success()
 Magic:    WOLF
 Version:  02
 Status:   00
-Tail Mgc: BOOT
+Trailer Magic: BOOT
 
 === Update Partition[00090000] ===
 Magic:    WOLF
 Version:  01
 Status:   70
-Tail Mgc: BOOT
+Trailer Magic: BOOT
 ```
-You can see "Current Firmware Version : 2". The state is Success("00") and Tail Magic number becomes "BOOT".
+You can see "Current Firmware Version : 2". The state is Success("00") and Trailer Magic number becomes "BOOT".
 You can also see flashing each LED light in 5 second at this new version.

--- a/IDE/Renesas/e2studio/RA6M4/app_RA/src/app_RA.c
+++ b/IDE/Renesas/e2studio/RA6M4/app_RA/src/app_RA.c
@@ -40,7 +40,7 @@ static void blink(int interval)
 
     /* LED type structure */
     bsp_leds_t leds = g_bsp_leds;
-    
+
 #if BSP_TZ_SECURE_BUILD
 
     /* Enter non-secure code */
@@ -59,8 +59,8 @@ static void blink(int interval)
     {
         /* Enable access to the PFS registers */
         R_BSP_PinAccessEnable();
-        
-        
+
+
         /* Update each LEDs*/
         for (uint32_t i = 0; i < leds.led_count; i++)
         {
@@ -69,18 +69,18 @@ static void blink(int interval)
 
             /* Write to this pin */
             R_BSP_PinWrite((bsp_io_port_pin_t) pin, pin_level);
-            
+
             /* Delay */
             R_BSP_SoftwareDelay(delay, bsp_delay_units);
         }
-        
+
         /* Protect PFS registers */
         R_BSP_PinAccessDisable();
 
         /* Toggle level for next write */
         if (BSP_IO_LEVEL_LOW == pin_level) {
             pin_level = BSP_IO_LEVEL_HIGH;
-        } 
+        }
         else {
             pin_level = BSP_IO_LEVEL_LOW;
         }
@@ -104,7 +104,7 @@ static void printPart(uint8_t *part)
     state = *(part + WOLFBOOT_PARTITION_SIZE - sizeof(uint32_t) - 1);
     myprintf("Status:   %02x\n", state);
     magic = part + WOLFBOOT_PARTITION_SIZE - sizeof(uint32_t);
-    myprintf("Tail Mgc: %c%c%c%c\n", magic[0], magic[1], magic[2], magic[3]);
+    myprintf("Trailer Magic: %c%c%c%c\n", magic[0], magic[1], magic[2], magic[3]);
 
 #ifdef WOLFBOOT_DEBUG_PARTION
     v = (uint32_t *)part;

--- a/IDE/Renesas/e2studio/RX72N/Readme.md
+++ b/IDE/Renesas/e2studio/RX72N/Readme.md
@@ -211,13 +211,13 @@ application V1.
 Magic:    WOLF
 Version:  01
 Status:   ff (New)
-Tail Mgc: ����
+Trailer Magic: ����
 
 === Update Partition[ffdf8000] ===
 Magic:    ����
 Version:  00
 Status:   ff (New)
-Tail Mgc: ����
+Trailer Magic: ����
 
 Current Firmware Version: 1
 Hit any key to call wolfBoot_success the firmware.
@@ -231,13 +231,13 @@ state and wait for any key again.
 Magic:    WOLF
 Version:  01
 Status:   00 (Success)
-Tail Mgc: BOOT
+Trailer Magic: BOOT
 
 === Update Partition[ffdf8000] ===
 Magic:    ����
 Version:  00
 Status:   00 (Success)
-Tail Mgc: BOOT
+Trailer Magic: BOOT
 
 ```
 You can see the state is Success("00").
@@ -280,13 +280,13 @@ Firmware Update is triggered
 Magic:    WOLF
 Version:  01
 Status:   00 (Success)
-Tail Mgc: BOOT
+Trailer Magic: BOOT
 
 === Update Partition[ffdf8000] ===
 Magic:    ����
 Version:  00
 Status:   70 (Updating)
-Tail Mgc: BOOT
+Trailer Magic: BOOT
 ```
 
 Since this is just a trigger, the application can continue the process.
@@ -309,13 +309,13 @@ information.
 Magic:    WOLF
 Version:  02
 Status:   10
-Tail Mgc: BOOT
+Trailer Magic: BOOT
 
 === Update Partition[ffdf8000] ===
 Magic:    WOLF
 Version:  01
 Status:   30
-Tail Mgc: BOOT
+Trailer Magic: BOOT
 
 Current Firmware Version: 2
 ```

--- a/IDE/Renesas/e2studio/RX72N/Readme_withTSIP.md
+++ b/IDE/Renesas/e2studio/RX72N/Readme_withTSIP.md
@@ -270,13 +270,13 @@ application V1.
 Magic:    WOLF
 Version:  01
 Status:   ff
-Tail Mgc: ����
+Trailer Magic: ����
 
 === Update Partition[ffe20000] ===
 Magic:    WOLF
 Version:  02
 Status:   ff
-Tail Mgc: ����
+Trailer Magic: ����
 
 Current Firmware Version: 1
 Hit any key to call wolfBoot_success the firmware.
@@ -294,13 +294,13 @@ You can see the state is Success("00").
 Magic:    WOLF
 Version:  01
 Status:   00
-Tail Mgc: BOOT
+Trailer Magic: BOOT
 
 === Update Partition[ffe20000] ===
 Magic:    WOLF
 Version:  02
 Status:   ff
-Tail Mgc: ����
+Trailer Magic: ����
 
 Hit any key to update the firmware.
 ```
@@ -361,13 +361,13 @@ information.
 Magic:    WOLF
 Version:  02
 Status:   10
-Tail Mgc: BOOT
+Trailer Magic: BOOT
 
 === Update Partition[ffe20000] ===
 Magic:    ����
 Version:  00
 Status:   ff
-Tail Mgc: ����
+Trailer Magic: ����
 
 Current Firmware Version: 2
 ```

--- a/IDE/Renesas/e2studio/RX72N/app_RenesasRX01/src/app_RenesasRX01.c
+++ b/IDE/Renesas/e2studio/RX72N/app_RenesasRX01/src/app_RenesasRX01.c
@@ -56,7 +56,7 @@ static void printPart(uint8_t *part)
     state = *(part + WOLFBOOT_PARTITION_SIZE - sizeof(uint32_t) - 1);
     printf("Status:   %02x (%s)\n", state,state2str(state));
     magic = part + WOLFBOOT_PARTITION_SIZE - sizeof(uint32_t);
-    printf("Tail Mgc: %c%c%c%c\n", magic[0], magic[1], magic[2], magic[3]);
+    printf("Trailer Mgc: %c%c%c%c\n", magic[0], magic[1], magic[2], magic[3]);
 
 #ifdef WOLFBOOT_DEBUG_PARTION
     v = (uint32_t *)part;

--- a/docs/Targets.md
+++ b/docs/Targets.md
@@ -2074,13 +2074,13 @@ wolfBoot HAL Init
 Magic:    WOLF
 Version:  01
 Status:   ff (New)
-Tail Mgc: ˇˇˇˇ
+Trailer Magic: ˇˇˇˇ
 
 === Update Partition[ffef0000] ===
 Magic:    ˇˇˇˇ
 Version:  00
 Status:   ff (New)
-Tail Mgc: ˇˇˇˇ
+Trailer Magic: ˇˇˇˇ
 
 Current Firmware Version: 1
 Hit any key to call wolfBoot_success the firmware.
@@ -2189,13 +2189,13 @@ wolfBoot HAL Init
 Magic:    WOLF
 Version:  01
 Status:   ff (New)
-Tail Mgc: ˇˇˇˇ
+Trailer Magic: ˇˇˇˇ
 
 === Update Partition[ffdf0000] ===
 Magic:    ˇˇˇˇ
 Version:  00
 Status:   ff (New)
-Tail Mgc: ˇˇˇˇ
+Trailer Magic: ˇˇˇˇ
 
 Current Firmware Version: 1
 Hit any key to call wolfBoot_success the firmware.

--- a/src/libwolfboot.c
+++ b/src/libwolfboot.c
@@ -239,7 +239,7 @@ static int RAMFUNCTION nvm_select_fresh_sector(int part)
     sel = 0;
 
     /* Select the sector with more flags set. Partition flag is at offset '4'.
-     * Sector flags begin from offset '5'. 
+     * Sector flags begin from offset '5'.
      */
     for (off = 4; off < WOLFBOOT_SECTOR_SIZE; off++) {
         volatile uint8_t byte_0 = get_base_offset(base, off);
@@ -1763,7 +1763,7 @@ int RAMFUNCTION ext_flash_decrypt_read(uintptr_t address, uint8_t *data, int len
     int i;
     int flash_read_size;
     int read_remaining = len;
-    int unaligned_head_size, unaligned_tail_size;
+    int unaligned_head_size, unaligned_trailer_size;
     uint8_t part;
     uintptr_t base_address;
 
@@ -1815,8 +1815,8 @@ int RAMFUNCTION ext_flash_decrypt_read(uintptr_t address, uint8_t *data, int len
         iv_counter++;
     }
     /* Trim the read size to align with the Encryption Blocks. Read the
-     * remaining unaligned tail bytes after, since the `data` buffer won't have
-     * enough space to handle the extra bytes.
+     * remaining unaligned trailer bytes after, since the `data` buffer won't
+     * have enough space to handle the extra bytes.
      */
     flash_read_size = read_remaining & ~(ENCRYPT_BLOCK_SIZE - 1);
     if (ext_flash_read(address, data, flash_read_size) != flash_read_size)
@@ -1833,17 +1833,17 @@ int RAMFUNCTION ext_flash_decrypt_read(uintptr_t address, uint8_t *data, int len
     data += flash_read_size;
     read_remaining -= flash_read_size;
 
-    /* Read the unaligned tail bytes. */
-    unaligned_tail_size = read_remaining;
-    if (unaligned_tail_size > 0)
+    /* Read the unaligned trailer bytes. */
+    unaligned_trailer_size = read_remaining;
+    if (unaligned_trailer_size > 0)
     {
         uint8_t dec_block[ENCRYPT_BLOCK_SIZE];
         if (ext_flash_read(address, block, ENCRYPT_BLOCK_SIZE)
                 != ENCRYPT_BLOCK_SIZE)
             return -1;
         crypto_decrypt(dec_block, block, ENCRYPT_BLOCK_SIZE);
-        XMEMCPY(data, dec_block, unaligned_tail_size);
-        read_remaining -= unaligned_tail_size;
+        XMEMCPY(data, dec_block, unaligned_trailer_size);
+        read_remaining -= unaligned_trailer_size;
     }
     return (len - read_remaining);
 }

--- a/src/update_flash.c
+++ b/src/update_flash.c
@@ -197,10 +197,10 @@ static int RAMFUNCTION wolfBoot_copy_sector(struct wolfBoot_image *src,
 #ifndef DISABLE_BACKUP
 
 #ifdef EXT_ENCRYPTED
-#   define TAIL_OFFSET_WORDS \
+#   define TRAILER_OFFSET_WORDS \
         ((ENCRYPT_KEY_SIZE + ENCRYPT_NONCE_SIZE) / sizeof(uint32_t))
 #else
-#   define TAIL_OFFSET_WORDS 0
+#   define TRAILER_OFFSET_WORDS 0
 #endif
 
 static int wolfBoot_swap_and_final_erase(int resume)
@@ -217,7 +217,7 @@ static int wolfBoot_swap_and_final_erase(int resume)
     int swapDone = 0;
     uintptr_t tmpBootPos = WOLFBOOT_PARTITION_SIZE - eraseLen -
         WOLFBOOT_SECTOR_SIZE;
-    uint32_t tmpBuffer[TAIL_OFFSET_WORDS + 1];
+    uint32_t tmpBuffer[TRAILER_OFFSET_WORDS + 1];
 
     /* open boot */
     wolfBoot_open_image(boot, PART_BOOT);
@@ -227,12 +227,12 @@ static int wolfBoot_swap_and_final_erase(int resume)
     wolfBoot_open_image(swap, PART_SWAP);
     wolfBoot_get_partition_state(PART_UPDATE, &st);
 
-    /* read tail */
+    /* read trailer */
     memcpy(tmpBuffer, boot->hdr + tmpBootPos, sizeof(tmpBuffer));
 
     /* check for trailing magic (BOOT) */
     /* final swap and erase flag is WOLFBOOT_MAGIC_TRAIL */
-    if (tmpBuffer[TAIL_OFFSET_WORDS] == WOLFBOOT_MAGIC_TRAIL) {
+    if (tmpBuffer[TRAILER_OFFSET_WORDS] == WOLFBOOT_MAGIC_TRAIL) {
         swapDone = 1;
     }
     /* if resuming, quit if swap isn't done */
@@ -253,7 +253,7 @@ static int wolfBoot_swap_and_final_erase(int resume)
             (uint8_t*)&tmpBuffer[ENCRYPT_KEY_SIZE/sizeof(uint32_t)]);
 #endif
         /* write TRAIL, encryption key and iv if enabled to tmpBootPos*/
-        tmpBuffer[TAIL_OFFSET_WORDS] = WOLFBOOT_MAGIC_TRAIL;
+        tmpBuffer[TRAILER_OFFSET_WORDS] = WOLFBOOT_MAGIC_TRAIL;
 
         wb_flash_erase(boot, tmpBootPos, WOLFBOOT_SECTOR_SIZE);
         wb_flash_write(boot, tmpBootPos, (void*)tmpBuffer, sizeof(tmpBuffer));

--- a/test-app/app_renesas_rx.c
+++ b/test-app/app_renesas_rx.c
@@ -65,7 +65,7 @@ static void printPart(uint8_t *part)
     state = *(part + WOLFBOOT_PARTITION_SIZE - sizeof(uint32_t) - 1);
     printf("Status:   %02x (%s)\n", state, state2str(state));
     magic = part + WOLFBOOT_PARTITION_SIZE - sizeof(uint32_t);
-    printf("Tail Mgc: %c%c%c%c\n", magic[0], magic[1], magic[2], magic[3]);
+    printf("Trailer Mgc: %c%c%c%c\n", magic[0], magic[1], magic[2], magic[3]);
 
 #ifdef WOLFBOOT_DEBUG_PARTION
     v = (uint32_t*)part;


### PR DESCRIPTION
Fix for update_flash.c `error: dereferencing type-punned pointer will break strict-aliasing rules [-Werror=strict-aliasing]`. Cleanup the swap logic for EXT_ENCRYPTED. Switch to using a uint32_t directly for checking tail magic.

```
src/update_flash.c: In function 'wolfBoot_swap_and_final_erase':
src/update_flash.c:237:5: error: dereferencing type-punned pointer will break strict-aliasing rules [-Werror=strict-aliasing]
     if (*((uint32_t*)tmpBuffer) == WOLFBOOT_MAGIC_TRAIL) {
     ^
src/update_flash.c:261:9: error: dereferencing type-punned pointer will break strict-aliasing rules [-Werror=strict-aliasing]
         *((uint32_t*)tmpBuffer) = WOLFBOOT_MAGIC_TRAIL;
         ^
cc1.exe: all warnings being treated as errors
```

Cleanup "tail" to "trailer"