### PR TITLE
Fixes for Renesas RX IRQ on boot and addition of SPI flash full chip erase API

### DIFF
--- a/hal/renesas-rx.c
+++ b/hal/renesas-rx.c
@@ -433,14 +433,7 @@ void hal_init(void)
 
 void hal_prepare_boot(void)
 {
-    /* make sure interrupts are disabled */
-#if defined(__CCRX__)
-    clrpsw_i();
-#elif defined(__GNUC__)
-    __builtin_rx_clrpsw('I');
-#elif defined(__ICCRX__)
-    __disable_interrupt();
-#endif
+
 }
 
 int hal_flash_init(void)

--- a/hal/renesas-rx.c
+++ b/hal/renesas-rx.c
@@ -433,7 +433,14 @@ void hal_init(void)
 
 void hal_prepare_boot(void)
 {
-
+    /* make sure interrupts are disabled */
+#if defined(__CCRX__)
+    clrpsw_i();
+#elif defined(__GNUC__)
+    __builtin_rx_clrpsw('I');
+#elif defined(__ICCRX__)
+    __disable_interrupt();
+#endif
 }
 
 int hal_flash_init(void)

--- a/hal/renesas-rx.h
+++ b/hal/renesas-rx.h
@@ -407,5 +407,8 @@ void hal_delay_us(uint32_t us);
 
 #define QSPI_FIFO_SIZE 32 /* bytes */
 
+/* Software Configurable Interrupt Request Registers */
+#define ICU_PIBR(x) (*(volatile uint8_t *)(SYSTEM_BASE + 0x7700 + (x)))
+#define ICU_PIAR(x) (*(volatile uint8_t *)(SYSTEM_BASE + 0x7900 + (x)))
 
 #endif /* !_WOLFBOOT_RENESAS_RX_H_ */

--- a/include/spi_flash.h
+++ b/include/spi_flash.h
@@ -45,6 +45,7 @@ uint16_t spi_flash_probe(void);
 void spi_flash_release(void);
 
 int spi_flash_sector_erase(uint32_t address);
+int spi_flash_chip_erase(void);
 int spi_flash_read(uint32_t address, void *data, int len);
 int spi_flash_write(uint32_t address, const void *data, int len);
 

--- a/src/boot_renesas.c
+++ b/src/boot_renesas.c
@@ -58,6 +58,16 @@ void do_boot(const uint32_t *app_offset)
     void (*app_entry)(void);
     uint32_t app_sp;
 
+    /* Make sure interrupts are disabled */
+    /* Application may assume interrupts are disabled */
+#if defined(__CCRX__)
+    clrpsw_i();
+#elif defined(__GNUC__)
+    __builtin_rx_clrpsw('I');
+#elif defined(__ICCRX__)
+    __disable_interrupt();
+#endif
+
 #ifdef BOOT_ENTRY_OFFSET
     /* add byte offset to uint32_t */
     app_offset += BOOT_ENTRY_OFFSET/sizeof(uint32_t);

--- a/src/spi_flash.c
+++ b/src/spi_flash.c
@@ -44,6 +44,7 @@
 #define WREN            0x06
 #define WRDI            0x04
 #define SECTOR_ERASE    0x20
+#define CHIP_ERASE      0x60
 #define BYTE_READ       0x03
 #define BYTE_WRITE      0x02
 #define AUTOINC         0xAD
@@ -205,6 +206,10 @@ uint16_t spi_flash_probe(void)
     wolfBoot_printf("SPI Probe: Manuf 0x%x, Product 0x%x\n", manuf, product);
     manuf_prod = (uint16_t)(manuf << 8) | (uint16_t)product;
 
+#ifdef SPI_FLASH_CHIP_ERASE
+    spi_flash_chip_erase();
+#endif
+
 #ifdef TEST_EXT_FLASH
     test_ext_flash();
 #endif
@@ -223,6 +228,18 @@ int RAMFUNCTION spi_flash_sector_erase(uint32_t address)
     spi_write(SECTOR_ERASE);
     spi_read();
     write_address(address);
+    spi_cs_off(SPI_CS_PIO_BASE, SPI_CS_FLASH);
+    wait_busy();
+    return 0;
+}
+
+int RAMFUNCTION spi_flash_chip_erase(void)
+{
+    wait_busy();
+    flash_write_enable();
+    spi_cs_on(SPI_CS_PIO_BASE, SPI_CS_FLASH);
+    spi_write(CHIP_ERASE);
+    spi_read();
     spi_cs_off(SPI_CS_PIO_BASE, SPI_CS_FLASH);
     wait_busy();
     return 0;


### PR DESCRIPTION
* Fix to make sure wolfBoot leaves IRQ's disabled. The TSIP driver will leave IRQ's on which could cause customer issues. 
* Added new `spi_flash_chip_erase` API for the SPI flash driver. Enabled with `SPI_FLASH_CHIP_ERASE`.