### PR TITLE
Renesas RX fix for flash write and RX65N Benchmarks

### DIFF
--- a/arch.mk
+++ b/arch.mk
@@ -363,6 +363,8 @@ ifeq ($(ARCH),RENESAS_RX)
             $(RX_TSIP_SRC_PATH)/ip/r_tsip_rx_pfa.o \
             $(RX_TSIP_SRC_PATH)/ip/r_tsip_rx_pfb.o \
             $(RX_TSIP_SRC_PATH)/ip/r_tsip_rx_pf1.o \
+            $(RX_TSIP_SRC_PATH)/ip/r_tsip_rx_pf5.o \
+            $(RX_TSIP_SRC_PATH)/ip/r_tsip_rx_pf6.o \
             $(RX_TSIP_SRC_PATH)/ip/s_flash.o \
             $(RX_TSIP_SRC_PATH)/ip/r_tsip_rx_p00.o \
             $(RX_TSIP_SRC_PATH)/ip/r_tsip_rx_p01.o \
@@ -379,6 +381,8 @@ ifeq ($(ARCH),RENESAS_RX)
             $(RX_TSIP_SRC_PATH)/ip/r_tsip_rx_function010.o \
             $(RX_TSIP_SRC_PATH)/ip/r_tsip_rx_function011.o \
             $(RX_TSIP_SRC_PATH)/ip/r_tsip_rx_function023.o \
+            $(RX_TSIP_SRC_PATH)/ip/r_tsip_rx_function027.o \
+            $(RX_TSIP_SRC_PATH)/ip/r_tsip_rx_function028.o \
             $(RX_TSIP_SRC_PATH)/ip/r_tsip_rx_function050.o \
             $(RX_TSIP_SRC_PATH)/ip/r_tsip_rx_function051.o \
             $(RX_TSIP_SRC_PATH)/ip/r_tsip_rx_function052.o \

--- a/docs/Renesas.md
+++ b/docs/Renesas.md
@@ -166,7 +166,9 @@ Download files to flash using Renesas flash programmer.
 
 #### RX TSIP Benchmarks
 
-| Algorithm         | RX TSIP  | Debug    | Release (-Os) | Release (-O2) |
-| ----------------- | -------- | -------- | ------------- | ------------- |
-| ECDSA Verify P384 | 17.26 ms | 1570 ms  | 441 ms        | 313 ms        |
-| ECDSA Verify P256 |  2.73 ms |  469 ms  | 135 ms        | 107 ms        |
+| Hardware | Clock  | Algorithm         | RX TSIP  | Debug    | Release (-Os) | Release (-O2) |
+| -------- | ------ | ----------------- | -------- | -------- | ------------- | ------------- |
+| RX72N    | 240MHz | ECDSA Verify P384 | 17.26 ms | 1570 ms  |  441 ms       |  313 ms       |
+| RX72N    | 240MHz | ECDSA Verify P256 |  2.73 ms |  469 ms  |  135 ms       |  107 ms       |
+| RX65N    | 120MHz | ECDSA Verify P384 | 18.57 ms | 4213 ms  | 2179 ms       | 1831 ms       |
+| RX65N    | 120MHz | ECDSA Verify P256 |  2.95 ms | 1208 ms  |  602 ms       |  517 ms       |

--- a/hal/renesas-rx.c
+++ b/hal/renesas-rx.c
@@ -69,6 +69,33 @@ static void hal_panic(void)
         ;
 }
 
+#ifdef ENABLE_LED
+void hal_led_on(void)
+{
+#if defined(TARGET_rx65n)
+    /* RX65N RSK+ LED0 P73 */
+    PORT_PDR(7) |= (1 << 3);   /* output */
+    PORT_PODR(7) &= ~(1 << 3); /* low */
+#elif defined(TARGET_rx72n)
+    /* RX72N Envision USR LED P40 */
+    PORT_PDR(4) |= (1 << 0);   /* output */
+    PORT_PODR(4) &= ~(1 << 0); /* low */
+#endif
+}
+void hal_led_off(void)
+{
+#ifdef TARGET_rx65n
+    /* RX65N RSK+ LED0 P73 */
+    PORT_PDR(7) |= (1 << 3);  /* output */
+    PORT_PODR(7) |= (1 << 3); /* high */
+#else
+    /* RX72N Envision USR LED P40 */
+    PORT_PDR(4) |= (1 << 0);  /* output */
+    PORT_PODR(4) |= (1 << 0); /* high */
+#endif
+}
+#endif
+
 void hal_delay_us(uint32_t us)
 {
     uint32_t delay;
@@ -351,6 +378,10 @@ void hal_init(void)
 #endif
 
     hal_clk_init();
+
+#ifdef ENABLE_LED
+    hal_led_off();
+#endif
 
 #ifdef DEBUG_UART
     uart_init();


### PR DESCRIPTION
* Updated Renesas RX TSIP Benchmarks to include RX65N
* Fixed Renesas RX for internal flash write when != 128 bytes. Improved internal flash test case.
* Added hal_led_on/hal_led_off API's enabled with `ENABLE_LED` for testing.