### PR TITLE
Add HAB support irrespective of MCUSDK setting for imx_rt target

### DIFF
--- a/arch.mk
+++ b/arch.mk
@@ -566,12 +566,13 @@ ifeq ($(TARGET),imx_rt)
     ifeq ($(DEBUG_UART),1)
       OBJS+= $(MCUXPRESSO_DRIVERS)/drivers/fsl_lpuart.o
     endif
-    ifeq ($(TARGET_IMX_HAB),1)
-        LSCRIPT_IN:=hal/$(TARGET)_hab.ld
-    else
-        LSCRIPT_IN:=hal/$(TARGET).ld
-    endif
-endif
+  endif
+
+  ifeq ($(TARGET_IMX_HAB),1)
+      LSCRIPT_IN:=hal/$(TARGET)_hab.ld
+  else
+      LSCRIPT_IN:=hal/$(TARGET).ld
+  endif
 
   ifeq ($(MCUXPRESSO_CPU),MIMXRT1064DVL6A)
     ARCH_FLASH_OFFSET=0x70000000


### PR DESCRIPTION
After https://github.com/wolfSSL/wolfBoot/pull/475 moved the selection of linker script from `Makefile` to `arch.mk`, building with `TARGET_IMX_HAB=1` only worked when `MCUSDK` wasn't set to 1. This PR fixes this.

cc @danielinux 