### PR TITLE
Fix AURIX build error 

### DIFF
--- a/hal/aurix_tc3xx.c
+++ b/hal/aurix_tc3xx.c
@@ -201,13 +201,13 @@ static void RAMFUNCTION programCachedSector(uint32_t           sectorAddress,
         for (offset = 0;
              offset < IFXFLASH_PFLASH_BURST_LENGTH / (2 * sizeof(uint32_t));
              offset++) {
-            bufferIndex =
+            bufferIdx =
                 burstIdx * (IFXFLASH_PFLASH_BURST_LENGTH / sizeof(uint32_t))
                 + (offset * 2);
 
             IfxFlash_loadPage2X32(UNUSED_PARAMETER,
-                                  sectorBuffer[bufferIndex],
-                                  sectorBuffer[bufferIndex + 1]);
+                                  sectorBuffer[bufferIdx],
+                                  sectorBuffer[bufferIdx + 1]);
         }
 
         /* Write the page */


### PR DESCRIPTION
Fixes typo in variable name that causes a compile error. 

Error was introduced during code review when splitting up combined assignment/declarations, and not found since CI doesn't compile `hal/aurix_tc3xx.c`.

Confirmed the fix builds and runs as expected on tc3xx.

