### PR TITLE
Keygen to allow multiple keystore types

### DIFF
--- a/tools/keytools/Makefile
+++ b/tools/keytools/Makefile
@@ -61,6 +61,11 @@ ifneq (,$(filter $(SIGN), ext_LMS ext_XMSS))
   CFLAGS  +=-DWOLFSSL_EXPERIMENTAL_SETTINGS
 endif
 
+# When WOLFBOOT_UNIVERSAL_KEYSTORE is defined, pad store_sizes in keystore.der
+ifeq ($(WOLFBOOT_UNIVERSAL_KEYSTORE),1)
+  CFLAGS+=-DWOLFBOOT_UNIVERSAL_KEYSTORE
+endif
+
 # option variables
 DEBUG_FLAGS     = -g -DDEBUG -DDEBUG_SIGNTOOL -DDEBUG_WOLFSSL -DDEBUG_WOLFSSL_VERBOSE
 SANITIZE_FLAGS  = -fsanitize=address

--- a/tools/keytools/keygen.c
+++ b/tools/keytools/keygen.c
@@ -405,8 +405,12 @@ void keystore_add(uint32_t ktype, uint8_t *key, uint32_t sz, const char *keyfile
 
     sl.pubkey_size = get_pubkey_size(ktype);
     memcpy(sl.pubkey, key, sl.pubkey_size);
-    slot_size = sizeof(struct keystore_slot) + sl.pubkey_size -
+#ifdef WOLFBOOT_UNIVERSAL_KEYSTORE
+    slot_size = sizeof(struct keystore_slot);
+#else
+    slot_size = sizeof(struct keystore_slot) +  sl.pubkey_size - 
         KEYSLOT_MAX_PUBKEY_SIZE;
+#endif
     fwrite(&sl, slot_size, 1, fpub_image);
     id_slot++;
 }


### PR DESCRIPTION
when WOLFBOOT_UNIVERSAL_KEYSTORE=1, the keystore.der file should align all the keys to the maximum slot size (576).