### PR TITLE
Fix logic error in wolfBoot_tpm_pcrmask_sel()

### DIFF
--- a/src/tpm.c
+++ b/src/tpm.c
@@ -477,7 +477,7 @@ uint32_t wolfBoot_tpm_pcrmask_sel(uint32_t pcrMask, uint8_t* pcrArray,
     for (i=0; i<IMPLEMENTATION_PCR; i++) {
         if (pcrMask & (1 << i)) {
             pcrArray[pcrArraySzAct++] = i;
-            if (pcrArraySzAct < pcrArraySz) { /* make sure we have room */
+            if (pcrArraySzAct > pcrArraySz) { /* make sure we have room */
                 break;
             }
         }


### PR DESCRIPTION
This logic error resulted in only one PCR effectively being used for building PCR policies and unsealing secrets with a PCR policy.