### PR TITLE
tools renode: reset SIGN_ARGS.

### DIFF
--- a/tools/test-renode.mk
+++ b/tools/test-renode.mk
@@ -5,6 +5,7 @@ RENODE_UART?=$(TMP)/wolfboot.uart
 RENODE_LOG?=$(TMP)/wolfboot.log
 RENODE_PIDFILE?=$(TMP)/renode.pid
 RENODE_UPDATE_FILE=$(TMP)/renode-test-update.bin
+SIGN_ARGS=
 
 
 RENODE_PORT=55155

--- a/tools/test-renode.mk
+++ b/tools/test-renode.mk
@@ -95,12 +95,11 @@ ifeq ($(SIGN),RSA4096)
   SIGN_ARGS+= --rsa4096
 endif
 
-ifeq ($(SIGN),LMS)
-  SIGN_ARGS+= --lms
+ifneq (,$(filter $(SIGN), LMS ext_LMS))
+	SIGN_ARGS+= --lms
 endif
-
-ifeq ($(SIGN),XMSS)
-  SIGN_ARGS+= --xmss
+ifneq (,$(filter $(SIGN), XMSS ext_XMSS))
+	SIGN_ARGS+= --xmss
 endif
 
 ifeq ($(SIGN),ML_DSA)


### PR DESCRIPTION
# Description

SIGN_ARGS is getting duplicate args.

# Testing

```
$./silly_reproducer 
Building key tools
make[1]: Entering directory '/home/jordan/work/boot/src/tools/keytools'
Building signing tool
Building keygen tool
make[1]: Leaving directory '/home/jordan/work/boot/src/tools/keytools'
/home/jordan/work/boot/src/tools/keytools/sign --ml_dsa --sha256 --ml_dsa --sha256  \
```

```
$cat silly_reproducer 
#!/bin/bash
# Any of these will do it:
#  cp config/examples/sim.config .config || exit 1
#  cp config/examples/sim-lms.config .config || exit 1
cp config/examples/sim-ml-dsa.config .config || exit 1
make distclean && make clean
make keytools || exit 1
make test-sim-internal-flash-with-update V=1 2>&1 | grep "sign.*sha256.*sha256"
```