### PR TITLE
Cleanups after hybrid signing PR 510

### DIFF
--- a/arch.mk
+++ b/arch.mk
@@ -59,7 +59,7 @@ ifeq ($(ARCH),x86_64)
   endif
 endif
 
-## ARM
+## ARM Cortex-A
 ifeq ($(ARCH),AARCH64)
   CROSS_COMPILE?=aarch64-none-elf-
   CFLAGS+=-DARCH_AARCH64 -march=armv8-a
@@ -71,6 +71,7 @@ ifeq ($(ARCH),AARCH64)
   endif
 endif
 
+## ARM Cortex-M
 ifeq ($(ARCH),ARM)
   CROSS_COMPILE?=arm-none-eabi-
   CFLAGS+=-DARCH_ARM

--- a/hal/raspi3.c
+++ b/hal/raspi3.c
@@ -264,15 +264,6 @@ void* hal_get_dts_update_address(void)
   return NULL; /* Not yet supported */
 }
 
-/* QSPI functions */
-void qspi_init(uint32_t cpu_clock, uint32_t flash_freq)
-{
-}
-
-void zynq_init(uint32_t cpu_clock)
-{
-}
-
 #if defined(DISPLAY_CLOCKS)
 static uint32_t getclocks(uint8_t cid)
 {

--- a/include/image.h
+++ b/include/image.h
@@ -66,6 +66,14 @@ int wolfBot_get_dts_size(void *dts_addr);
 #  endif
 #endif
 
+#ifndef UNUSEDFUNCTION
+#  if defined(__GNUC__) || defined(__CC_ARM)
+#    define UNUSEDFUNCTION __attribute__((unused))
+#  else
+#    define UNUSEDFUNCTION
+#  endif
+#endif
+
 
 #ifndef WOLFBOOT_FLAGS_INVERT
 #define SECT_FLAG_NEW      0x0F
@@ -79,32 +87,32 @@ int wolfBot_get_dts_size(void *dts_addr);
 #define SECT_FLAG_UPDATED   0x0f
 #endif
 
-#ifdef WOLFBOOT_SIGN_PRIMARY_ED25519
+#ifdef WOLFBOOT_SIGN_ED25519
 #define wolfBoot_verify_signature_primary wolfBoot_verify_signature_ed25519
 #endif
-#ifdef WOLFBOOT_SIGN_PRIMARY_ED448
+#ifdef WOLFBOOT_SIGN_ED448
 #define wolfBoot_verify_signature_primary wolfBoot_verify_signature_ed448
 #endif
-#if defined (WOLFBOOT_SIGN_PRIMARY_RSA2048) || \
-    defined (WOLFBOOT_SIGN_PRIMARY_RSA3072) || \
-    defined (WOLFBOOT_SIGN_PRIMARY_RSA4096) || \
-    defined (WOLFBOOT_SIGN_PRIMARY_RSA2048ENC) || \
-    defined (WOLFBOOT_SIGN_PRIMARY_RSA3072ENC) || \
-    defined (WOLFBOOT_SIGN_PRIMARY_RSA4096ENC)
+#if defined (WOLFBOOT_SIGN_RSA2048) || \
+    defined (WOLFBOOT_SIGN_RSA3072) || \
+    defined (WOLFBOOT_SIGN_RSA4096) || \
+    defined (WOLFBOOT_SIGN_RSA2048ENC) || \
+    defined (WOLFBOOT_SIGN_RSA3072ENC) || \
+    defined (WOLFBOOT_SIGN_RSA4096ENC)
 #define wolfBoot_verify_signature_primary wolfBoot_verify_signature_rsa
 #endif
-#if defined (WOLFBOOT_SIGN_PRIMARY_ECC256) || \
-        defined (WOLFBOOT_SIGN_PRIMARY_ECC384) || \
-        defined (WOLFBOOT_SIGN_PRIMARY_ECC521)
+#if defined (WOLFBOOT_SIGN_ECC256) || \
+        defined (WOLFBOOT_SIGN_ECC384) || \
+        defined (WOLFBOOT_SIGN_ECC521)
 #define wolfBoot_verify_signature_primary wolfBoot_verify_signature_ecc
 #endif
-#if defined(WOLFBOOT_SIGN_PRIMARY_LMS) || defined(WOLFBOOT_SIGN_PRIMARY_ext_LMS)
+#if defined(WOLFBOOT_SIGN_LMS) || defined(WOLFBOOT_SIGN_ext_LMS)
 #define wolfBoot_verify_signature_primary wolfBoot_verify_signature_lms
 #endif
-#if defined(WOLFBOOT_SIGN_PRIMARY_XMSS ) || defined(WOLFBOOT_SIGN_PRIMARY_ext_XMSS)
+#if defined(WOLFBOOT_SIGN_XMSS ) || defined(WOLFBOOT_SIGN_ext_XMSS)
 #define wolfBoot_verify_signature_primary wolfBoot_verify_signature_xmss
 #endif
-#ifdef WOLFBOOT_SIGN_PRIMARY_ML_DSA
+#ifdef WOLFBOOT_SIGN_ML_DSA
 #define wolfBoot_verify_signature_primary wolfBoot_verify_signature_ml_dsa
 #endif
 
@@ -598,12 +606,15 @@ struct wolfBoot_image {
     uint8_t not_ext : 1; /* image is no longer external */
 };
 
+
 /* do not warn if this is not used */
-static void wolfBoot_image_confirm_signature_ok(struct wolfBoot_image *img)
+static void UNUSEDFUNCTION wolfBoot_image_confirm_signature_ok(
+    struct wolfBoot_image *img)
 {
     img->signature_ok = 1;
 }
-static void wolfBoot_image_clear_signature_ok(struct wolfBoot_image *img)
+static void UNUSEDFUNCTION wolfBoot_image_clear_signature_ok(
+    struct wolfBoot_image *img)
 {
 	img->signature_ok = 0;
 }

--- a/options.mk
+++ b/options.mk
@@ -478,7 +478,7 @@ ifeq ($(SIGN),ML_DSA)
   ifneq ($(HASH),SHA3)
     WOLFCRYPT_OBJS+=./lib/wolfssl/wolfcrypt/src/sha3.o
   endif
-  
+
   ifeq ($(WOLFBOOT_SMALL_STACK),1)
     $(error WOLFBOOT_SMALL_STACK with ML-DSA not supported yet)
   else
@@ -539,8 +539,6 @@ ifneq ($(SIGN_SECONDARY),)
   endif
 endif
 
-
-CFLAGS+=-DWOLFBOOT_SIGN_PRIMARY_$(SIGN)
 
 ifeq ($(RAM_CODE),1)
   CFLAGS+= -D"RAM_CODE"

--- a/src/image.c
+++ b/src/image.c
@@ -1260,6 +1260,7 @@ int wolfBoot_verify_authenticity(struct wolfBoot_image *img)
      *
      */
     wolfBoot_verify_signature_primary(key_slot, img, stored_signature);
+    (void)stored_signature_size;
     if (img->signature_ok == 1)
 #ifdef SIGN_HYBRID
     {

--- a/src/update_ram.c
+++ b/src/update_ram.c
@@ -39,8 +39,8 @@ extern int wolfBoot_get_dts_size(void *dts_addr);
 extern uint32_t kernel_load_addr;
 extern uint32_t dts_load_addr;
 
-#if (defined(EXT_FLASH) && defined(NO_XIP)) || \
-    (defined(EXT_ENCRYPTED) && defined(MMU)) && \
+#if ((defined(EXT_FLASH) && defined(NO_XIP)) || \
+    (defined(EXT_ENCRYPTED) && defined(MMU))) && \
     !defined(WOLFBOOT_NO_RAMBOOT)
     /* Load firmware to RAM on boot (single flash read) */
     #undef  WOLFBOOT_USE_RAMBOOT

--- a/tools/keytools/sign.c
+++ b/tools/keytools/sign.c
@@ -490,7 +490,7 @@ static int load_key_rsa(int sign_type, uint32_t rsa_keysz, uint32_t rsa_pubkeysz
                 CMD.sign = sign_type;
                 CMD.signature_sz = keySzOut;
             }
-            printf("Found RSA%d key\n", keySzOut);
+            printf("Found RSA%d key\n", keySzOut*8);
         }
     }
     return ret;

--- a/tools/unit-tests/unit-image.c
+++ b/tools/unit-tests/unit-image.c
@@ -43,7 +43,7 @@
 
 #define ENCRYPT_KEY "123456789abcdef0123456789abcdef0123456789abcdef"
 #define KEYSTORE_PUBKEY_SIZE KEYSTORE_PUBKEY_SIZE_ECC256
-#define WOLFBOOT_SIGN_PRIMARY_ECC256
+#define WOLFBOOT_SIGN_ECC256
 
 #include <stdio.h>
 #include <check.h>
@@ -267,7 +267,7 @@ int wc_ecc_import_unsigned(ecc_key* key, const byte* qx, const byte* qy,
 {
     if (ecc_import_fail)
         return -1;
-    
+
     key->type = ECC_PUBLICKEY;
     return 0;
 }
@@ -285,7 +285,7 @@ START_TEST(test_verify_signature)
 {
     uint8_t pubkey[32];
     struct wolfBoot_image test_img;
-    
+
     test_img.part = PART_UPDATE;
     test_img.fw_size = test_img_len;
     test_img.fw_base = 0;
@@ -455,7 +455,7 @@ START_TEST(test_verify_authenticity)
     find_header_mocked = 1;
     ret = wolfBoot_verify_authenticity(&test_img);
     ck_assert_int_eq(ret, -1);
-    
+
     /* Wrong pubkey  */
     find_header_mocked = 0;
     hdr_cpy_done = 0;
@@ -463,7 +463,7 @@ START_TEST(test_verify_authenticity)
             test_img_len);
     ret = wolfBoot_verify_authenticity(&test_img);
     ck_assert_int_lt(ret, 0);
-    
+
     /* Wrong signature  */
     find_header_mocked = 0;
     find_header_fail = 0;
@@ -539,7 +539,7 @@ START_TEST(test_open_image)
     ck_assert_ptr_eq(img.hdr, (void *)WOLFBOOT_PARTITION_SWAP_ADDRESS);
     ck_assert_ptr_eq(img.hdr, img.fw_base);
     ck_assert_uint_eq(img.fw_size, WOLFBOOT_SECTOR_SIZE);
-    
+
     /* Valid image */
     hdr_cpy_done = 0;
     ext_flash_write(0, test_img_v200000000_signed_bin,
@@ -574,17 +574,17 @@ Suite *wolfboot_suite(void)
     tcase_set_timeout(tcase_headers, 20);
     tcase_add_test(tcase_headers, test_headers);
     suite_add_tcase(s, tcase_headers);
-    
+
     TCase* tcase_verify_authenticity = tcase_create("verify_authenticity");
     tcase_set_timeout(tcase_verify_authenticity, 20);
     tcase_add_test(tcase_verify_authenticity, test_verify_authenticity);
     suite_add_tcase(s, tcase_verify_authenticity);
-    
+
     TCase* tcase_verify_integrity = tcase_create("verify_integrity");
     tcase_set_timeout(tcase_verify_integrity, 20);
     tcase_add_test(tcase_verify_integrity, test_verify_integrity);
     suite_add_tcase(s, tcase_verify_integrity);
-    
+
     TCase* tcase_open_image = tcase_create("open_image");
     tcase_set_timeout(tcase_open_image, 20);
     tcase_add_test(tcase_open_image, test_open_image);


### PR DESCRIPTION
* Fixes issues from https://github.com/wolfSSL/wolfBoot/pull/510
* Do not change sign macro to _PRIMARY. Breaks existing users.
* Add back "unused" on `wolfBoot_image_confirm_signature_ok`
* Fix unused `stored_signature_size`.
* Fix size reported in sign tool "Found RSA%d key".