### PR TITLE
Fix wolfBoot_update_trigger sector calculation

### DIFF
--- a/src/libwolfboot.c
+++ b/src/libwolfboot.c
@@ -742,7 +742,7 @@ void RAMFUNCTION wolfBoot_update_trigger(void)
 
     /* if PART_UPDATE_ENDFLAGS straddles a sector, (all non FLAGS_HOME builds)
      * align it to the correct sector */
-    if (PART_UPDATE_ENDFLAGS % WOLFBOOT_SECTOR_SIZE == 0)
+    if (PART_UPDATE_ENDFLAGS % WOLFBOOT_SECTOR_SIZE != 0)
         lastSector -= WOLFBOOT_SECTOR_SIZE;
 
     /* erase the sector flags */


### PR DESCRIPTION
`wolfBoot_update_trigger` is called to initiate an update on the next boot. It does this by modifying the metadata in the last sector (selecting one of the two if `NVM_FLASH_WRITEONCE` is defined).

There's a check to handle the case where the `PART_UPDATE_ENDFLAGS` isn't aligned with the `WOLFBOOT_SECTOR_SIZE`. However, this check was wrong, as the modulo of these two macros is 0 when aligned, so the check should be != 0.

See ticket #19133 for more information.