### PR TITLE
stop the selSec from being applied twice to lastSector

### DIFF
--- a/src/libwolfboot.c
+++ b/src/libwolfboot.c
@@ -763,10 +763,11 @@ void RAMFUNCTION wolfBoot_update_trigger(void)
         hal_flash_erase(lastSector, SECTOR_FLAGS_SIZE);
 #else
         selSec = nvm_select_fresh_sector(PART_UPDATE);
-        lastSector -= selSec * WOLFBOOT_SECTOR_SIZE;
-        XMEMCPY(NVM_CACHE, (uint8_t*)lastSector, WOLFBOOT_SECTOR_SIZE);
+        XMEMCPY(NVM_CACHE, (uint8_t*)lastSector - WOLFBOOT_SECTOR_SIZE * selSec,
+            WOLFBOOT_SECTOR_SIZE);
         /* write to the non selected sector */
-        hal_flash_erase(lastSector - WOLFBOOT_SECTOR_SIZE * !selSec, WOLFBOOT_SECTOR_SIZE);
+        hal_flash_erase(lastSector - WOLFBOOT_SECTOR_SIZE * !selSec,
+            WOLFBOOT_SECTOR_SIZE);
         hal_flash_write(lastSector - WOLFBOOT_SECTOR_SIZE * !selSec, NVM_CACHE,
             WOLFBOOT_SECTOR_SIZE);
         /* erase the previously selected sector */

--- a/src/libwolfboot.c
+++ b/src/libwolfboot.c
@@ -740,11 +740,6 @@ void RAMFUNCTION wolfBoot_update_trigger(void)
     uint8_t selSec = 0;
 #endif
 
-    /* if PART_UPDATE_ENDFLAGS straddles a sector, (all non FLAGS_HOME builds)
-     * align it to the correct sector */
-    if (PART_UPDATE_ENDFLAGS % WOLFBOOT_SECTOR_SIZE == 0)
-        lastSector -= WOLFBOOT_SECTOR_SIZE;
-
     /* erase the sector flags */
     if (FLAGS_UPDATE_EXT()) {
         ext_flash_unlock();


### PR DESCRIPTION
ZD 19133

I found a mistake in the update trigger code where the selSec for nvm writeonce was being subtracted from the base address and then subtracted again for the erase operation. We need to add a test with a fullsize update image that would have been corrupted by this mistake. I've previously tried and failed to make a full size image test in test.mk @danielinux I could use advise or help on this