### PR TITLE
Remove external ext_lms, ext_xmss pq integrations.

### DIFF
--- a/.github/workflows/test-renode-nrf52.yml
+++ b/.github/workflows/test-renode-nrf52.yml
@@ -58,27 +58,13 @@ jobs:
       - name: Renode Tests RSA4096
         run: ./tools/renode/docker-test.sh "SIGN=RSA4096"
 
-#
-# LMS and ext_LMS tests
-#
 # LMS TEST
       - name: Renode Tests LMS-8-5-5
         run: ./tools/renode/docker-test.sh "SIGN=LMS LMS_LEVELS=2 LMS_HEIGHT=5 LMS_WINTERNITZ=8 WOLFBOOT_SMALL_STACK=0 IMAGE_SIGNATURE_SIZE=2644 IMAGE_HEADER_SIZE=5288"
 
-# ext_LMS TEST
-      - name: Renode Tests ext_LMS-8-5-5
-        run: ./tools/renode/docker-test.sh "SIGN=ext_LMS LMS_LEVELS=2 LMS_HEIGHT=5 LMS_WINTERNITZ=8 WOLFBOOT_SMALL_STACK=0 IMAGE_SIGNATURE_SIZE=2644 IMAGE_HEADER_SIZE=5288"
-
-#
-# XMSS and ext_XMSS tests
-#
 # XMSS TEST
       - name: Renode Tests XMSS-SHA2_10_256
         run: ./tools/renode/docker-test.sh "SIGN=XMSS XMSS_PARAMS='XMSS-SHA2_10_256' WOLFBOOT_SMALL_STACK=0 IMAGE_SIGNATURE_SIZE=2500 IMAGE_HEADER_SIZE=5000"
-
-# ext_XMSS TEST
-      - name: Renode Tests ext_XMSS-SHA2_10_256
-        run: ./tools/renode/docker-test.sh "SIGN=ext_XMSS XMSS_PARAMS='XMSS-SHA2_10_256' WOLFBOOT_SMALL_STACK=0 IMAGE_SIGNATURE_SIZE=2500 IMAGE_HEADER_SIZE=5000"
 
 # ML-DSA TEST
       - name: Renode Tests ML-DSA-44

--- a/docs/PQ.md
+++ b/docs/PQ.md
@@ -103,11 +103,9 @@ See these links for more info on stateful HBS support and wolfSSL/wolfCrypt:
 
 ### Supported PQ HBS Options
 
-These four PQ signature options are supported:
+These two hash-based PQ signature options are supported:
 - LMS: uses wolfcrypt implementation from `wc_lms.c`, and `wc_lms_impl.c`.
 - XMSS: uses wolfcrypt implementation from `wc_xmss.c`, and `wc_xmss_impl.c`.
-- ext_LMS: uses external integration from `ext_lms.c`.
-- ext_XMSS: uses external integration from `ext_xmss.c`.
 
 The wolfcrypt implementations are more performant and are recommended.
 The external integrations are experimental and for testing interoperability.
@@ -281,58 +279,3 @@ Creating hybrid signature
 
 The resulting image `image_v1_signed.bin` contains both signatures, and can be verified using a wolfBoot with hybrid signature support.
 
-## Building the external PQ Integrations
-
-### ext_LMS Support
-
-The external LMS/HSS support in wolfCrypt requires the hash-sigs library ( https://github.com/cisco/hash-sigs ).
-Use the following procedure to prepare hash-sigs for building with wolfBoot:
-
-```
-$ cd lib
-$ mkdir hash-sigs
-$ls
- CMakeLists.txt  hash-sigs  wolfssl  wolfTPM
-$ cd hash-sigs
-$ mkdir lib
-$ git clone https://github.com/cisco/hash-sigs.git src
-$ cd src
-$ git checkout b0631b8891295bf2929e68761205337b7c031726
-$ git apply ../../../tools/lms/0001-Patch-to-support-wolfBoot-LMS-build.patch
-```
-
-Nothing more is needed, as wolfBoot will automatically produce the required
-hash-sigs build artifacts.
-
-Note: the hash-sigs project only builds static libraries:
-- hss_verify.a: a single-threaded verify-only static lib.
-- hss_lib.a: a single-threaded static lib.
-- hss_lib_thread.a: a multi-threaded static lib.
-
-The keytools utility links against `hss_lib.a`, as it needs full
-keygen, signing, and verifying functionality. However wolfBoot
-links directly with the subset of objects in the `hss_verify.a`
-build rule, as it only requires verify functionality.
-
-
-### ext_XMSS Support
-
-The external XMSS/XMSS^MT support in wolfCrypt requires a patched version of the
-xmss-reference library ( https://github.com/XMSS/xmss-reference.git ).
-Use the following procedure to prepare xmss-reference for building with
-wolfBoot:
-
-```
-$ cd lib
-$ git clone https://github.com/XMSS/xmss-reference.git xmss
-$ ls
-CMakeLists.txt  wolfPKCS11  wolfTPM  wolfssl  xmss
-$ cd xmss
-$ git checkout 171ccbd26f098542a67eb5d2b128281c80bd71a6
-$ git apply ../../tools/xmss/0001-Patch-to-support-wolfSSL-xmss-reference-integration.patch
-```
-
-The patch creates an addendum readme, `patch_readme.md`, with further comments.
-
-Nothing more is needed beyond the patch step, as wolfBoot will handle building
-the xmss build artifacts it requires.

--- a/docs/PQ.md
+++ b/docs/PQ.md
@@ -107,9 +107,6 @@ These two hash-based PQ signature options are supported:
 - LMS: uses wolfcrypt implementation from `wc_lms.c`, and `wc_lms_impl.c`.
 - XMSS: uses wolfcrypt implementation from `wc_xmss.c`, and `wc_xmss_impl.c`.
 
-The wolfcrypt implementations are more performant and are recommended.
-The external integrations are experimental and for testing interoperability.
-
 ### LMS/HSS Config
 
 A new LMS sim example has been added here:

--- a/docs/Targets.md
+++ b/docs/Targets.md
@@ -1106,13 +1106,13 @@ This should output 3 binary files, `wolfboot.bin`, `image_v1_signed.bin` and `fa
 
 ### Hardware Setup LS1028ARDB
 
-DIP Switch Configuraiton for XSPI_NOR_BOOT:
+DIP Switch Configuration for XSPI_NOR_BOOT:
 ```
 SW2 : 0xF8 = 11111000  SW3 : 0x70 = 01110000  SW5 : 0x20 = 00100000
 Where '1' = UP/ON
 ```
 
-UART Configuraiton:
+UART Configuration:
 ```
 Baud Rate: 115200
 Data Bits: 8
@@ -1155,15 +1155,15 @@ the RCW is `0x0` and the address offset for wolboot is `0x1000`.
 
 #### Other Tools
 
-1. Make sure the memory addresses are alinged with the `.config` file.
-2. Note the important NOR flash addresses in the defualt config are as follows.
+1. Make sure the memory addresses are aligned with the `.config` file.
+2. Note the important NOR flash addresses in the default config are as follows.
 3. RCW location is offset `0x0` or `0x20000000` memory mapped.
 4. Wolfboot location is offset `0x1000` or `0x20001000` where wolfboot starts.
 5. Application location is offset `0x20000` or `0x20020000` where application code goes.
 6. Update location is offset `0x40000` or `0x20040000` where the new or updated applciaiton goes.
 7. Load Location is `0x18020100` which is OCRAM or where the applciaiton code is loaded if using RAM loading from
 8. DTS Location is
-9. Update memory locations as neeeded.
+9. Update memory locations as needed.
 
 
 ## Cortex-A53 / Raspberry PI 3 (experimental)
@@ -1251,7 +1251,7 @@ cp wolfboot_linux_raspi.bin /media/foo/boot/kernel8.img
 
 * Troubleshooting
 
-o Turn on UART for debugging to know what boot-process is going on. Chaning DEBUG_UART property in .config to 1.
+o Turn on UART for debugging to know what boot-process is going on. Changing DEBUG_UART property in .config to 1.
 ```
 DEBUG_UART?=1
 ```

--- a/include/image.h
+++ b/include/image.h
@@ -122,10 +122,10 @@ int wolfBot_get_dts_size(void *dts_addr);
         defined (WOLFBOOT_SIGN_ECC521)
 #define wolfBoot_verify_signature_primary wolfBoot_verify_signature_ecc
 #endif
-#if defined(WOLFBOOT_SIGN_LMS) || defined(WOLFBOOT_SIGN_ext_LMS)
+#if defined(WOLFBOOT_SIGN_LMS)
 #define wolfBoot_verify_signature_primary wolfBoot_verify_signature_lms
 #endif
-#if defined(WOLFBOOT_SIGN_XMSS ) || defined(WOLFBOOT_SIGN_ext_XMSS)
+#if defined(WOLFBOOT_SIGN_XMSS )
 #define wolfBoot_verify_signature_primary wolfBoot_verify_signature_xmss
 #endif
 #ifdef WOLFBOOT_SIGN_ML_DSA

--- a/options.mk
+++ b/options.mk
@@ -338,7 +338,7 @@ ifneq ($(findstring RSA4096,$(SIGN)),)
   endif
 endif
 
-ifneq (,$(filter $(SIGN), LMS ext_LMS))
+ifeq ($(SIGN),LMS)
   # For LMS the signature size is a function of the LMS parameters.
   # All five of these parms must be set in the LMS .config file:
   #   LMS_LEVELS, LMS_HEIGHT, LMS_WINTERNITZ, IMAGE_SIGNATURE_SIZE,
@@ -377,38 +377,7 @@ ifeq ($(SIGN),LMS)
   endif
 endif
 
-ifeq ($(SIGN),ext_LMS)
-  LMSDIR = lib/hash-sigs
-  KEYGEN_OPTIONS+=--lms
-  SIGN_OPTIONS+=--lms
-  CFLAGS+=-D"LMS_IMAGE_SIGNATURE_SIZE"=$(IMAGE_SIGNATURE_SIZE)
-  WOLFCRYPT_OBJS+= \
-    ./$(LMSDIR)/src/hss_verify.o \
-    ./$(LMSDIR)/src/hss_verify_inc.o \
-    ./$(LMSDIR)/src/hss_common.o \
-    ./$(LMSDIR)/src/hss_thread_single.o \
-    ./$(LMSDIR)/src/hss_zeroize.o \
-    ./$(LMSDIR)/src/lm_common.o \
-    ./$(LMSDIR)/src/lm_ots_common.o \
-    ./$(LMSDIR)/src/lm_ots_verify.o \
-    ./$(LMSDIR)/src/lm_verify.o \
-    ./$(LMSDIR)/src/endian.o \
-    ./$(LMSDIR)/src/hash.o \
-    ./$(LMSDIR)/src/sha256.o \
-    ./lib/wolfssl/wolfcrypt/src/ext_lms.o
-  CFLAGS+=-D"WOLFBOOT_SIGN_LMS" -D"WOLFSSL_HAVE_LMS" -D"HAVE_LIBLMS" \
-    -D"LMS_LEVELS=$(LMS_LEVELS)" -D"LMS_HEIGHT=$(LMS_HEIGHT)" \
-    -D"LMS_WINTERNITZ=$(LMS_WINTERNITZ)" -I$(LMSDIR)/src \
-    -D"IMAGE_SIGNATURE_SIZE"=$(IMAGE_SIGNATURE_SIZE) \
-    -D"WOLFSSL_LMS_VERIFY_ONLY"
-  ifeq ($(WOLFBOOT_SMALL_STACK),1)
-    $(error WOLFBOOT_SMALL_STACK with LMS not supported)
-  else
-    STACK_USAGE=1024
-  endif
-endif
-
-ifneq (,$(filter $(SIGN), XMSS ext_XMSS))
+ifeq ($(SIGN),XMSS)
   ifndef XMSS_PARAMS
     $(error XMSS_PARAMS not set)
   endif
@@ -434,39 +403,6 @@ ifeq ($(SIGN),XMSS)
   else
     STACK_USAGE=9352
   endif
-endif
-
-ifeq ($(SIGN),ext_XMSS)
-  # Use ext_xmss implementation.
-  XMSSDIR = lib/xmss
-  KEYGEN_OPTIONS+=--xmss
-  SIGN_OPTIONS+=--xmss
-  CFLAGS+=-D"XMSS_IMAGE_SIGNATURE_SIZE"=$(IMAGE_SIGNATURE_SIZE)
-  WOLFCRYPT_OBJS+= \
-    ./$(XMSSDIR)/params.o \
-    ./$(XMSSDIR)/thash.o \
-    ./$(XMSSDIR)/hash_address.o \
-    ./$(XMSSDIR)/wots.o \
-    ./$(XMSSDIR)/xmss.o \
-    ./$(XMSSDIR)/xmss_core_fast.o \
-    ./$(XMSSDIR)/xmss_commons.o \
-    ./$(XMSSDIR)/utils.o \
-    ./lib/wolfssl/wolfcrypt/src/ext_xmss.o
-  CFLAGS+=-D"WOLFBOOT_SIGN_XMSS" -D"WOLFSSL_HAVE_XMSS" -D"HAVE_LIBXMSS" \
-    -DWOLFBOOT_XMSS_PARAMS=\"$(XMSS_PARAMS)\" -I$(XMSSDIR) \
-    -D"IMAGE_SIGNATURE_SIZE"=$(IMAGE_SIGNATURE_SIZE) \
-    -D"WOLFSSL_XMSS_VERIFY_ONLY" -D"XMSS_VERIFY_ONLY"
-  ifeq ($(WOLFBOOT_SMALL_STACK),1)
-    $(error WOLFBOOT_SMALL_STACK with XMSS not supported)
-  else
-    STACK_USAGE=2712
-  endif
-endif
-
-# Only needed if using 3rd party integration. This can be
-# removed if ext_lms and ext_xmss are deprecated.
-ifneq (,$(filter $(SIGN), ext_LMS ext_XMSS))
-  CFLAGS  +=-DWOLFSSL_EXPERIMENTAL_SETTINGS
 endif
 
 ifeq ($(SIGN),ML_DSA)
@@ -899,14 +835,6 @@ endif
 
 ifeq ($(SIGN_ALG),)
   SIGN_ALG=$(SIGN)
-endif
-
-ifeq ($(SIGN_ALG),ext_XMSS)
-  SIGN_ALG=XMSS
-endif
-
-ifeq ($(SIGN_ALG),ext_LMS)
-  SIGN_ALG=LMS
 endif
 
 ifneq ($(KEYVAULT_OBJ_SIZE),)

--- a/tools/scripts/renode-test-update.sh
+++ b/tools/scripts/renode-test-update.sh
@@ -20,34 +20,6 @@ quit_renode() {
 
 rm -f $RENODE_UART
 
-# external LMS test
-if (echo $TEST_OPTIONS | grep "ext_LMS" &>/dev/null); then
-    # Need git.
-    apt install -y git
-
-    # Extra steps needed for external LMS support.
-    # Need to clone the hash-sigs repo, and patch it for wolfBoot build.
-    mkdir -p lib/hash-sigs/lib || exit 2
-    git clone https://github.com/cisco/hash-sigs.git lib/hash-sigs/src || exit 2
-    cd lib/hash-sigs/src && git checkout b0631b8891295bf2929e68761205337b7c031726 && \
-        git apply ../../../tools/lms/0001-Patch-to-support-wolfBoot-LMS-build.patch &&\
-        cd ../../.. || exit 2
-fi
-
-# external XMSS test
-if (echo $TEST_OPTIONS | grep "ext_XMSS" &>/dev/null); then
-    # Need git.
-    apt install -y git
-
-    # Extra steps needed for external XMSS support.
-    # Need to clone the xmss-reference repo, and patch it for wolfBoot build.
-    cd lib || exit 2
-    git clone https://github.com/XMSS/xmss-reference.git xmss || exit 2
-    cd xmss && git checkout 171ccbd26f098542a67eb5d2b128281c80bd71a6 && \
-        git apply ../../tools/xmss/0001-Patch-to-support-wolfSSL-xmss-reference-integration.patch &&\
-        cd ../../ || exit 2
-fi
-
 make keysclean
 make keytools
 make -C tools/test-expect-version

--- a/tools/test-renode.mk
+++ b/tools/test-renode.mk
@@ -86,11 +86,12 @@ ifeq ($(SIGN),RSA4096)
   SIGN_ARGS+= --rsa4096
 endif
 
-ifneq (,$(filter $(SIGN), LMS ext_LMS))
-	SIGN_ARGS+= --lms
+ifeq ($(SIGN),LMS)
+  SIGN_ARGS+= --lms
 endif
-ifneq (,$(filter $(SIGN), XMSS ext_XMSS))
-	SIGN_ARGS+= --xmss
+
+ifeq ($(SIGN),XMSS)
+  SIGN_ARGS+= --xmss
 endif
 
 ifeq ($(SIGN),ML_DSA)

--- a/tools/test.mk
+++ b/tools/test.mk
@@ -43,10 +43,10 @@ endif
 ifeq ($(SIGN),RSA4096)
 	SIGN_ARGS+= --rsa4096
 endif
-ifneq (,$(filter $(SIGN), LMS ext_LMS))
+ifeq ($(SIGN),LMS)
 	SIGN_ARGS+= --lms
 endif
-ifneq (,$(filter $(SIGN), XMSS ext_XMSS))
+ifeq ($(SIGN),XMSS)
 	SIGN_ARGS+= --xmss
 endif
 ifeq ($(SIGN),ML_DSA)


### PR DESCRIPTION
# Description

Prune external post-quantum integrations: ext_LMS, ext_XMSS.

- Removed `WOLFBOOT_SIGN_ext_LMS`, `WOLFBOOT_SIGN_ext_XMSS` from`include/image.h`. 
- Removed `ext_LMS`, `ext_XMSS` from `options.mk`.

## Testing

- Removed ext_LMS, ext_XMSS tests from `.github/workflows/`.
- Removed ext_LMS, ext_XMSS from `tools/` build scripts.

## Docs

- Updated `docs/PQ.md`, and removed references to the external integrations.
- Spelling cleanup in `docs/Targets.md`.


