### PR TITLE
Enforce USE_GCC=1 when building host tools

### DIFF
--- a/tools/bin-assemble/Makefile
+++ b/tools/bin-assemble/Makefile
@@ -3,6 +3,7 @@
 -include ../../options.mk
 
 CC=gcc
+USE_GCC=1
 CFLAGS+=-Wall -g -ggdb
 EXE=bin-assemble
 

--- a/tools/keytools/Makefile
+++ b/tools/keytools/Makefile
@@ -9,6 +9,7 @@ endif
 
 CC      = gcc
 LD      = gcc
+USE_GCC = 1
 WOLFBOOTDIR = ../..
 WOLFDIR = $(WOLFBOOTDIR)/lib/wolfssl
 CFLAGS  = -Wall -Wextra -Werror

--- a/tools/tpm/Makefile
+++ b/tools/tpm/Makefile
@@ -9,6 +9,7 @@ endif
 
 CC = gcc
 LD = gcc
+USE_GCC = 1
 WOLFBOOTDIR = ../..
 WOLFDIR = $(WOLFBOOTDIR)/lib/wolfssl/
 WOLFTPMDIR = $(WOLFBOOTDIR)/lib/wolfTPM/


### PR DESCRIPTION
Should fix issue #537 