### PR TITLE
Fix cmake keytools build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -721,6 +721,7 @@ if(NOT PYTHON_KEYTOOLS)
         lib/wolfssl/wolfcrypt/src/ecc.c
         lib/wolfssl/wolfcrypt/src/coding.c
         lib/wolfssl/wolfcrypt/src/chacha.c
+        lib/wolfssl/wolfcrypt/src/dilithium.c
         lib/wolfssl/wolfcrypt/src/ed25519.c
         lib/wolfssl/wolfcrypt/src/ed448.c
         lib/wolfssl/wolfcrypt/src/fe_operations.c
@@ -739,7 +740,11 @@ if(NOT PYTHON_KEYTOOLS)
         lib/wolfssl/wolfcrypt/src/sha256.c
         lib/wolfssl/wolfcrypt/src/sha512.c
         lib/wolfssl/wolfcrypt/src/tfm.c
+        lib/wolfssl/wolfcrypt/src/wc_lms.c
+        lib/wolfssl/wolfcrypt/src/wc_lms_impl.c
         lib/wolfssl/wolfcrypt/src/wc_port.c
+        lib/wolfssl/wolfcrypt/src/wc_xmss.c
+        lib/wolfssl/wolfcrypt/src/wc_xmss_impl.c
         lib/wolfssl/wolfcrypt/src/wolfmath.c)
 
     list(

--- a/tools/keytools/user_settings.h
+++ b/tools/keytools/user_settings.h
@@ -29,7 +29,10 @@
 #include <stdint.h>
 
 /* System */
+#ifndef WOLFBOOT_KEYTOOLS
 #define WOLFBOOT_KEYTOOLS
+#endif
+
 #define SINGLE_THREADED
 #define WOLFCRYPT_ONLY
 


### PR DESCRIPTION
New user here. :wave:  Thanks for this valuable tool!
Following the README, using cmake, I ran (starting in the wolfBoot root dir)
```
mkdir build
cd build
cmake \
  -DWOLFBOOT_TARGET=stm32f4 \
  -DBUILD_TEST_APPS=no \
  -DBUILD_IMAGE=yes \
  -DWOLFBOOT_PARTITION_BOOT_ADDRESS=0x8020000 \
  -DWOLFBOOT_SECTOR_SIZE=0x20000 -DWOLFBOOT_PARTITION_SIZE=0xD0000 \
  -DWOLFBOOT_PARTITION_UPDATE_ADDRESS=0x80F0000 \
  -DWOLFBOOT_PARTITION_SWAP_ADDRESS=0x81C0000 \
  ..
make
```
The cmake (config) step succeeds, but on the `make` (build) step, I see the following errors: 
```
[  3%] Building C object CMakeFiles/wolfboothal.dir/hal/stm32f4.c.o
[  7%] Linking C static library libwolfboothal.a
[  7%] Built target wolfboothal
[ 11%] Building signing tool
In file included from lib/wolfssl/wolfssl/wolfcrypt/settings.h:333,
                 from tools/keytools/sign.c:81:
tools/keytools/user_settings.h:32: error: "WOLFBOOT_KEYTOOLS" redefined [-Werror]
   32 | #define WOLFBOOT_KEYTOOLS
      | 
<command-line>: note: this is the location of the previous definition
cc1: all warnings being treated as errors
In file included from lib/wolfssl/wolfssl/wolfcrypt/settings.h:333,
                 from lib/wolfssl/wolfcrypt/src/asn.c:41:
tools/keytools/user_settings.h:32: error: "WOLFBOOT_KEYTOOLS" redefined [-Werror]
   32 | #define WOLFBOOT_KEYTOOLS
      | 
```
[... Total of 26 of the same error ...]

The first commit in this PR addresses these errors.  
After applying that fix, repeating the same command sequence from a clean build dir, I see these linker errors, again on the `make` step: 
```
$ make
[  3%] Building C object CMakeFiles/wolfboothal.dir/hal/stm32f4.c.o
[  7%] Linking C static library libwolfboothal.a
[  7%] Built target wolfboothal
[ 11%] Building signing tool
/usr/bin/ld: /tmp/ccWdDoG4.o: in function `FreeSignatureCtx':
asn.c:(.text+0x7231): undefined reference to `wc_dilithium_free'
/usr/bin/ld: /tmp/ccWdDoG4.o: in function `wc_CheckPrivateKey':
asn.c:(.text+0xa781): undefined reference to `wc_dilithium_init'
/usr/bin/ld: asn.c:(.text+0xa7b8): undefined reference to `wc_dilithium_set_level'
/usr/bin/ld: asn.c:(.text+0xa7d7): undefined reference to `wc_Dilithium_PrivateKeyDecode'
/usr/bin/ld: asn.c:(.text+0xa7ea): undefined reference to `wc_dilithium_free'
/usr/bin/ld: asn.c:(.text+0xa8e3): undefined reference to `wc_dilithium_import_public'
/usr/bin/ld: asn.c:(.text+0xa8f6): undefined reference to `wc_dilithium_check_key'
/usr/bin/ld: asn.c:(.text+0xa9d9): undefined reference to `wc_dilithium_set_level'
/usr/bin/ld: asn.c:(.text+0xa9f1): undefined reference to `wc_dilithium_set_level'
/usr/bin/ld: /tmp/ccWdDoG4.o: in function `ConfirmSignature.constprop.0':
asn.c:(.text+0xb106): undefined reference to `wc_dilithium_init_ex'
/usr/bin/ld: asn.c:(.text+0xb11e): undefined reference to `wc_dilithium_set_level'
/usr/bin/ld: asn.c:(.text+0xb140): undefined reference to `wc_Dilithium_PublicKeyDecode'
/usr/bin/ld: asn.c:(.text+0xb179): undefined reference to `wc_dilithium_verify_ctx_msg'
/usr/bin/ld: /tmp/ccxy63V0.o: in function `set_signature_sizes':
sign.c:(.text+0xf1): undefined reference to `wc_dilithium_init_ex'
/usr/bin/ld: sign.c:(.text+0x10e): undefined reference to `wc_dilithium_set_level'
/usr/bin/ld: sign.c:(.text+0x139): undefined reference to `wc_MlDsaKey_GetSigLen'
/usr/bin/ld: sign.c:(.text+0x3c0): undefined reference to `wc_LmsKey_Init'
/usr/bin/ld: sign.c:(.text+0x3dd): undefined reference to `wc_LmsKey_SetParameters'
/usr/bin/ld: sign.c:(.text+0x40e): undefined reference to `wc_LmsKey_GetSigLen'
/usr/bin/ld: sign.c:(.text+0x484): undefined reference to `wc_XmssKey_Init'
/usr/bin/ld: sign.c:(.text+0x49c): undefined reference to `wc_XmssKey_SetParamStr'
/usr/bin/ld: sign.c:(.text+0x4b1): undefined reference to `wc_XmssKey_GetSigLen'
/usr/bin/ld: /tmp/ccxy63V0.o: in function `sign_digest':
sign.c:(.text+0xc6a): undefined reference to `wc_dilithium_sign_msg'
/usr/bin/ld: sign.c:(.text+0xcd7): undefined reference to `wc_LmsKey_SetWriteCb'
/usr/bin/ld: sign.c:(.text+0xd44): undefined reference to `wc_XmssKey_Init'
/usr/bin/ld: sign.c:(.text+0xd7e): undefined reference to `wc_LmsKey_SetReadCb'
/usr/bin/ld: sign.c:(.text+0xd95): undefined reference to `wc_LmsKey_SetContext'
/usr/bin/ld: sign.c:(.text+0xda7): undefined reference to `wc_LmsKey_Reload'
/usr/bin/ld: sign.c:(.text+0xdc7): undefined reference to `wc_LmsKey_Sign'
/usr/bin/ld: sign.c:(.text+0xde7): undefined reference to `wc_XmssKey_SetWriteCb'
/usr/bin/ld: sign.c:(.text+0xe00): undefined reference to `wc_XmssKey_SetReadCb'
/usr/bin/ld: sign.c:(.text+0xe17): undefined reference to `wc_XmssKey_SetContext'
/usr/bin/ld: sign.c:(.text+0xe30): undefined reference to `wc_XmssKey_SetParamStr'
/usr/bin/ld: sign.c:(.text+0xe42): undefined reference to `wc_XmssKey_Reload'
/usr/bin/ld: sign.c:(.text+0xe62): undefined reference to `wc_XmssKey_Sign'
/usr/bin/ld: /tmp/ccxy63V0.o: in function `load_key.constprop.0':
sign.c:(.text+0x1732): undefined reference to `wc_MlDsaKey_GetPubLen'
/usr/bin/ld: sign.c:(.text+0x1754): undefined reference to `wc_MlDsaKey_GetPrivLen'
/usr/bin/ld: sign.c:(.text+0x180c): undefined reference to `wc_XmssKey_GetPrivLen'
/usr/bin/ld: sign.c:(.text+0x1f02): undefined reference to `wc_dilithium_import_private'
/usr/bin/ld: /tmp/ccxy63V0.o: in function `main':
sign.c:(.text.startup+0x877): undefined reference to `wc_dilithium_free'
/usr/bin/ld: sign.c:(.text.startup+0xd69): undefined reference to `wc_LmsKey_Free'
/usr/bin/ld: sign.c:(.text.startup+0xd7a): undefined reference to `wc_XmssKey_Free'
collect2: error: ld returned 1 exit status
make[2]: *** [CMakeFiles/keytools.dir/build.make:78: sign] Error 1
make[1]: *** [CMakeFiles/Makefile2:180: CMakeFiles/keytools.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
```

So I went through finding where these missing functions are defined, and added those 5 files to the WOLFBOOT_KEYTOOL_SRCS list.  (the second commit).  
With this second fix also applied, the build succeeds with the following output:  
```
$ make
[  3%] Building C object CMakeFiles/wolfboothal.dir/hal/stm32f4.c.o
[  7%] Linking C static library libwolfboothal.a
[  7%] Built target wolfboothal
[ 11%] Building signing tool
[ 14%] Building keygen tool
[ 14%] Built target keytools
[ 18%] Generating keystore.c and signing private key
Keystore size: 2608
Keytype: ECC256
Generating key (type: ECC256)
Associated key file:   /home/rileyt/repos/xmc-ota/deps/wolfBoot/build/wolfboot_signing_private_key.der
Partition ids mask:   ffffffff
Key type   :           ECC256
Public key slot:       0
Done.
[ 22%] Building C object CMakeFiles/public_key.dir/keystore.c.o
[ 25%] Linking C static library libpublic_key.a
[ 29%] Built target public_key
[ 33%] Building C object lib/CMakeFiles/wolfcrypt.dir/wolfssl/wolfcrypt/src/integer.c.o
[ 37%] Building C object lib/CMakeFiles/wolfcrypt.dir/wolfssl/wolfcrypt/src/tfm.c.o
[ 40%] Building C object lib/CMakeFiles/wolfcrypt.dir/wolfssl/wolfcrypt/src/ecc.c.o
[ 44%] Building C object lib/CMakeFiles/wolfcrypt.dir/wolfssl/wolfcrypt/src/memory.c.o
[ 48%] Building C object lib/CMakeFiles/wolfcrypt.dir/wolfssl/wolfcrypt/src/wc_port.c.o
[ 51%] Building C object lib/CMakeFiles/wolfcrypt.dir/wolfssl/wolfcrypt/src/wolfmath.c.o
[ 55%] Building C object lib/CMakeFiles/wolfcrypt.dir/wolfssl/wolfcrypt/src/hash.c.o
[ 59%] Building C object lib/CMakeFiles/wolfcrypt.dir/wolfssl/wolfcrypt/src/sha256.c.o
[ 62%] Linking C static library libwolfcrypt.a
[ 62%] Built target wolfcrypt
[ 66%] Building C object CMakeFiles/wolfboot.dir/src/libwolfboot.c.o
[ 70%] Linking C static library libwolfboot.a
[ 70%] Built target wolfboot
[ 74%] Building C object test-app/CMakeFiles/wolfboot_stm32f4.dir/__/src/string.c.o
[ 77%] Building C object test-app/CMakeFiles/wolfboot_stm32f4.dir/__/src/image.c.o
[ 81%] Building C object test-app/CMakeFiles/wolfboot_stm32f4.dir/__/src/loader.c.o
[ 85%] Building C object test-app/CMakeFiles/wolfboot_stm32f4.dir/__/src/boot_arm.c.o
[ 88%] Building C object test-app/CMakeFiles/wolfboot_stm32f4.dir/__/src/update_flash.c.o
[ 92%] Linking C executable wolfboot_stm32f4
[ 92%] Built target wolfboot_stm32f4
[ 96%] Generating wolfboot_stm32f4.bin
[100%] Generating wolfboot_stm32f4.size
   text    data     bss     dec     hex filename
  41392       0      44   41436    a1dc /home/rileyt/repos/xmc-ota/deps/wolfBoot/build/test-app/wolfboot_stm32f4
[100%] Built target wolfboot_stm32f4_outputs
```

Hope this helps.