### PR TITLE
Fix for documented option bytes on STM32H5 with TrustZone enabled

### DIFF
--- a/docs/STM32-TZ.md
+++ b/docs/STM32-TZ.md
@@ -182,8 +182,8 @@ OPTION BYTES BANK: 4
 
    Bank2 - Flash watermark area definition:
 
-     SECWM2_STRT  : 0x7F  (0x81FE000)
-     SECWM2_END   : 0x0  (0x8100000)
+     SECWM2_STRT  : 0x0  (0x08100000)
+     SECWM2_END   : 0x1F  (0x0813e000)
 
    Write sector group protection 2:
 


### PR DESCRIPTION
Fix for documented option bytes on STM32H5 with TrustZone enabled. Flash bank 2 watermark (SECWM2_STRT=0x0 and SECWM2_END=0x1F). ZD 20037