### PR TITLE
Fixed unaligned access report by user (Cortex-A5)

### DIFF
--- a/arch.mk
+++ b/arch.mk
@@ -272,7 +272,8 @@ ifeq ($(ARCH),ARM)
 
 ifeq ($(CORTEX_A5),1)
   FPU=-mfpu=vfp4-d16
-  CFLAGS+=-mcpu=cortex-a5  -mtune=cortex-a5 -static -z noexecstack
+  CFLAGS+=-mcpu=cortex-a5  -mtune=cortex-a5 -static -z noexecstack \
+		  -mno-unaligned-access
   LDLAGS+=-mcpu=cortex-a5 -mtune=cortex-a5  -mtune=cortex-a5 -static \
           -z noexecstack  -Ttext 0x300000
   # Cortex-A uses boot_arm32.o


### PR DESCRIPTION
As reported in ZD 20152, this flag is needed to prevent unaligned access when running integrity check.
