### PR TITLE
Refactor Makefiles to allow overriding library  paths

### DIFF
--- a/.github/workflows/test-external-library-paths.yml
+++ b/.github/workflows/test-external-library-paths.yml
@@ -1,0 +1,89 @@
+name: Test External Library Paths
+
+on:
+  push:
+    branches: [ 'master', 'main', 'release/**' ]
+  pull_request:
+    branches: [ '*' ]
+  workflow_dispatch:
+
+jobs:
+  test_external_libs:
+    runs-on: ubuntu-latest
+
+    # Matrix to test multiple configurations
+    strategy:
+      matrix:
+        test-config:
+          - name: "External wolfSSL"
+            config: "config/examples/sim.config"
+
+          - name: "External wolfTPM"
+            config: "config/examples/sim-tpm.config"
+            build-tpm-tools: true
+
+          - name: "external wolfHSM"
+            config: "config/examples/sim-wolfHSM-client.config"
+
+          - name: "Unit tests"
+            config: ""
+            is-unit-test: true
+
+      fail-fast: false
+
+    steps:
+      # Checkout wolfBoot with submodules
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      # Move libraries outside the wolfBoot tree
+      - name: Relocate libraries to external path
+        run: |
+          echo "=== Moving libraries outside wolfBoot tree ==="
+          mv lib ../external-libs
+          ls -la ../external-libs/
+          echo "Libraries moved to ../external-libs"
+
+      # Select configuration (skip for unit tests)
+      - name: Select config
+        if: matrix.test-config.config != ''
+        run: |
+          cp ${{ matrix.test-config.config }} .config
+          echo "=== Selected config: ${{ matrix.test-config.name }} ==="
+
+      # Build TPM tools if needed
+      - name: Build TPM tools with external paths
+        if: matrix.test-config.build-tpm-tools == true
+        run: |
+          echo "=== Building TPM tools with external paths ==="
+          make tpmtools \
+            WOLFBOOT_LIB_WOLFSSL=$(realpath ../external-libs/wolfssl) \
+            WOLFBOOT_LIB_WOLFTPM=$(realpath ../external-libs/wolfTPM)
+
+      # Build main target (skip for unit tests)
+      - name: Build wolfBoot with external library paths
+        if: matrix.test-config.is-unit-test != true
+        run: |
+          echo "=== Building wolfBoot with external paths ==="
+          make clean
+          make \
+            WOLFBOOT_LIB_WOLFSSL="$(realpath ../external-libs/wolfssl)" \
+            WOLFBOOT_LIB_WOLFTPM="$(realpath ../external-libs/wolfTPM)" \
+            WOLFBOOT_LIB_WOLFPKCS11="$(realpath ../external-libs/wolfPKCS11)" \
+            WOLFBOOT_LIB_WOLFHSM="$(realpath ../external-libs/wolfHSM)"
+
+      # If building unit tests, install libcheck
+      - name: install libcheck
+        if: matrix.test-config.is-unit-test == true
+        run: sudo apt-get install --no-install-recommends -y -q check
+
+
+      # Build unit tests with external paths
+      - name: Build unit tests with external library paths
+        if: matrix.test-config.is-unit-test == true
+        run: |
+          echo "=== Building unit tests with external paths ==="
+          make -C tools/unit-tests \
+            WOLFBOOT_LIB_WOLFSSL="$(realpath ../external-libs/wolfssl)" \
+            WOLFBOOT_LIB_WOLFPKCS11="$(realpath ../external-libs/wolfPKCS11)"

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,26 @@ ifneq ("$(NO_LOADER)","1")
   OBJS+=./src/loader.o
 endif
 
+## Library Path Configuration
+# Default paths for wolf* submodules - can be overridden with absolute or relative paths
+# Convert all paths to absolute paths for consistent handling across sub-makefiles
+WOLFBOOT_LIB_WOLFSSL?=lib/wolfssl
+WOLFBOOT_LIB_WOLFTPM?=lib/wolfTPM
+WOLFBOOT_LIB_WOLFPKCS11?=lib/wolfPKCS11
+WOLFBOOT_LIB_WOLFHSM?=lib/wolfHSM
+
+# Convert to absolute paths using abspath function
+WOLFBOOT_LIB_WOLFSSL:=$(abspath $(WOLFBOOT_LIB_WOLFSSL))
+WOLFBOOT_LIB_WOLFTPM:=$(abspath $(WOLFBOOT_LIB_WOLFTPM))
+WOLFBOOT_LIB_WOLFPKCS11:=$(abspath $(WOLFBOOT_LIB_WOLFPKCS11))
+WOLFBOOT_LIB_WOLFHSM:=$(abspath $(WOLFBOOT_LIB_WOLFHSM))
+
+# Export variables so they are available to sub-makefiles
+export WOLFBOOT_LIB_WOLFSSL
+export WOLFBOOT_LIB_WOLFTPM
+export WOLFBOOT_LIB_WOLFPKCS11
+export WOLFBOOT_LIB_WOLFHSM
+
 ## Architecture/CPU configuration
 include arch.mk
 
@@ -70,7 +90,7 @@ OBJS+=$(PUBLIC_KEY_OBJS)
 OBJS+=$(WOLFHSM_OBJS)
 
 CFLAGS+= \
-  -I"." -I"include/" -I"lib/wolfssl" \
+  -I"." -I"include/" -I"$(WOLFBOOT_LIB_WOLFSSL)" \
   -Wno-array-bounds \
   -D"WOLFSSL_USER_SETTINGS" \
   -D"WOLFTPM_USER_SETTINGS"
@@ -364,8 +384,8 @@ keys: $(PRIVATE_KEY)
 
 clean:
 	$(Q)rm -f src/*.o hal/*.o hal/spi/*.o test-app/*.o src/x86/*.o
-	$(Q)rm -f lib/wolfssl/wolfcrypt/src/*.o lib/wolfTPM/src/*.o lib/wolfTPM/hal/*.o lib/wolfTPM/examples/pcr/*.o
-	$(Q)rm -f lib/wolfssl/wolfcrypt/src/port/Renesas/*.o
+	$(Q)rm -f $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/*.o $(WOLFBOOT_LIB_WOLFTPM)/src/*.o $(WOLFBOOT_LIB_WOLFTPM)/hal/*.o $(WOLFBOOT_LIB_WOLFTPM)/examples/pcr/*.o
+	$(Q)rm -f $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/port/Renesas/*.o
 	$(Q)rm -f wolfboot.bin wolfboot.elf wolfboot.map test-update.rom wolfboot.hex
 	$(Q)rm -f $(MACHINE_OBJ) $(MAIN_TARGET) $(LSCRIPT)
 	$(Q)rm -f $(OBJS)

--- a/arch.mk
+++ b/arch.mk
@@ -1,21 +1,18 @@
 ## CPU Architecture selection via $ARCH
 
-# Global reference to lib directory that works with relative paths
-LIBDIR := $(dir $(lastword $(MAKEFILE_LIST)))lib
-
 # check for math library
 ifeq ($(SPMATH),1)
   # SP Math
-  MATH_OBJS:=./lib/wolfssl/wolfcrypt/src/sp_int.o
+  MATH_OBJS:=$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/sp_int.o
 else
   ifeq ($(SPMATHALL),1)
     # SP Math all
     CFLAGS+=-DWOLFSSL_SP_MATH_ALL
-    MATH_OBJS:=./lib/wolfssl/wolfcrypt/src/sp_int.o
+    MATH_OBJS:=$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/sp_int.o
   else
     # Fastmath
     CFLAGS+=-DUSE_FAST_MATH
-    MATH_OBJS:=./lib/wolfssl/wolfcrypt/src/integer.o ./lib/wolfssl/wolfcrypt/src/tfm.o
+    MATH_OBJS:=$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/integer.o $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/tfm.o
   endif
 endif
 
@@ -29,11 +26,11 @@ SPI_TARGET=$(TARGET)
 UART_TARGET=$(TARGET)
 
 # Include some modules by default
-WOLFCRYPT_OBJS+=./lib/wolfssl/wolfcrypt/src/sha256.o \
-                ./lib/wolfssl/wolfcrypt/src/hash.o \
-                ./lib/wolfssl/wolfcrypt/src/memory.o \
-                ./lib/wolfssl/wolfcrypt/src/wc_port.o \
-                ./lib/wolfssl/wolfcrypt/src/wolfmath.o
+WOLFCRYPT_OBJS+=$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/sha256.o \
+                $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/hash.o \
+                $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/memory.o \
+                $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/wc_port.o \
+                $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/wolfmath.o
 
 
 ifeq ($(ARCH),x86_64)
@@ -45,13 +42,13 @@ ifeq ($(ARCH),x86_64)
   ifeq ($(SPMATH),1)
     ifeq ($(NO_ASM),1)
       ifeq ($(FORCE_32BIT),1)
-        MATH_OBJS += ./lib/wolfssl/wolfcrypt/src/sp_c32.o
+        MATH_OBJS += $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/sp_c32.o
         CFLAGS+=-DWOLFSSL_SP_DIV_WORD_HALF
       else
-        MATH_OBJS += ./lib/wolfssl/wolfcrypt/src/sp_c64.o
+        MATH_OBJS += $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/sp_c64.o
       endif
     else
-      MATH_OBJS += ./lib/wolfssl/wolfcrypt/src/sp_x86_64.o
+      MATH_OBJS += $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/sp_x86_64.o
     endif
   endif
   ifeq ($(TARGET),x86_64_efi)
@@ -101,18 +98,18 @@ ifeq ($(ARCH),AARCH64)
   endif
 
   ifeq ($(SPMATH),1)
-    MATH_OBJS += ./lib/wolfssl/wolfcrypt/src/sp_c32.o
-    MATH_OBJS += ./lib/wolfssl/wolfcrypt/src/sp_arm64.o
+    MATH_OBJS += $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/sp_c32.o
+    MATH_OBJS += $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/sp_arm64.o
   endif
   ifeq ($(NO_ARM_ASM),0)
     ARCH_FLAGS=-mstrict-align
     CFLAGS+=$(ARCH_FLAGS) -DWOLFSSL_ARMASM -DWOLFSSL_ARMASM_INLINE -DWC_HASH_DATA_ALIGNMENT=8 -DWOLFSSL_AARCH64_PRIVILEGE_MODE
-    WOLFCRYPT_OBJS += lib/wolfssl/wolfcrypt/src/cpuid.o \
-                      lib/wolfssl/wolfcrypt/src/port/arm/armv8-sha256.o \
-                      lib/wolfssl/wolfcrypt/src/port/arm/armv8-sha512.o \
-                      lib/wolfssl/wolfcrypt/src/port/arm/armv8-aes.o \
-                      lib/wolfssl/wolfcrypt/src/port/arm/armv8-sha512-asm_c.o \
-                      lib/wolfssl/wolfcrypt/src/port/arm/armv8-sha3-asm_c.o
+    WOLFCRYPT_OBJS += $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/cpuid.o \
+                      $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/port/arm/armv8-sha256.o \
+                      $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/port/arm/armv8-sha512.o \
+                      $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/port/arm/armv8-aes.o \
+                      $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/port/arm/armv8-sha512-asm_c.o \
+                      $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/port/arm/armv8-sha3-asm_c.o
   endif
 endif
 
@@ -196,7 +193,7 @@ ifeq ($(ARCH),ARM)
     ARCH_FLASH_OFFSET=0x08000000
     SPI_TARGET=stm32
     ifneq ($(PKA),0)
-      PKA_EXTRA_OBJS+= $(STM32CUBE)/Drivers/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_pka.o  ./lib/wolfssl/wolfcrypt/src/port/st/stm32.o
+      PKA_EXTRA_OBJS+= $(STM32CUBE)/Drivers/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_pka.o  $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/port/st/stm32.o
       PKA_EXTRA_CFLAGS+=-DWOLFSSL_STM32_PKA -I$(STM32CUBE)/Drivers/STM32WBxx_HAL_Driver/Inc \
           -Isrc -I$(STM32CUBE)/Drivers/BSP/P-NUCLEO-WB55.Nucleo/ -I$(STM32CUBE)/Drivers/CMSIS/Device/ST/STM32WBxx/Include \
           -I$(STM32CUBE)/Drivers/STM32WBxx_HAL_Driver/Inc/ \
@@ -283,13 +280,13 @@ ifeq ($(CORTEX_A5),1)
   # Cortex-A uses boot_arm32.o
   OBJS+=src/boot_arm32.o src/boot_arm32_start.o
   ifeq ($(NO_ASM),1)
-    MATH_OBJS+=./lib/wolfssl/wolfcrypt/src/sp_c32.o
+    MATH_OBJS+=$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/sp_c32.o
   else
-    MATH_OBJS+=./lib/wolfssl/wolfcrypt/src/sp_arm32.o
+    MATH_OBJS+=$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/sp_arm32.o
     ifneq ($(NO_ARM_ASM),1)
-      OBJS+=./lib/wolfssl/wolfcrypt/src/port/arm/armv8-sha256.o
-      OBJS+=./lib/wolfssl/wolfcrypt/src/port/arm/armv8-32-sha256-asm.o
-      OBJS+=./lib/wolfssl/wolfcrypt/src/port/arm/armv8-32-sha256-asm_c.o
+      OBJS+=$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/port/arm/armv8-sha256.o
+      OBJS+=$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/port/arm/armv8-32-sha256-asm.o
+      OBJS+=$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/port/arm/armv8-32-sha256-asm_c.o
       CFLAGS+=-DWOLFSSL_SP_ARM32_ASM -DWOLFSSL_ARMASM -DWOLFSSL_ARMASM_NO_HW_CRYPTO \
               -DWOLFSSL_ARM_ARCH=7 -DWOLFSSL_ARMASM_INLINE -DWOLFSSL_ARMASM_NO_NEON
     endif
@@ -299,20 +296,20 @@ else
   OBJS+=src/boot_arm.o
   ifneq ($(NO_ARM_ASM),1)
     CORTEXM_ARM_EXTRA_OBJS= \
-          ./lib/wolfssl/wolfcrypt/src/port/arm/armv8-aes.o \
-          ./lib/wolfssl/wolfcrypt/src/port/arm/armv8-chacha.o \
-          ./lib/wolfssl/wolfcrypt/src/port/arm/armv8-sha256.o \
-          ./lib/wolfssl/wolfcrypt/src/port/arm/armv8-sha512.o \
-          ./lib/wolfssl/wolfcrypt/src/port/arm/thumb2-aes-asm.o \
-          ./lib/wolfssl/wolfcrypt/src/port/arm/thumb2-aes-asm_c.o \
-          ./lib/wolfssl/wolfcrypt/src/port/arm/thumb2-sha256-asm.o \
-          ./lib/wolfssl/wolfcrypt/src/port/arm/thumb2-sha256-asm_c.o \
-          ./lib/wolfssl/wolfcrypt/src/port/arm/thumb2-sha512-asm.o \
-          ./lib/wolfssl/wolfcrypt/src/port/arm/thumb2-sha512-asm_c.o \
-          ./lib/wolfssl/wolfcrypt/src/port/arm/thumb2-sha3-asm.o \
-          ./lib/wolfssl/wolfcrypt/src/port/arm/thumb2-sha3-asm_c.o \
-          ./lib/wolfssl/wolfcrypt/src/port/arm/thumb2-chacha-asm.o \
-          ./lib/wolfssl/wolfcrypt/src/port/arm/thumb2-chacha-asm_c.o
+          $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/port/arm/armv8-aes.o \
+          $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/port/arm/armv8-chacha.o \
+          $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/port/arm/armv8-sha256.o \
+          $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/port/arm/armv8-sha512.o \
+          $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/port/arm/thumb2-aes-asm.o \
+          $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/port/arm/thumb2-aes-asm_c.o \
+          $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/port/arm/thumb2-sha256-asm.o \
+          $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/port/arm/thumb2-sha256-asm_c.o \
+          $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/port/arm/thumb2-sha512-asm.o \
+          $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/port/arm/thumb2-sha512-asm_c.o \
+          $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/port/arm/thumb2-sha3-asm.o \
+          $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/port/arm/thumb2-sha3-asm_c.o \
+          $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/port/arm/thumb2-chacha-asm.o \
+          $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/port/arm/thumb2-chacha-asm_c.o
 
 
     CORTEXM_ARM_EXTRA_CFLAGS+=-DWOLFSSL_ARMASM -DWOLFSSL_ARMASM_NO_HW_CRYPTO \
@@ -336,10 +333,10 @@ else
     endif # TZEN=1
       ifeq ($(SPMATH),1)
         ifeq ($(NO_ASM),1)
-          MATH_OBJS += ./lib/wolfssl/wolfcrypt/src/sp_c32.o
+          MATH_OBJS += $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/sp_c32.o
         else
           CFLAGS+=-DWOLFSSL_SP_ASM -DWOLFSSL_SP_ARM_CORTEX_M_ASM
-          MATH_OBJS += ./lib/wolfssl/wolfcrypt/src/sp_cortexm.o
+          MATH_OBJS += $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/sp_cortexm.o
           CFLAGS+=$(CORTEXM_ARM_EXTRA_CFLAGS) -DWOLFSSL_ARM_ARCH=8
           OBJS+=$(CORTEXM_ARM_EXTRA_OBJS)
         endif
@@ -350,10 +347,10 @@ else
       LDFLAGS+=-mcpu=cortex-m7
       ifeq ($(SPMATH),1)
         ifeq ($(NO_ASM),1)
-          MATH_OBJS += ./lib/wolfssl/wolfcrypt/src/sp_c32.o
+          MATH_OBJS += $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/sp_c32.o
         else
           CFLAGS+=-DWOLFSSL_SP_ASM -DWOLFSSL_SP_ARM_CORTEX_M_ASM
-          MATH_OBJS += ./lib/wolfssl/wolfcrypt/src/sp_cortexm.o
+          MATH_OBJS += $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/sp_cortexm.o
           CFLAGS+=$(CORTEXM_ARM_EXTRA_CFLAGS) -DWOLFSSL_ARM_ARCH=7
           OBJS+=$(CORTEXM_ARM_EXTRA_OBJS)
         endif
@@ -364,10 +361,10 @@ else
         LDFLAGS+=-mcpu=cortex-m0
         ifeq ($(SPMATH),1)
           ifeq ($(NO_ASM),1)
-            MATH_OBJS += ./lib/wolfssl/wolfcrypt/src/sp_c32.o
+            MATH_OBJS += $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/sp_c32.o
           else
             CFLAGS+=-DWOLFSSL_SP_ASM -DWOLFSSL_SP_ARM_THUMB_ASM
-            MATH_OBJS += ./lib/wolfssl/wolfcrypt/src/sp_armthumb.o
+            MATH_OBJS += $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/sp_armthumb.o
             # No ARMASM support available for ARMv6-M.
           endif
         endif
@@ -377,12 +374,12 @@ else
           LDFLAGS+=-mcpu=cortex-m3
           ifeq ($(NO_ASM),1)
             ifeq ($(SPMATH),1)
-              MATH_OBJS += ./lib/wolfssl/wolfcrypt/src/sp_c32.o
+              MATH_OBJS += $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/sp_c32.o
             endif
           else
             ifeq ($(SPMATH),1)
               CFLAGS+=-DWOLFSSL_SP_ASM -DWOLFSSL_SP_ARM_CORTEX_M_ASM -DWOLFSSL_SP_NO_UMAAL
-              MATH_OBJS += ./lib/wolfssl/wolfcrypt/src/sp_cortexm.o
+              MATH_OBJS += $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/sp_cortexm.o
               CFLAGS+=$(CORTEXM_ARM_EXTRA_CFLAGS) -DWOLFSSL_ARM_ARCH=7
               OBJS+=$(CORTEXM_ARM_EXTRA_OBJS)
             endif
@@ -393,13 +390,13 @@ else
         LDFLAGS+=-mcpu=cortex-m4
         ifeq ($(NO_ASM),1)
           ifeq ($(SPMATH),1)
-            MATH_OBJS += ./lib/wolfssl/wolfcrypt/src/sp_c32.o
+            MATH_OBJS += $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/sp_c32.o
           endif
         else
           CFLAGS+=-fomit-frame-pointer # required with debug builds only
           ifeq ($(SPMATH),1)
             CFLAGS+=-DWOLFSSL_SP_ASM -DWOLFSSL_SP_ARM_CORTEX_M_ASM
-            MATH_OBJS += ./lib/wolfssl/wolfcrypt/src/sp_cortexm.o
+            MATH_OBJS += $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/sp_cortexm.o
             CFLAGS+=$(CORTEXM_ARM_EXTRA_CFLAGS) -DWOLFSSL_ARM_ARCH=7
             OBJS+=$(CORTEXM_ARM_EXTRA_OBJS)
           endif
@@ -446,7 +443,7 @@ ifeq ($(ARCH),RENESAS_RX)
   # Renesas specific files
   OBJS+=src/boot_renesas.o src/boot_renesas_start.o hal/renesas-rx.o
   ifeq ($(SPMATH),1)
-    MATH_OBJS += ./lib/wolfssl/wolfcrypt/src/sp_c32.o
+    MATH_OBJS += $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/sp_c32.o
   endif
 
   # RX parts support big or little endian data depending on MDE register
@@ -473,10 +470,10 @@ ifeq ($(ARCH),RENESAS_RX)
     CFLAGS+=-DWOLFBOOT_RENESAS_TSIP
     RX_DRIVER_PATH?=./lib
 
-    OBJS+=./lib/wolfssl/wolfcrypt/src/cryptocb.o \
-          ./lib/wolfssl/wolfcrypt/src/port/Renesas/renesas_common.o \
-          ./lib/wolfssl/wolfcrypt/src/port/Renesas/renesas_tsip_util.o \
-          ./lib/wolfssl/wolfcrypt/src/port/Renesas/renesas_tsip_aes.o
+    OBJS+=$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/cryptocb.o \
+          $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/port/Renesas/renesas_common.o \
+          $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/port/Renesas/renesas_tsip_util.o \
+          $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/port/Renesas/renesas_tsip_aes.o
 
     # RX TSIP uses pre-compiled .a library by default
     ifneq ($(RX_TSIP_SRC),1)
@@ -527,7 +524,7 @@ ifeq ($(ARCH),RENESAS_RX)
       OBJS+=$(RX_DRIVER_PATH)/r_bsp/mcu/rx72n/mcu_interrupts.o
     endif
 
-    CFLAGS+=-Ihal -I./lib/wolfssl \
+    CFLAGS+=-Ihal -I$(WOLFBOOT_LIB_WOLFSSL) \
             -I$(RX_DRIVER_PATH)/r_bsp \
             -I$(RX_DRIVER_PATH)/r_config \
             -I$(RX_DRIVER_PATH)/r_tsip_rx \
@@ -541,7 +538,7 @@ ifeq ($(ARCH),RISCV)
   CROSS_COMPILE?=riscv32-unknown-elf-
   CFLAGS+=-fno-builtin-printf -DUSE_M_TIME -g -march=rv32imac -mabi=ilp32 -mcmodel=medany -nostartfiles -DARCH_RISCV
   LDFLAGS+=-march=rv32imac -mabi=ilp32 -mcmodel=medany
-  MATH_OBJS += ./lib/wolfssl/wolfcrypt/src/sp_c32.o
+  MATH_OBJS += $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/sp_c32.o
 
   # Prune unused functions and data
   CFLAGS +=-ffunction-sections -fdata-sections
@@ -568,7 +565,7 @@ ifeq ($(ARCH),PPC)
   OBJS+=src/boot_ppc_start.o src/boot_ppc.o
 
   ifeq ($(SPMATH),1)
-    MATH_OBJS += ./lib/wolfssl/wolfcrypt/src/sp_c32.o
+    MATH_OBJS += $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/sp_c32.o
   endif
 
   ifneq ($(NO_ASM),1)
@@ -576,7 +573,7 @@ ifeq ($(ARCH),PPC)
     CFLAGS+=-DWOLFSSL_SP_PPC
     CFLAGS+=-DWOLFSSL_PPC32_ASM -DWOLFSSL_PPC32_ASM_INLINE
     #CFLAGS+=-DWOLFSSL_PPC32_ASM_SMALL
-    MATH_OBJS+=./lib/wolfssl/wolfcrypt/src/port/ppc32/ppc32-sha256-asm_c.o
+    MATH_OBJS+=$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/port/ppc32/ppc32-sha256-asm_c.o
   endif
 endif
 
@@ -616,7 +613,7 @@ ifeq ($(TARGET),kinetis)
   ifeq ($(MCUXPRESSO_CPU),MK82FN256VLL15)
     ifeq ($(PKA),1)
       PKA_EXTRA_CFLAGS+=-DFREESCALE_USE_LTC
-      PKA_EXTRA_OBJS+=./lib/wolfssl/wolfcrypt/src/port/nxp/ksdk_port.o
+      PKA_EXTRA_OBJS+=$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/port/nxp/ksdk_port.o
       ifeq ($(MCUXSDK),1)
         PKA_EXTRA_OBJS+=$(MCUXPRESSO)/drivers/ltc/fsl_ltc.o
       else
@@ -773,7 +770,7 @@ ifeq ($(TARGET),imx_rt)
     else
       PKA_EXTRA_OBJS+= $(MCUXPRESSO_DRIVERS)/drivers/fsl_dcp.o
     endif
-    PKA_EXTRA_OBJS+=./lib/wolfssl/wolfcrypt/src/port/nxp/dcp_port.o
+    PKA_EXTRA_OBJS+=$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/port/nxp/dcp_port.o
     PKA_EXTRA_CFLAGS+=\
         -DWOLFSSL_IMXRT_DCP \
         -I$(MCUXPRESSO)/drivers/cache/armv7-m7 \
@@ -785,7 +782,7 @@ endif
 ifeq ($(ARCH),ARM_BE)
   OBJS+=src/boot_arm.o
   ifeq ($(SPMATH),1)
-    MATH_OBJS += ./lib/wolfssl/wolfcrypt/src/sp_c32.o
+    MATH_OBJS += $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/sp_c32.o
   endif
 endif
 
@@ -928,7 +925,7 @@ ifeq ($(TARGET),psoc6)
         $(CYPRESS_PDL)/drivers/source/TOOLCHAIN_GCC_ARM/cy_syslib_gcc.o \
         $(CYPRESS_PDL)/devices/templates/COMPONENT_MTB/COMPONENT_CM0P/system_psoc6_cm0plus.o
     PSOC6_CRYPTO_OBJS=\
-        ./lib/wolfssl/wolfcrypt/src/port/cypress/psoc6_crypto.o \
+        $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/port/cypress/psoc6_crypto.o \
         $(CYPRESS_PDL)/drivers/source/cy_crypto_core_vu.o \
         $(CYPRESS_PDL)/drivers/source/cy_crypto_core_ecc_domain_params.o \
         $(CYPRESS_PDL)/drivers/source/cy_crypto_core_ecc_nist_p.o \
@@ -1126,11 +1123,11 @@ ifeq ($(ARCH),sim)
     LDFLAGS+=-m32
   endif
   ifeq ($(SPMATH),1)
-    MATH_OBJS += ./lib/wolfssl/wolfcrypt/src/sp_c32.o
+    MATH_OBJS += $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/sp_c32.o
     CFLAGS+=-DWOLFSSL_SP_DIV_WORD_HALF
   endif
   ifeq ($(WOLFHSM_CLIENT),1)
-    WOLFHSM_OBJS += $(LIBDIR)/wolfHSM/port/posix/posix_transport_tcp.o
+    WOLFHSM_OBJS += $(WOLFBOOT_LIB_WOLFHSM)/port/posix/posix_transport_tcp.o
   endif
 endif
 
@@ -1170,7 +1167,7 @@ CFLAGS+=-DWOLFBOOT_ORIGIN=$(WOLFBOOT_ORIGIN)
 CFLAGS+=-DBOOTLOADER_PARTITION_SIZE=$(BOOTLOADER_PARTITION_SIZE)
 
 ## Debug
-WOLFCRYPT_OBJS+=./lib/wolfssl/wolfcrypt/src/logging.o
+WOLFCRYPT_OBJS+=$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/logging.o
 
 # Debug UART
 ifeq ($(DEBUG_UART),1)

--- a/docs/compile.md
+++ b/docs/compile.md
@@ -343,3 +343,17 @@ LC_ALL=
 
 Then run the normal `make` steps.
 
+### Building Against Alternate Library Dependency Versions
+
+wolfBoot includes its internal dependencies (all official wolfSSL projects) as git submodules under `lib/`, ensuring known-compatible versions. You may override these paths with `WOLFBOOT_LIB_XXX` environment variables to point to local copies of the libraries.
+
+This mechanism exists mainly for internal use and is NOT RECOMMENDED, as mismatched versions can cause build failures or subtle bugs.
+
+Note that all paths MUST be supplied to the Makefiles as absolute paths.
+
+Available overrides:
+
+- `WOLFBOOT_LIB_WOLFSSL`: Path to the [wolfSSL](https://github.com/wolfSSL/wolfssl) library source code
+- `WOLFBOOT_LIB_WOLFTPM`: Path to the [wolfTPM](https://github.com/wolfSSL/wolfTPM) library source code
+- `WOLFBOOT_LIB_WOLFPKCS11`: Path to the [wolfPKCS11](https://github.com/wolfssl/wolfpkcs11) library source code
+- `WOLFBOOT_LIB_WOLFHSM`: Path to the [wolfHSM](https://github.com/wolfSSL/wolfHSM) library source code

--- a/options.mk
+++ b/options.mk
@@ -1,4 +1,4 @@
-WOLFCRYPT_OBJS+=./lib/wolfssl/wolfcrypt/src/asn.o
+WOLFCRYPT_OBJS+=$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/asn.o
 USE_GCC?=1
 
 # Support for Built-in ROT into OTP flash memory
@@ -73,26 +73,26 @@ endif
 
 
 ECC_OBJS= \
-    ./lib/wolfssl/wolfcrypt/src/ecc.o
+    $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/ecc.o
 
-ED25519_OBJS=./lib/wolfssl/wolfcrypt/src/sha512.o \
-    ./lib/wolfssl/wolfcrypt/src/ed25519.o \
-    ./lib/wolfssl/wolfcrypt/src/ge_low_mem.o \
-    ./lib/wolfssl/wolfcrypt/src/fe_low_mem.o
+ED25519_OBJS=$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/sha512.o \
+    $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/ed25519.o \
+    $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/ge_low_mem.o \
+    $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/fe_low_mem.o
 
-ED448_OBJS=./lib/wolfssl/wolfcrypt/src/ed448.o \
-    ./lib/wolfssl/wolfcrypt/src/ge_low_mem.o \
-    ./lib/wolfssl/wolfcrypt/src/ge_448.o \
-    ./lib/wolfssl/wolfcrypt/src/fe_448.o \
-    ./lib/wolfssl/wolfcrypt/src/fe_low_mem.o
+ED448_OBJS=$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/ed448.o \
+    $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/ge_low_mem.o \
+    $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/ge_448.o \
+    $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/fe_448.o \
+    $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/fe_low_mem.o
 
 RSA_OBJS=\
     $(RSA_EXTRA_OBJS) \
-    ./lib/wolfssl/wolfcrypt/src/rsa.o
+    $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/rsa.o
 
 LMS_OBJS=\
-    ./lib/wolfssl/wolfcrypt/src/wc_lms.o \
-    ./lib/wolfssl/wolfcrypt/src/wc_lms_impl.o
+    $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/wc_lms.o \
+    $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/wc_lms_impl.o
 
 LMS_EXTRA=\
     -D"WOLFSSL_HAVE_LMS" \
@@ -105,8 +105,8 @@ LMS_EXTRA=\
     -D"WOLFSSL_LMS_VERIFY_ONLY"
 
 XMSS_OBJS=\
-    ./lib/wolfssl/wolfcrypt/src/wc_xmss.o \
-    ./lib/wolfssl/wolfcrypt/src/wc_xmss_impl.o
+    $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/wc_xmss.o \
+    $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/wc_xmss_impl.o
 
 XMSS_EXTRA=\
     -D"WOLFSSL_HAVE_XMSS" \
@@ -116,8 +116,8 @@ XMSS_EXTRA=\
     -D"WOLFSSL_XMSS_VERIFY_ONLY" -D"WOLFSSL_XMSS_MAX_HEIGHT=32"
 
 ML_DSA_OBJS=\
-    ./lib/wolfssl/wolfcrypt/src/dilithium.o \
-    ./lib/wolfssl/wolfcrypt/src/memory.o
+    $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/dilithium.o \
+    $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/memory.o
 
 ML_DSA_EXTRA=\
     -D"ML_DSA_IMAGE_SIGNATURE_SIZE"=$(IMAGE_SIGNATURE_SIZE) \
@@ -227,7 +227,7 @@ ifeq ($(SIGN),ED448)
 
 
   ifneq ($(HASH),SHA3)
-    WOLFCRYPT_OBJS+=./lib/wolfssl/wolfcrypt/src/sha3.o
+    WOLFCRYPT_OBJS+=$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/sha3.o
   endif
   CFLAGS+=-D"WOLFBOOT_SIGN_ED448"
   ifeq ($(shell test $(IMAGE_HEADER_SIZE) -lt 512; echo $$?),0)
@@ -412,7 +412,7 @@ ifeq ($(SIGN),ML_DSA)
   WOLFCRYPT_OBJS+= $(ML_DSA_OBJS)
   CFLAGS+=-D"WOLFBOOT_SIGN_ML_DSA" $(ML_DSA_EXTRA)
   ifneq ($(HASH),SHA3)
-    WOLFCRYPT_OBJS+=./lib/wolfssl/wolfcrypt/src/sha3.o
+    WOLFCRYPT_OBJS+=$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/sha3.o
   endif
 
   ifeq ($(WOLFBOOT_SMALL_STACK),1)
@@ -469,7 +469,7 @@ ifneq ($(SIGN_SECONDARY),)
   ifeq ($(SIGN_SECONDARY),ML_DSA)
     WOLFCRYPT_OBJS+= $(ML_DSA_OBJS)
     ifneq ($(HASH),SHA3)
-      WOLFCRYPT_OBJS+=./lib/wolfssl/wolfcrypt/src/sha3.o
+      WOLFCRYPT_OBJS+=$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/sha3.o
     endif
     CFLAGS+=-D"WOLFBOOT_SIGN_ML_DSA" $(ML_DSA_EXTRA)
   endif
@@ -534,15 +534,15 @@ ifeq ($(ENCRYPT),1)
   ifeq ($(ENCRYPT_WITH_AES128),1)
     CFLAGS+=-DWOLFSSL_AES_COUNTER -DWOLFSSL_AES_DIRECT
     CFLAGS+=-DENCRYPT_WITH_AES128 -DWOLFSSL_AES_128
-    WOLFCRYPT_OBJS+=./lib/wolfssl/wolfcrypt/src/aes.o
+    WOLFCRYPT_OBJS+=$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/aes.o
   else
     ifeq ($(ENCRYPT_WITH_AES256),1)
       CFLAGS+=-DWOLFSSL_AES_COUNTER -DWOLFSSL_AES_DIRECT
       CFLAGS+=-DENCRYPT_WITH_AES256 -DWOLFSSL_AES_256
-      WOLFCRYPT_OBJS+=./lib/wolfssl/wolfcrypt/src/aes.o
+      WOLFCRYPT_OBJS+=$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/aes.o
     else
       ENCRYPT_WITH_CHACHA=1
-      WOLFCRYPT_OBJS+=./lib/wolfssl/wolfcrypt/src/chacha.o
+      WOLFCRYPT_OBJS+=$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/chacha.o
       CFLAGS+=-DENCRYPT_WITH_CHACHA -DHAVE_CHACHA
     endif
   endif
@@ -650,23 +650,23 @@ ifeq ($(WOLFCRYPT_TZ_PKCS11),1)
   CFLAGS+=-DSECURE_PKCS11
   CFLAGS+=-DWOLFSSL_PKCS11_RW_TOKENS
   CFLAGS+=-DCK_CALLABLE="__attribute__((cmse_nonsecure_entry))"
-  CFLAGS+=-Ilib/wolfPKCS11
+  CFLAGS+=-I$(WOLFBOOT_LIB_WOLFPKCS11)
   CFLAGS+=-DWP11_HASH_PIN_COST=3
   WOLFCRYPT_OBJS+=src/pkcs11_store.o
   WOLFCRYPT_OBJS+=src/pkcs11_callable.o
-  WOLFCRYPT_OBJS+=./lib/wolfssl/wolfcrypt/src/pwdbased.o
-  WOLFCRYPT_OBJS+=./lib/wolfssl/wolfcrypt/src/hmac.o
-  WOLFCRYPT_OBJS+=./lib/wolfssl/wolfcrypt/src/dh.o
+  WOLFCRYPT_OBJS+=$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/pwdbased.o
+  WOLFCRYPT_OBJS+=$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/hmac.o
+  WOLFCRYPT_OBJS+=$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/dh.o
   ifeq ($(findstring random.o,$(WOLFCRYPT_OBJS)),)
-    WOLFCRYPT_OBJS+=./lib/wolfssl/wolfcrypt/src/random.o
+    WOLFCRYPT_OBJS+=$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/random.o
   endif
-  WOLFCRYPT_OBJS+=./lib/wolfPKCS11/src/crypto.o \
-        ./lib/wolfPKCS11/src/internal.o \
-        ./lib/wolfPKCS11/src/slot.o \
-        ./lib/wolfPKCS11/src/wolfpkcs11.o
+  WOLFCRYPT_OBJS+=$(WOLFBOOT_LIB_WOLFPKCS11)/src/crypto.o \
+        $(WOLFBOOT_LIB_WOLFPKCS11)/src/internal.o \
+        $(WOLFBOOT_LIB_WOLFPKCS11)/src/slot.o \
+        $(WOLFBOOT_LIB_WOLFPKCS11)/src/wolfpkcs11.o
   STACK_USAGE=16688
   ifneq ($(ENCRYPT),1)
-      WOLFCRYPT_OBJS+=./lib/wolfssl/wolfcrypt/src/aes.o
+      WOLFCRYPT_OBJS+=$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/aes.o
   endif
   ifeq ($(findstring RSA,$(SIGN)),)
   ifeq ($(findstring RSA,$(SIGN_SECONDARY)),)
@@ -697,12 +697,12 @@ endif
 ifeq ($(WOLFTPM),1)
   OBJS+=\
     ./src/tpm.o \
-    lib/wolfTPM/src/tpm2.o \
-    lib/wolfTPM/src/tpm2_packet.o \
-    lib/wolfTPM/src/tpm2_tis.o \
-    lib/wolfTPM/src/tpm2_wrap.o \
-    lib/wolfTPM/src/tpm2_param_enc.o
-  CFLAGS+=-Ilib/wolfTPM
+    $(WOLFBOOT_LIB_WOLFTPM)/src/tpm2.o \
+    $(WOLFBOOT_LIB_WOLFTPM)/src/tpm2_packet.o \
+    $(WOLFBOOT_LIB_WOLFTPM)/src/tpm2_tis.o \
+    $(WOLFBOOT_LIB_WOLFTPM)/src/tpm2_wrap.o \
+    $(WOLFBOOT_LIB_WOLFTPM)/src/tpm2_param_enc.o
+  CFLAGS+=-I$(WOLFBOOT_LIB_WOLFTPM)
   CFLAGS+=-D"WOLFBOOT_TPM"
   CFLAGS+=-D"WOLFTPM_SMALL_STACK"
   CFLAGS+=-D"WOLFTPM_AUTODETECT"
@@ -713,21 +713,21 @@ ifeq ($(WOLFTPM),1)
     endif
     ifeq ($(SIM_TPM),1)
       CFLAGS+=-DWOLFTPM_SWTPM -DTPM_TIMEOUT_TRIES=0 -DHAVE_NETDB_H -DHAVE_UNISTD_H
-      OBJS+=./lib/wolfTPM/src/tpm2_swtpm.o
+      OBJS+=$(WOLFBOOT_LIB_WOLFTPM)/src/tpm2_swtpm.o
     else
       # Use memory-mapped WOLFTPM on x86-64
        ifeq ($(ARCH),x86_64)
           CFLAGS+=-DWOLFTPM_MMIO -DWOLFTPM_EXAMPLE_HAL -DWOLFTPM_INCLUDE_IO_FILE
-          OBJS+=./lib/wolfTPM/hal/tpm_io_mmio.o
+          OBJS+=$(WOLFBOOT_LIB_WOLFTPM)/hal/tpm_io_mmio.o
         # By default, on other architectures, provide SPI driver
         else
           WOLFCRYPT_OBJS+=hal/spi/spi_drv_$(SPI_TARGET).o
         endif
     endif
   endif
-  WOLFCRYPT_OBJS+=./lib/wolfssl/wolfcrypt/src/aes.o
-  WOLFCRYPT_OBJS+=./lib/wolfssl/wolfcrypt/src/hmac.o
-  WOLFCRYPT_OBJS+=./lib/wolfssl/wolfcrypt/src/random.o
+  WOLFCRYPT_OBJS+=$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/aes.o
+  WOLFCRYPT_OBJS+=$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/hmac.o
+  WOLFCRYPT_OBJS+=$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/random.o
   ifeq ($(DEBUG),1)
     CFLAGS+=-DWOLFBOOT_DEBUG_TPM=1
   endif
@@ -742,7 +742,7 @@ ifeq ($(HASH),SHA384)
   CFLAGS+=-D"WOLFBOOT_HASH_SHA384"
   SIGN_OPTIONS+=--sha384
   ifneq ($(SIGN),ED25519)
-    WOLFCRYPT_OBJS+=./lib/wolfssl/wolfcrypt/src/sha512.o
+    WOLFCRYPT_OBJS+=$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/sha512.o
   endif
 endif
 
@@ -752,7 +752,7 @@ endif
 
 ifeq ($(HASH),SHA3)
   ifeq ($(HASH_HAL),)
-    WOLFCRYPT_OBJS+=./lib/wolfssl/wolfcrypt/src/sha3.o
+    WOLFCRYPT_OBJS+=$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/sha3.o
   endif
   CFLAGS+=-D"WOLFBOOT_HASH_SHA3_384"
   SIGN_OPTIONS+=--sha3
@@ -821,7 +821,7 @@ ifeq ($(DISK_LOCK),1)
   ifneq ($(DISK_LOCK_PASSWORD),)
     CFLAGS+=-DWOLFBOOT_ATA_DISK_LOCK_PASSWORD=\"$(DISK_LOCK_PASSWORD)\"
   endif
-  OBJS+=./lib/wolfssl/wolfcrypt/src/coding.o
+  OBJS+=$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/coding.o
 endif
 
 ifeq ($(FSP), 1)
@@ -873,34 +873,33 @@ endif
 
 # wolfHSM client options
 ifeq ($(WOLFHSM_CLIENT),1)
-  LIBDIR := $(dir $(lastword $(MAKEFILE_LIST)))lib
   WOLFCRYPT_OBJS += \
-    $(LIBDIR)/wolfssl/wolfcrypt/src/cryptocb.o \
-    $(LIBDIR)/wolfssl/wolfcrypt/src/coding.o
+    $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/cryptocb.o \
+    $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/coding.o
 
   ifeq ($(SIGN),ML_DSA)
     WOLFCRYPT_OBJS += $(MATH_OBJS)
     # Dilithium asn.c decode/encode requires mp_xxx functions
     WOLFCRYPT_OBJS += \
-        $(LIBDIR)/wolfssl/wolfcrypt/src/random.o
+        $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/random.o
 
     # Large enough to handle the largest Dilithium key/signature
     CFLAGS += -DWOLFHSM_CFG_COMM_DATA_LEN=5000
   endif
 
   WOLFHSM_OBJS += \
-    $(LIBDIR)/wolfHSM/src/wh_client.o \
-    $(LIBDIR)/wolfHSM/src/wh_client_nvm.o \
-    $(LIBDIR)/wolfHSM/src/wh_client_cryptocb.o \
-    $(LIBDIR)/wolfHSM/src/wh_client_crypto.o \
-    $(LIBDIR)/wolfHSM/src/wh_crypto.o \
-    $(LIBDIR)/wolfHSM/src/wh_utils.o \
-    $(LIBDIR)/wolfHSM/src/wh_comm.o \
-    $(LIBDIR)/wolfHSM/src/wh_message_comm.o \
-    $(LIBDIR)/wolfHSM/src/wh_message_nvm.o \
-    $(LIBDIR)/wolfHSM/src/wh_message_customcb.o
+    $(WOLFBOOT_LIB_WOLFHSM)/src/wh_client.o \
+    $(WOLFBOOT_LIB_WOLFHSM)/src/wh_client_nvm.o \
+    $(WOLFBOOT_LIB_WOLFHSM)/src/wh_client_cryptocb.o \
+    $(WOLFBOOT_LIB_WOLFHSM)/src/wh_client_crypto.o \
+    $(WOLFBOOT_LIB_WOLFHSM)/src/wh_crypto.o \
+    $(WOLFBOOT_LIB_WOLFHSM)/src/wh_utils.o \
+    $(WOLFBOOT_LIB_WOLFHSM)/src/wh_comm.o \
+    $(WOLFBOOT_LIB_WOLFHSM)/src/wh_message_comm.o \
+    $(WOLFBOOT_LIB_WOLFHSM)/src/wh_message_nvm.o \
+    $(WOLFBOOT_LIB_WOLFHSM)/src/wh_message_customcb.o
   #includes
-  CFLAGS += -I"$(LIBDIR)/wolfHSM"
+  CFLAGS += -I"$(WOLFBOOT_LIB_WOLFHSM)"
   # defines
   CFLAGS += -DWOLFBOOT_ENABLE_WOLFHSM_CLIENT -DWOLFHSM_CFG_ENABLE_CLIENT
   # Make sure we export generated public keys so they can be used to load into
@@ -919,19 +918,18 @@ ifeq ($(WOLFHSM_CLIENT),1)
   # doing cert chain verification
   ifneq ($(CERT_CHAIN_VERIFY),)
     WOLFHSM_OBJS += \
-      $(LIBDIR)/wolfHSM/src/wh_client_cert.o \
-      $(LIBDIR)/wolfHSM/src/wh_message_cert.o
+      $(WOLFBOOT_LIB_WOLFHSM)/src/wh_client_cert.o \
+      $(WOLFBOOT_LIB_WOLFHSM)/src/wh_message_cert.o
     CFLAGS += -DWOLFHSM_CFG_CERTIFICATE_MANAGER
   endif
 endif
 
 # wolfHSM server options
 ifeq ($(WOLFHSM_SERVER),1)
-  LIBDIR := $(dir $(lastword $(MAKEFILE_LIST)))lib
   WOLFCRYPT_OBJS += \
-    $(LIBDIR)/wolfssl/wolfcrypt/src/cryptocb.o \
-    $(LIBDIR)/wolfssl/wolfcrypt/src/coding.o \
-    $(LIBDIR)/wolfssl/wolfcrypt/src/random.o
+    $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/cryptocb.o \
+    $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/coding.o \
+    $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/random.o
 
   ifeq ($(SIGN),ML_DSA)
     WOLFCRYPT_OBJS += $(MATH_OBJS)
@@ -940,44 +938,44 @@ ifeq ($(WOLFHSM_SERVER),1)
   endif
 
   WOLFHSM_OBJS += \
-    $(LIBDIR)/wolfHSM/src/wh_utils.o \
-    $(LIBDIR)/wolfHSM/src/wh_comm.o \
-    $(LIBDIR)/wolfHSM/src/wh_nvm.o \
-    $(LIBDIR)/wolfHSM/src/wh_nvm_flash.o \
-    $(LIBDIR)/wolfHSM/src/wh_flash_unit.o \
-    $(LIBDIR)/wolfHSM/src/wh_crypto.o \
-    $(LIBDIR)/wolfHSM/src/wh_server.o \
-    $(LIBDIR)/wolfHSM/src/wh_server_nvm.o \
-    $(LIBDIR)/wolfHSM/src/wh_server_crypto.o \
-    $(LIBDIR)/wolfHSM/src/wh_server_counter.o \
-    $(LIBDIR)/wolfHSM/src/wh_server_keystore.o \
-    $(LIBDIR)/wolfHSM/src/wh_server_customcb.o \
-    $(LIBDIR)/wolfHSM/src/wh_message_customcb.o \
-    $(LIBDIR)/wolfHSM/src/wh_message_keystore.o \
-    $(LIBDIR)/wolfHSM/src/wh_message_crypto.o \
-    $(LIBDIR)/wolfHSM/src/wh_message_counter.o \
-    $(LIBDIR)/wolfHSM/src/wh_message_nvm.o \
-    $(LIBDIR)/wolfHSM/src/wh_message_comm.o \
-    $(LIBDIR)/wolfHSM/src/wh_transport_mem.o \
-    $(LIBDIR)/wolfHSM/port/posix/posix_flash_file.o
+    $(WOLFBOOT_LIB_WOLFHSM)/src/wh_utils.o \
+    $(WOLFBOOT_LIB_WOLFHSM)/src/wh_comm.o \
+    $(WOLFBOOT_LIB_WOLFHSM)/src/wh_nvm.o \
+    $(WOLFBOOT_LIB_WOLFHSM)/src/wh_nvm_flash.o \
+    $(WOLFBOOT_LIB_WOLFHSM)/src/wh_flash_unit.o \
+    $(WOLFBOOT_LIB_WOLFHSM)/src/wh_crypto.o \
+    $(WOLFBOOT_LIB_WOLFHSM)/src/wh_server.o \
+    $(WOLFBOOT_LIB_WOLFHSM)/src/wh_server_nvm.o \
+    $(WOLFBOOT_LIB_WOLFHSM)/src/wh_server_crypto.o \
+    $(WOLFBOOT_LIB_WOLFHSM)/src/wh_server_counter.o \
+    $(WOLFBOOT_LIB_WOLFHSM)/src/wh_server_keystore.o \
+    $(WOLFBOOT_LIB_WOLFHSM)/src/wh_server_customcb.o \
+    $(WOLFBOOT_LIB_WOLFHSM)/src/wh_message_customcb.o \
+    $(WOLFBOOT_LIB_WOLFHSM)/src/wh_message_keystore.o \
+    $(WOLFBOOT_LIB_WOLFHSM)/src/wh_message_crypto.o \
+    $(WOLFBOOT_LIB_WOLFHSM)/src/wh_message_counter.o \
+    $(WOLFBOOT_LIB_WOLFHSM)/src/wh_message_nvm.o \
+    $(WOLFBOOT_LIB_WOLFHSM)/src/wh_message_comm.o \
+    $(WOLFBOOT_LIB_WOLFHSM)/src/wh_transport_mem.o \
+    $(WOLFBOOT_LIB_WOLFHSM)/port/posix/posix_flash_file.o
 
   #includes
-  CFLAGS += -I"$(LIBDIR)/wolfHSM"
+  CFLAGS += -I"$(WOLFBOOT_LIB_WOLFHSM)"
   # defines'
   CFLAGS += -DWOLFBOOT_ENABLE_WOLFHSM_SERVER -DWOLFHSM_CFG_ENABLE_SERVER
 
   # Ensure wolfHSM is configured to use certificate manager if we are
   # doing cert chain verification
   ifneq ($(CERT_CHAIN_VERIFY),)
-    CFLAGS += -I"$(LIBDIR)/wolfssl"
+    CFLAGS += -I"$(WOLFBOOT_LIB_WOLFSSL)"
     WOLFCRYPT_OBJS += \
-      $(LIBDIR)/wolfssl/src/internal.o \
-      $(LIBDIR)/wolfssl/src/ssl.o \
-      $(LIBDIR)/wolfssl/src/ssl_certman.o
+      $(WOLFBOOT_LIB_WOLFSSL)/src/internal.o \
+      $(WOLFBOOT_LIB_WOLFSSL)/src/ssl.o \
+      $(WOLFBOOT_LIB_WOLFSSL)/src/ssl_certman.o
 
     WOLFHSM_OBJS += \
-      $(LIBDIR)/wolfHSM/src/wh_message_cert.o \
-      $(LIBDIR)/wolfHSM/src/wh_server_cert.o
+      $(WOLFBOOT_LIB_WOLFHSM)/src/wh_message_cert.o \
+      $(WOLFBOOT_LIB_WOLFHSM)/src/wh_server_cert.o
     CFLAGS += -DWOLFHSM_CFG_CERTIFICATE_MANAGER
   endif
 endif

--- a/stage1/Makefile
+++ b/stage1/Makefile
@@ -64,8 +64,8 @@ ifeq ($(WOLFTPM),1)
 endif
 
 CFLAGS+= \
-  -I".." -I"../include/" -I"../lib/wolfssl" \
-  -I"../lib/wolfTPM" \
+  -I".." -I"../include/" -I"$(WOLFBOOT_LIB_WOLFSSL)" \
+  -I"$(WOLFBOOT_LIB_WOLFTPM)" \
   -D"WOLFSSL_USER_SETTINGS" \
   -D"WOLFTPM_USER_SETTINGS"
 
@@ -113,7 +113,7 @@ BUILD_DIR=.
 LS1_OBJS=$(addprefix $(BUILD_DIR)/, $(notdir $(OBJS)))
 vpath %.c ../src
 vpath %.c ../hal
-vpath %.c ../lib/wolfssl/wolfcrypt/src ../lib/wolfTPM/src
+vpath %.c $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src $(WOLFBOOT_LIB_WOLFTPM)/src
 vpath %.c ../src/x86
 vpath %.S ../src
 
@@ -190,7 +190,7 @@ $(BUILD_DIR)/%.o: ../src/%.c
 $(BUILD_DIR)/%.o: ../hal/%.c
 	@echo "\t[CC-$(ARCH)] $@"
 	$(Q)$(CC) $(CFLAGS) -c $(OUTPUT_FLAG) $@ $<
-$(BUILD_DIR)/%.o: ../lib/wolfssl/wolfcrypt/src/%.c
+$(BUILD_DIR)/%.o: $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/%.c
 	@echo "\t[CC-$(ARCH)] $@"
 	$(Q)$(CC) $(CFLAGS) -c $(OUTPUT_FLAG) $@ $<
 

--- a/test-app/Makefile
+++ b/test-app/Makefile
@@ -25,7 +25,7 @@ ifeq ($(SIGN),RSA4096)
   IMAGE_HEADER_SIZE:=1024
 endif
 ifeq ($(HASH),SHA256)
-  WOLFCRYPT_OBJS+=./lib/wolfssl/wolfcrypt/src/sha256.o
+  WOLFCRYPT_OBJS+=$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/sha256.o
   CFLAGS+=-D"WOLFBOOT_HASH_SHA256"
 endif
 
@@ -35,7 +35,7 @@ endif
 
 
 ifeq ($(HASH),SHA3_384)
-  WOLFCRYPT_OBJS+=./lib/wolfssl/wolfcrypt/src/sha3.o
+  WOLFCRYPT_OBJS+=$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/sha3.o
   CFLAGS+=-D"WOLFBOOT_HASH_SHA3_384"
 endif
 
@@ -83,7 +83,7 @@ ifeq ($(TZEN),1)
         APP_OBJS+=../src/wc_secure_calls.o
         ifeq ($(WOLFCRYPT_TZ_PKCS11),1)
             CFLAGS+=-DWOLFSSL_USER_SETTINGS -DWOLFBOOT_PKCS11_APP -DSECURE_PKCS11
-            CFLAGS+=-I../lib/wolfPKCS11
+            CFLAGS+=-I"$(WOLFBOOT_LIB_WOLFPKCS11)"
             APP_OBJS+=./wcs/pkcs11_test_ecc.o
             APP_OBJS+=./wcs/pkcs11_stub.o
             APP_OBJS+=./wcs/ecc.o
@@ -183,9 +183,9 @@ ifeq ($(TARGET),stm32h5)
     LSCRIPT_TEMPLATE=ARM-stm32h5-ns.ld
     APP_OBJS+=wcs/wolfcrypt_secure.o
     ifeq ($(WOLFCRYPT_TZ),1)
-      APP_OBJS+=../lib/wolfssl/wolfcrypt/src/logging.o
-      APP_OBJS+=../lib/wolfssl/wolfcrypt/test/test.o
-      APP_OBJS+=../lib/wolfssl/wolfcrypt/benchmark/benchmark.o
+      APP_OBJS+=$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/logging.o
+      APP_OBJS+=$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/test/test.o
+      APP_OBJS+=$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/benchmark/benchmark.o
     endif
   else
     LSCRIPT_TEMPLATE=ARM-stm32h5.ld
@@ -460,18 +460,18 @@ ifeq ($(TARGET), pic32cz)
   APP_OBJS+=../hal/pic32c.o
 endif
 
-CFLAGS+=-I../lib/wolfssl
+CFLAGS+=-I"$(WOLFBOOT_LIB_WOLFSSL)"
 
 ifeq ($(WOLFHSM_CLIENT),1)
-  CFLAGS += -DWOLFSSL_USER_SETTINGS -DSTRING_USER -I../lib/wolfssl
+  CFLAGS += -DWOLFSSL_USER_SETTINGS -DSTRING_USER -I"$(WOLFBOOT_LIB_WOLFSSL)"
   APP_OBJS += $(WOLFHSM_OBJS)
-  APP_OBJS += $(sort $(patsubst ./lib/wolfssl/%, ../lib/wolfssl/%, $(WOLFCRYPT_OBJS)))
+  APP_OBJS += $(sort $(patsubst $(WOLFBOOT_LIB_WOLFSSL)/%, $(WOLFBOOT_LIB_WOLFSSL)/%, $(WOLFCRYPT_OBJS)))
 endif
 
 ifeq ($(WOLFHSM_SERVER),1)
-  CFLAGS += -DWOLFSSL_USER_SETTINGS -DSTRING_USER -I../lib/wolfssl
+  CFLAGS += -DWOLFSSL_USER_SETTINGS -DSTRING_USER -I"$(WOLFBOOT_LIB_WOLFSSL)"
   APP_OBJS += $(WOLFHSM_OBJS)
-  APP_OBJS += $(sort $(patsubst ./lib/wolfssl/%, ../lib/wolfssl/%, $(WOLFCRYPT_OBJS)))
+  APP_OBJS += $(sort $(patsubst $(WOLFBOOT_LIB_WOLFSSL)/%, $(WOLFBOOT_LIB_WOLFSSL)/%, $(WOLFCRYPT_OBJS)))
 endif
 
 

--- a/test-app/wcs/pkcs11.mk
+++ b/test-app/wcs/pkcs11.mk
@@ -1,8 +1,8 @@
 vpath %.c $(dir ../src)
 vpath %.c $(dir ../hal)
-vpath %.c $(dir ../lib/wolfssl/wolfcrypt/src)
+vpath %.c $(dir $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src)
 
-./wcs/%.o: ./lib/wolfssl/wolfcrypt/src/%.c
+./wcs/%.o: $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/%.c
 	@echo "\t[CC-$(ARCH)] $@"
 	$(Q)$(CC) $(CFLAGS) -c $(OUTPUT_FLAG) $@ $<
 

--- a/tools/keytools/Makefile
+++ b/tools/keytools/Makefile
@@ -7,12 +7,17 @@ ifeq ($(V),0)
   Q=@
 endif
 
+# Default library paths (can be overridden)
+WOLFBOOT_LIB_WOLFSSL?=../../lib/wolfssl
+
+# Convert to absolute paths for standalone usage
+WOLFBOOT_LIB_WOLFSSL:=$(abspath $(WOLFBOOT_LIB_WOLFSSL))
+
 CC      = gcc
 LD      = gcc
 WOLFBOOTDIR = ../..
-WOLFDIR = $(WOLFBOOTDIR)/lib/wolfssl
 CFLAGS  = -Wall -Wextra -Werror
-CFLAGS  += -I. -DWOLFSSL_USER_SETTINGS -I$(WOLFDIR) -I$(WOLFBOOTDIR)/include
+CFLAGS  += -I. -DWOLFSSL_USER_SETTINGS -I$(WOLFBOOT_LIB_WOLFSSL) -I$(WOLFBOOTDIR)/include
 LDFLAGS =
 OBJDIR = ./
 LIBS =
@@ -68,46 +73,46 @@ endif
 
 # Sources
 OBJS_REAL=\
-	$(WOLFDIR)/wolfcrypt/src/asn.o \
-	$(WOLFDIR)/wolfcrypt/src/aes.o \
-	$(WOLFDIR)/wolfcrypt/src/ecc.o \
-	$(WOLFDIR)/wolfcrypt/src/coding.o \
-	$(WOLFDIR)/wolfcrypt/src/chacha.o \
-	$(WOLFDIR)/wolfcrypt/src/ed25519.o \
-	$(WOLFDIR)/wolfcrypt/src/ed448.o \
-	$(WOLFDIR)/wolfcrypt/src/fe_operations.o \
-	$(WOLFDIR)/wolfcrypt/src/ge_operations.o \
-	$(WOLFDIR)/wolfcrypt/src/fe_448.o \
-	$(WOLFDIR)/wolfcrypt/src/ge_448.o \
-	$(WOLFDIR)/wolfcrypt/src/hash.o \
-	$(WOLFDIR)/wolfcrypt/src/logging.o \
-	$(WOLFDIR)/wolfcrypt/src/memory.o \
-	$(WOLFDIR)/wolfcrypt/src/random.o \
-	$(WOLFDIR)/wolfcrypt/src/rsa.o \
-	$(WOLFDIR)/wolfcrypt/src/sp_int.o \
-	$(WOLFDIR)/wolfcrypt/src/sp_c32.o \
-	$(WOLFDIR)/wolfcrypt/src/sp_c64.o \
-	$(WOLFDIR)/wolfcrypt/src/sha3.o \
-	$(WOLFDIR)/wolfcrypt/src/sha256.o \
-	$(WOLFDIR)/wolfcrypt/src/sha512.o \
-	$(WOLFDIR)/wolfcrypt/src/tfm.o \
-	$(WOLFDIR)/wolfcrypt/src/wc_port.o \
-	$(WOLFDIR)/wolfcrypt/src/wolfmath.o
+	$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/asn.o \
+	$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/aes.o \
+	$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/ecc.o \
+	$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/coding.o \
+	$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/chacha.o \
+	$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/ed25519.o \
+	$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/ed448.o \
+	$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/fe_operations.o \
+	$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/ge_operations.o \
+	$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/fe_448.o \
+	$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/ge_448.o \
+	$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/hash.o \
+	$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/logging.o \
+	$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/memory.o \
+	$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/random.o \
+	$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/rsa.o \
+	$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/sp_int.o \
+	$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/sp_c32.o \
+	$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/sp_c64.o \
+	$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/sha3.o \
+	$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/sha256.o \
+	$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/sha512.o \
+	$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/tfm.o \
+	$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/wc_port.o \
+	$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/wolfmath.o
 
 OBJS_REAL+=\
 	$(WOLFBOOTDIR)/src/delta.o
 
 OBJS_REAL+=\
-	$(WOLFDIR)/wolfcrypt/src/wc_lms.o \
-	$(WOLFDIR)/wolfcrypt/src/wc_lms_impl.o
+	$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/wc_lms.o \
+	$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/wc_lms_impl.o
 
 OBJS_REAL+=\
-	$(WOLFDIR)/wolfcrypt/src/wc_xmss.o \
-	$(WOLFDIR)/wolfcrypt/src/wc_xmss_impl.o
-OBJS_REAL+=$(WOLFDIR)/wolfcrypt/src/dilithium.o
+	$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/wc_xmss.o \
+	$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/wc_xmss_impl.o
+OBJS_REAL+=$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/dilithium.o
 
 OBJS_VIRT=$(addprefix $(OBJDIR), $(notdir $(OBJS_REAL)))
-vpath %.c $(WOLFDIR)/wolfcrypt/src/
+vpath %.c $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/
 vpath %.c $(WOLFBOOTDIR)/src/
 vpath %.c ./
 
@@ -123,7 +128,7 @@ $(OBJDIR)/%.o: %.c
 	$(Q)$(CC) $(CFLAGS) -c -o $@ $<
 $(OBJDIR)/%.o: $(WOLFBOOTDIR)/src/%.c
 	$(Q)$(CC) $(CFLAGS) -c -o $@ $<
-$(OBJDIR)/%.o: $(WOLFDIR)/wolfcrypt/src/%.c
+$(OBJDIR)/%.o: $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/%.c
 	$(Q)$(CC) $(CFLAGS) -c -o $@ $<
 
 # build templates

--- a/tools/tpm/Makefile
+++ b/tools/tpm/Makefile
@@ -7,15 +7,21 @@ ifeq ($(V),0)
   Q=@
 endif
 
+# Default library paths (can be overridden)
+WOLFBOOT_LIB_WOLFSSL?=../../lib/wolfssl
+WOLFBOOT_LIB_WOLFTPM?=../../lib/wolfTPM
+
+# Convert to absolute paths for standalone usage
+WOLFBOOT_LIB_WOLFSSL:=$(abspath $(WOLFBOOT_LIB_WOLFSSL))
+WOLFBOOT_LIB_WOLFTPM:=$(abspath $(WOLFBOOT_LIB_WOLFTPM))
+
 CC = gcc
 LD = gcc
 WOLFBOOTDIR = ../..
-WOLFDIR = $(WOLFBOOTDIR)/lib/wolfssl/
-WOLFTPMDIR = $(WOLFBOOTDIR)/lib/wolfTPM/
 CFLAGS = -Wall -Wextra -Werror -Wno-unused-function
 CFLAGS += -DWOLFSSL_USER_SETTINGS -DWOLFTPM_USER_SETTINGS -DWOLFBOOT_TPM -DHAVE_NETDB_H -DWOLFBOOT_SIGN_$(SIGN)
 CFLAGS += -DXSTRTOL=strtol
-CFLAGS += -I. -I$(WOLFDIR) -I$(WOLFTPMDIR) -I$(WOLFBOOTDIR)/include
+CFLAGS += -I. -I$(WOLFBOOT_LIB_WOLFSSL) -I$(WOLFBOOT_LIB_WOLFTPM) -I$(WOLFBOOTDIR)/include
 LDFLAGS =
 OBJDIR = ./
 
@@ -38,41 +44,41 @@ endif
 # Sources
 OBJS_REAL=\
 	$(WOLFBOOTDIR)/src/keystore.o \
-	$(WOLFDIR)wolfcrypt/src/asn.o \
-	$(WOLFDIR)wolfcrypt/src/aes.o \
-	$(WOLFDIR)wolfcrypt/src/ecc.o \
-	$(WOLFDIR)wolfcrypt/src/error.o \
-	$(WOLFDIR)wolfcrypt/src/coding.o \
-	$(WOLFDIR)wolfcrypt/src/hash.o \
-	$(WOLFDIR)wolfcrypt/src/logging.o \
-	$(WOLFDIR)wolfcrypt/src/memory.o \
-	$(WOLFDIR)wolfcrypt/src/random.o \
-	$(WOLFDIR)wolfcrypt/src/rsa.o \
-	$(WOLFDIR)wolfcrypt/src/hmac.o \
-	$(WOLFDIR)wolfcrypt/src/sp_int.o \
-	$(WOLFDIR)wolfcrypt/src/sp_c32.o \
-	$(WOLFDIR)wolfcrypt/src/sp_c64.o \
-	$(WOLFDIR)wolfcrypt/src/sha256.o \
-	$(WOLFDIR)wolfcrypt/src/sha512.o \
-	$(WOLFDIR)wolfcrypt/src/tfm.o \
-	$(WOLFDIR)wolfcrypt/src/wc_port.o \
-	$(WOLFDIR)wolfcrypt/src/wolfmath.o \
-	$(WOLFTPMDIR)src/tpm2_wrap.o \
-	$(WOLFTPMDIR)src/tpm2.o \
-	$(WOLFTPMDIR)src/tpm2_linux.o \
-	$(WOLFTPMDIR)src/tpm2_packet.o \
-	$(WOLFTPMDIR)src/tpm2_param_enc.o \
-	$(WOLFTPMDIR)src/tpm2_swtpm.o \
-	$(WOLFTPMDIR)src/tpm2_tis.o \
-	$(WOLFTPMDIR)src/tpm2_winapi.o \
-	$(WOLFTPMDIR)hal/tpm_io.o
+	$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/asn.o \
+	$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/aes.o \
+	$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/ecc.o \
+	$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/error.o \
+	$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/coding.o \
+	$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/hash.o \
+	$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/logging.o \
+	$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/memory.o \
+	$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/random.o \
+	$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/rsa.o \
+	$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/hmac.o \
+	$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/sp_int.o \
+	$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/sp_c32.o \
+	$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/sp_c64.o \
+	$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/sha256.o \
+	$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/sha512.o \
+	$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/tfm.o \
+	$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/wc_port.o \
+	$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/wolfmath.o \
+	$(WOLFBOOT_LIB_WOLFTPM)/src/tpm2_wrap.o \
+	$(WOLFBOOT_LIB_WOLFTPM)/src/tpm2.o \
+	$(WOLFBOOT_LIB_WOLFTPM)/src/tpm2_linux.o \
+	$(WOLFBOOT_LIB_WOLFTPM)/src/tpm2_packet.o \
+	$(WOLFBOOT_LIB_WOLFTPM)/src/tpm2_param_enc.o \
+	$(WOLFBOOT_LIB_WOLFTPM)/src/tpm2_swtpm.o \
+	$(WOLFBOOT_LIB_WOLFTPM)/src/tpm2_tis.o \
+	$(WOLFBOOT_LIB_WOLFTPM)/src/tpm2_winapi.o \
+	$(WOLFBOOT_LIB_WOLFTPM)/hal/tpm_io.o
 
 OBJS_VIRT=$(addprefix $(OBJDIR), $(notdir $(OBJS_REAL)))
-vpath %.c $(WOLFDIR)/wolfcrypt/src/
+vpath %.c $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/
 vpath %.c $(WOLFBOOTDIR)/src/
-vpath %.c $(WOLFTPMDIR)/src/
-vpath %.c $(WOLFTPMDIR)/hal/
-vpath %.c $(WOLFTPMDIR)/examples/pcr
+vpath %.c $(WOLFBOOT_LIB_WOLFTPM)/src/
+vpath %.c $(WOLFBOOT_LIB_WOLFTPM)/hal/
+vpath %.c $(WOLFBOOT_LIB_WOLFTPM)/examples/pcr
 vpath %.c ./
 
 .PHONY: clean all
@@ -90,11 +96,11 @@ $(OBJDIR)/%.o: %.c
 	$(Q)$(CC) $(CFLAGS) -c -o $@ $<
 $(OBJDIR)/%.o: $(WOLFBOOTDIR)/src/%.c
 	$(Q)$(CC) $(CFLAGS) -c -o $@ $<
-$(OBJDIR)/%.o: $(WOLFDIR)/wolfcrypt/src/%.c
+$(OBJDIR)/%.o: $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/%.c
 	$(Q)$(CC) $(CFLAGS) -c -o $@ $<
-$(OBJDIR)/%.o: $(WOLFTPMDIR)/src/%.c
+$(OBJDIR)/%.o: $(WOLFBOOT_LIB_WOLFTPM)/src/%.c
 	$(Q)$(CC) $(CFLAGS) -c -o $@ $<
-$(OBJDIR)/%.o: $(WOLFTPMDIR)/hal/%.c
+$(OBJDIR)/%.o: $(WOLFBOOT_LIB_WOLFTPM)/hal/%.c
 	$(Q)$(CC) $(CFLAGS) -c -o $@ $<
 
 # build templates
@@ -110,17 +116,17 @@ policy_sign: $(OBJS_VIRT) policy_sign.o
 	@echo "Building Policy Sign Tool"
 	$(Q)$(LD) -o $@ $@.o $(OBJS_VIRT) $(LDFLAGS)
 
-pcr_extend: $(OBJS_VIRT) $(WOLFTPMDIR)/examples/pcr/extend.o
+pcr_extend: $(OBJS_VIRT) $(WOLFBOOT_LIB_WOLFTPM)/examples/pcr/extend.o
 	@echo "Building PCR Extend Tool"
-	$(Q)$(LD) -o $@ $(WOLFTPMDIR)/examples/pcr/extend.o $(OBJS_VIRT) $(LDFLAGS)
+	$(Q)$(LD) -o $@ $(WOLFBOOT_LIB_WOLFTPM)/examples/pcr/extend.o $(OBJS_VIRT) $(LDFLAGS)
 
-pcr_read: $(OBJS_VIRT) $(WOLFTPMDIR)/examples/pcr/read_pcr.o
+pcr_read: $(OBJS_VIRT) $(WOLFBOOT_LIB_WOLFTPM)/examples/pcr/read_pcr.o
 	@echo "Building PCR Read Tool"
-	$(Q)$(LD) -o $@ $(WOLFTPMDIR)/examples/pcr/read_pcr.o $(OBJS_VIRT) $(LDFLAGS)
+	$(Q)$(LD) -o $@ $(WOLFBOOT_LIB_WOLFTPM)/examples/pcr/read_pcr.o $(OBJS_VIRT) $(LDFLAGS)
 
-pcr_reset: $(OBJS_VIRT) $(WOLFTPMDIR)/examples/pcr/reset.o
+pcr_reset: $(OBJS_VIRT) $(WOLFBOOT_LIB_WOLFTPM)/examples/pcr/reset.o
 	@echo "Building PCR Reset Tool"
-	$(Q)$(LD) -o $@ $(WOLFTPMDIR)/examples/pcr/reset.o $(OBJS_VIRT) $(LDFLAGS)
+	$(Q)$(LD) -o $@ $(WOLFBOOT_LIB_WOLFTPM)/examples/pcr/reset.o $(OBJS_VIRT) $(LDFLAGS)
 
 clean:
 	rm -f rot policy_create pcr_extend pcr_read pcr_reset *.o

--- a/tools/unit-tests/Makefile
+++ b/tools/unit-tests/Makefile
@@ -5,7 +5,15 @@ ifneq ($(UNAME_S),Darwin)
 	LDFLAGS+=-lrt -lsubunit
 endif
 
-CFLAGS=-I. -I../../src -I../../include -I../../lib/wolfssl
+# Default library paths (can be overridden)
+WOLFBOOT_LIB_WOLFSSL?=../../lib/wolfssl
+WOLFBOOT_LIB_WOLFPKCS11?=../../lib/wolfPKCS11
+
+# Convert to absolute paths for standalone usage
+WOLFBOOT_LIB_WOLFSSL:=$(abspath $(WOLFBOOT_LIB_WOLFSSL))
+WOLFBOOT_LIB_WOLFPKCS11:=$(abspath $(WOLFBOOT_LIB_WOLFPKCS11))
+
+CFLAGS=-I. -I../../src -I../../include -I$(WOLFBOOT_LIB_WOLFSSL)
 CFLAGS+=-g -ggdb
 CFLAGS+=-fprofile-arcs
 CFLAGS+=-ftest-coverage
@@ -13,8 +21,7 @@ CFLAGS+=--coverage
 CFLAGS+=-DUNIT_TEST -DWOLFSSL_USER_SETTINGS
 LDFLAGS+=-fprofile-arcs
 LDFLAGS+=-ftest-coverage
-WOLFCRYPT=../../lib/wolfssl/
-WOLFPKCS11=../../lib/wolfPKCS11/
+
 
 
 
@@ -39,12 +46,12 @@ run: $(TESTS)
 	done
 
 
-WOLFCRYPT_SRC:=$(WOLFCRYPT)/wolfcrypt/src/sha.c \
-               $(WOLFCRYPT)/wolfcrypt/src/sha256.c \
-               $(WOLFCRYPT)/wolfcrypt/src/sp_int.c \
-               $(WOLFCRYPT)/wolfcrypt/src/sp_c64.c \
-               $(WOLFCRYPT)/wolfcrypt/src/random.c \
-               $(WOLFCRYPT)/wolfcrypt/src/memory.c
+WOLFCRYPT_SRC:=$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/sha.c \
+               $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/sha256.c \
+               $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/sp_int.c \
+               $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/sp_c64.c \
+               $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/random.c \
+               $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/memory.c
 
 unit-aes128:CFLAGS+=-DEXT_ENCRYPTED -DENCRYPT_WITH_AES128
 unit-aes256:CFLAGS+=-DEXT_ENCRYPTED -DENCRYPT_WITH_AES256
@@ -54,12 +61,12 @@ unit-nvm:CFLAGS+=-DNVM_FLASH_WRITEONCE -DMOCK_PARTITIONS
 unit-nvm-flagshome:CFLAGS+=-DNVM_FLASH_WRITEONCE -DMOCK_PARTITIONS -DFLAGS_HOME
 unit-enc-nvm:CFLAGS+=-DNVM_FLASH_WRITEONCE -DMOCK_PARTITIONS -DEXT_ENCRYPTED \
 	-DENCRYPT_WITH_CHACHA -DEXT_FLASH -DHAVE_CHACHA
-unit-enc-nvm:WOLFCRYPT_SRC+=$(WOLFCRYPT)/wolfcrypt/src/chacha.c
+unit-enc-nvm:WOLFCRYPT_SRC+=$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/chacha.c
 unit-enc-nvm-flagshome:CFLAGS+=-DNVM_FLASH_WRITEONCE -DMOCK_PARTITIONS \
 	-DEXT_ENCRYPTED -DENCRYPT_WITH_CHACHA -DEXT_FLASH -DHAVE_CHACHA -DFLAGS_HOME
-unit-enc-nvm-flagshome:WOLFCRYPT_SRC+=$(WOLFCRYPT)/wolfcrypt/src/chacha.c
+unit-enc-nvm-flagshome:WOLFCRYPT_SRC+=$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/chacha.c
 unit-delta:CFLAGS+=-DNVM_FLASH_WRITEONCE -DMOCK_PARTITIONS -DDELTA_UPDATES -DDELTA_BLOCK_SIZE=512
-unit-pkcs11_store:CFLAGS+=-I$(WOLFPKCS11) -DMOCK_PARTITIONS -DMOCK_KEYVAULT -DSECURE_PKCS11
+unit-pkcs11_store:CFLAGS+=-I$(WOLFBOOT_LIB_WOLFPKCS11) -DMOCK_PARTITIONS -DMOCK_KEYVAULT -DSECURE_PKCS11
 unit-update-flash:CFLAGS+=-DMOCK_PARTITIONS -DWOLFBOOT_NO_SIGN -DUNIT_TEST_AUTH \
 	-DWOLFBOOT_HASH_SHA256 -DPRINTF_ENABLED -DEXT_FLASH -DPART_UPDATE_EXT -DPART_SWAP_EXT
 unit-update-ram:CFLAGS+=-DMOCK_PARTITIONS -DWOLFBOOT_NO_SIGN -DUNIT_TEST_AUTH \
@@ -121,10 +128,10 @@ unit-delta: ../../include/target.h unit-delta.c
 	gcc -o $@ unit-delta.c $(CFLAGS) $(LDFLAGS)
 
 unit-update-flash: ../../include/target.h unit-update-flash.c
-	gcc -o $@ unit-update-flash.c ../../src/image.c ../../lib/wolfssl/wolfcrypt/src/sha256.c $(CFLAGS) $(LDFLAGS)
+	gcc -o $@ unit-update-flash.c ../../src/image.c $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/sha256.c $(CFLAGS) $(LDFLAGS)
 
 unit-update-ram: ../../include/target.h unit-update-ram.c
-	gcc -o $@ unit-update-ram.c ../../src/image.c ../../lib/wolfssl/wolfcrypt/src/sha256.c  $(CFLAGS) $(LDFLAGS)
+	gcc -o $@ unit-update-ram.c ../../src/image.c $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/sha256.c $(CFLAGS) $(LDFLAGS)
 
 unit-pkcs11_store: ../../include/target.h unit-pkcs11_store.c
 	gcc -o $@ $(WOLFCRYPT_SRC) unit-pkcs11_store.c $(CFLAGS) $(WOLFCRYPT_CFLAGS) $(LDFLAGS)


### PR DESCRIPTION
Allows for the user to build wolfBoot against a different version of internal library dependencies (`wolfHSM`, `wolfTPM`, etc) if they want to live dangerously.

The default behavior remains the same (points to `lib/*`)