### PR TITLE
Reduce workflow timeout from default 360 minutes to 15

### DIFF
--- a/.github/workflows/build-keytools-windows.yml
+++ b/.github/workflows/build-keytools-windows.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   build-windows:
     runs-on: windows-latest
+    timeout-minutes: 15
 
     steps:
     # Step 1: Checkout the repository

--- a/.github/workflows/footprint.yml
+++ b/.github/workflows/footprint.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   footprint_test:
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test-build-aarch64.yml
+++ b/.github/workflows/test-build-aarch64.yml
@@ -18,6 +18,7 @@ jobs:
 
   build:
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v4
@@ -29,7 +30,7 @@ jobs:
 
       - name: Update repository
         run: sudo apt-get update
-      
+
       - name: Install dependencies
         run: |
           sudo apt-get install -y build-essential curl

--- a/.github/workflows/test-build-cmake.yml
+++ b/.github/workflows/test-build-cmake.yml
@@ -5,6 +5,8 @@ on:
 jobs:
   cmake_automated_test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/test-build-kontron-vx3060-s2.yml
+++ b/.github/workflows/test-build-kontron-vx3060-s2.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   fsp_qemu_test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/test-build-lms.yml
+++ b/.github/workflows/test-build-lms.yml
@@ -18,6 +18,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test-build-mcux-sdk.yml
+++ b/.github/workflows/test-build-mcux-sdk.yml
@@ -18,6 +18,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test-build-pico-sdk.yml
+++ b/.github/workflows/test-build-pico-sdk.yml
@@ -21,6 +21,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test-build-sim-tpm.yml
+++ b/.github/workflows/test-build-sim-tpm.yml
@@ -27,6 +27,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       # setup ibmswtpm2

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -18,6 +18,7 @@ jobs:
 
   build:
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test-cppcheck.yml
+++ b/.github/workflows/test-cppcheck.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   cppcheck:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test-custom-tlv-simulator.yml
+++ b/.github/workflows/test-custom-tlv-simulator.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   custom_tlv_simulator_tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test-elf-scattered.yml
+++ b/.github/workflows/test-elf-scattered.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   elf_scattered_test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test-external-library-paths.yml
+++ b/.github/workflows/test-external-library-paths.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   test_external_libs:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     # Matrix to test multiple configurations
     strategy:

--- a/.github/workflows/test-keytools-msys2.yml
+++ b/.github/workflows/test-keytools-msys2.yml
@@ -10,6 +10,7 @@ jobs:
 
   build:
     runs-on: windows-latest
+    timeout-minutes: 15
 
     steps:
       - name: Setup MSYS2

--- a/.github/workflows/test-keytools.yml
+++ b/.github/workflows/test-keytools.yml
@@ -10,6 +10,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test-library.yml
+++ b/.github/workflows/test-library.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   test-lib:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     strategy:
       fail-fast: false

--- a/.github/workflows/test-parse-tools.yml
+++ b/.github/workflows/test-parse-tools.yml
@@ -10,6 +10,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test-powerfail-simulator.yml
+++ b/.github/workflows/test-powerfail-simulator.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   powerfail_simulator_tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test-renode-fastmath.yml
+++ b/.github/workflows/test-renode-fastmath.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   renode_automated_fastmath:
     runs-on: ubuntu-22.04
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test-renode-noasm-smallstack.yml
+++ b/.github/workflows/test-renode-noasm-smallstack.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   renode_automated_noasm_smallstack:
     runs-on: ubuntu-22.04
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test-renode-noasm.yml
+++ b/.github/workflows/test-renode-noasm.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   renode_automated_noasm:
     runs-on: ubuntu-22.04
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test-renode-nrf52.yml
+++ b/.github/workflows/test-renode-nrf52.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   renode_automated_base:
     runs-on: ubuntu-22.04
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test-renode-sha3.yml
+++ b/.github/workflows/test-renode-sha3.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   renode_automated_multi_sha:
     runs-on: ubuntu-22.04
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test-renode-sha384.yml
+++ b/.github/workflows/test-renode-sha384.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   renode_automated_multi_sha:
     runs-on: ubuntu-22.04
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test-renode-smallstack.yml
+++ b/.github/workflows/test-renode-smallstack.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   renode_automated_smallstack:
     runs-on: ubuntu-22.04
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test-sunnyday-simulator.yml
+++ b/.github/workflows/test-sunnyday-simulator.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   simulator_tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test-units.yml
+++ b/.github/workflows/test-units.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   unit_tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test-wolfhsm-simulator.yml
+++ b/.github/workflows/test-wolfhsm-simulator.yml
@@ -26,6 +26,8 @@ jobs:
       fail-fast: false
 
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/test-x86-fsp-qemu.yml
+++ b/.github/workflows/test-x86-fsp-qemu.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   fsp_qemu_test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Ensures workflow tests abort early when stuck.

On two of my recent pull requests, the workflow got stuck here:

```
Run sudo apt-get install -y gcc-arm-none-eabi
Reading package lists...
Building dependency tree...
Reading state information...
The following additional packages will be installed:
  binutils-arm-none-eabi libnewlib-arm-none-eabi libnewlib-dev
  libstdc++-arm-none-eabi-dev libstdc++-arm-none-eabi-newlib
Suggested packages:
  libnewlib-doc
The following NEW packages will be installed:
  binutils-arm-none-eabi gcc-arm-none-eabi libnewlib-arm-none-eabi
  libnewlib-dev libstdc++-arm-none-eabi-dev libstdc++-arm-none-eabi-newlib
0 upgraded, 6 newly installed, 0 to remove and 21 not upgraded.
Need to get 574 MB of archives.
After this operation, 3106 MB of additional disk space will be used.
Get:1 file:/etc/apt/apt-mirrors.txt Mirrorlist [144 B]
Get:2 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 binutils-arm-none-eabi amd64 2.42-1ubuntu1+23 [3137 kB]
Get:3 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 gcc-arm-none-eabi amd64 15:13.2.rel1-2 [57.5 MB]
Get:4 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libstdc++-arm-none-eabi-dev all 15:13.2.rel1-2+26 [1320 kB]
Get:5 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libnewlib-dev all 4.4.0.20231231-2 [140 kB]
Get:6 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libnewlib-arm-none-eabi all 4.4.0.20231231-2 [49.2 MB]
Get:7 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libstdc++-arm-none-eabi-newlib all 15:13.2.rel1-2+26 [463 MB]
```
 
See also [this example](https://github.com/wolfSSL/wolfBoot/actions/runs/18290114605/job/52075047206?pr=598) that ran for over 2 hours, similarly stuck, before I canceled it.

During _this_ PR, job was stick again. See [this one](https://github.com/wolfSSL/wolfBoot/actions/runs/18293317620/job/52085691863?pr=600). Problem only today? Longer timeout?