### PR TITLE
CMake: Use find_program instead of `which` to find gcc toolchain

### DIFF
--- a/cmake/toolchain_aarch64-none-elf.cmake
+++ b/cmake/toolchain_aarch64-none-elf.cmake
@@ -35,10 +35,10 @@ set(MARCH_FLAGS "-march=armv8-a")
 set(TOOLCHAIN aarch64-none-elf)
 set(CMAKE_CXX_STANDARD 20)
 
-execute_process(
-    COMMAND which ${TOOLCHAIN}-gcc
-    OUTPUT_VARIABLE TOOLCHAIN_GCC_PATH
-    OUTPUT_STRIP_TRAILING_WHITESPACE)
+find_program(TOOLCHAIN_GCC_PATH
+  NAMES ${TOOLCHAIN}-gcc
+  HINTS $ENV{PATH}
+)
 
 # get toolchain version. CMAKE_C_COMPILER_VERSION cannot be used here since its not defined until
 # `project()` is run in the top-level cmake. The toolchain has to be setup before the `project` call

--- a/cmake/toolchain_arm-none-eabi.cmake
+++ b/cmake/toolchain_arm-none-eabi.cmake
@@ -47,10 +47,10 @@ endif()
 set(TOOLCHAIN arm-none-eabi)
 set(CMAKE_CXX_STANDARD 20)
 
-execute_process(
-    COMMAND which ${TOOLCHAIN}-gcc
-    OUTPUT_VARIABLE TOOLCHAIN_GCC_PATH
-    OUTPUT_STRIP_TRAILING_WHITESPACE)
+find_program(TOOLCHAIN_GCC_PATH
+  NAMES ${TOOLCHAIN}-gcc
+  HINTS $ENV{PATH}
+)
 
 # get toolchain version. CMAKE_C_COMPILER_VERSION cannot be used here since its not defined until
 # `project()` is run in the top-level cmake. The toolchain has to be setup before the `project` call


### PR DESCRIPTION
This updates the CMake configuration to use the CMake [`find_program()`](https://cmake.org/cmake/help/latest/command/find_program.html) function to locate the toolchain `gcc` application.  The existing implementation uses `which`, which is only available on Linux.  `find_program()` works cross-platform.  By setting `HINTS` to `$ENV{PATH}`, CMake looks for the program using the `PATH` environment variable, in the same way `which` would on Linux.