### PR TITLE
Fix workflow timeout with revised apt-get source replacements

### DIFF
--- a/.github/workflows/test-build-aarch64.yml
+++ b/.github/workflows/test-build-aarch64.yml
@@ -26,10 +26,52 @@ jobs:
           submodules: true
 
       - name: Workaround for sources.list
-        run: sudo sed -i 's|http://azure.archive.ubuntu.com/ubuntu/|http://mirror.arizona.edu/ubuntu/|g' /etc/apt/sources.list
+        run: |
+            # Replace sources
+
+            set -euxo pipefail
+
+            # Peek (what repos are active now)
+            apt-cache policy
+            grep -RInE '^(deb|Types|URIs)' /etc/apt || true
+
+            # Enable nullglob so *.list/*.sources that don't exist don't break sed
+            shopt -s nullglob
+
+            echo "Replace sources.list (legacy)"
+            sudo sed -i \
+              -e "s|https\?://azure\.archive\.ubuntu\.com/ubuntu/?|http://mirror.arizona.edu/ubuntu/|g" \
+              /etc/apt/sources.list || true
+
+            echo "Replace sources.list.d/*.list (legacy)"
+            for f in /etc/apt/sources.list.d/*.list; do
+              sudo sed -i \
+                -e "s|https\?://azure\.archive\.ubuntu\.com/ubuntu/?|http://mirror.arizona.edu/ubuntu/|g" \
+                "$f"
+            done
+
+            echo "Replace sources.list.d/*.sources (deb822)"
+            for f in /etc/apt/sources.list.d/*.sources; do
+              sudo sed -i \
+                -e "s|https\?://azure\.archive\.ubuntu\.com/ubuntu/?|http://mirror.arizona.edu/ubuntu/|g" \
+                -e "s|https\?://azure\.archive\.ubuntu\.com|http://mirror.arizona.edu|g" \
+                "$f"
+            done
+
+            echo "Fix /etc/apt/apt-mirrors.txt (used by URIs: mirror+file:...)"
+            if grep -qE '^[[:space:]]*https?://azure\.archive\.ubuntu\.com/ubuntu/?' /etc/apt/apt-mirrors.txt; then
+              # Replace azure with our mirror (idempotent)
+              sudo sed -i 's|https\?://azure\.archive\.ubuntu\.com/ubuntu/|http://mirror.arizona.edu/ubuntu/|g' /etc/apt/apt-mirrors.txt
+            fi
+
+            # Peek (verify changes)
+            grep -RIn "azure.archive.ubuntu.com" /etc/apt || true
+            grep -RInE '^(deb|Types|URIs)' /etc/apt || true
+            echo "--- apt-mirrors.txt ---"
+            cat /etc/apt/apt-mirrors.txt || true
 
       - name: Update repository
-        run: sudo apt-get update
+        run: sudo apt-get update -o Acquire::Retries=3
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test-build-lms.yml
+++ b/.github/workflows/test-build-lms.yml
@@ -26,7 +26,11 @@ jobs:
           submodules: true
 
       - name: Workaround for sources.list
-        run: sudo sed -i 's|http://azure.archive.ubuntu.com/ubuntu/|http://mirror.arizona.edu/ubuntu/|g' /etc/apt/sources.list
+        run: |
+            # workaround disabled, splitting the load between azure and arizona.edu to avoid timeouts
+
+            # See reference code in test-build.yml for various sources that may be updated. Enable as needed here.
+            echo "Workaround for sources.list disabled for this workflow"
 
       - name: Update repository
         run: sudo apt-get update

--- a/.github/workflows/test-build-mcux-sdk.yml
+++ b/.github/workflows/test-build-mcux-sdk.yml
@@ -36,7 +36,11 @@ jobs:
           path: CMSIS_5
 
       - name: Workaround for sources.list
-        run: sudo sed -i 's|http://azure.archive.ubuntu.com/ubuntu/|http://mirror.arizona.edu/ubuntu/|g' /etc/apt/sources.list
+        run: |
+            # workaround disabled, splitting the load between azure and arizona.edu to avoid timeouts
+
+            # See reference code in test-build.yml for various sources that may be updated. Enable as needed here.
+            echo "Workaround for sources.list disabled for this workflow"
 
       - name: Update repository
         run: sudo apt-get update

--- a/.github/workflows/test-build-pico-sdk.yml
+++ b/.github/workflows/test-build-pico-sdk.yml
@@ -39,7 +39,11 @@ jobs:
           git submodule update --init --recursive
 
       - name: Workaround for sources.list
-        run: sudo sed -i 's|http://azure.archive.ubuntu.com/ubuntu/|http://mirror.arizona.edu/ubuntu/|g' /etc/apt/sources.list
+        run: |
+            # workaround disabled, splitting the load between azure and arizona.edu to avoid timeouts
+
+            # See reference code in test-build.yml for various sources that may be updated. Enable as needed here.
+            echo "Workaround for sources.list disabled for this workflow"
 
       - name: Update repository
         run: sudo apt-get update

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -26,10 +26,52 @@ jobs:
           submodules: true
 
       - name: Workaround for sources.list
-        run: sudo sed -i 's|http://azure.archive.ubuntu.com/ubuntu/|http://mirror.arizona.edu/ubuntu/|g' /etc/apt/sources.list
+        run: |
+            # Replace sources
+
+            set -euxo pipefail
+
+            # Peek (what repos are active now)
+            apt-cache policy
+            grep -RInE '^(deb|Types|URIs)' /etc/apt || true
+
+            # Enable nullglob so *.list/*.sources that don't exist don't break sed
+            shopt -s nullglob
+
+            echo "Replace sources.list (legacy)"
+            sudo sed -i \
+              -e "s|https\?://azure\.archive\.ubuntu\.com/ubuntu/?|http://mirror.arizona.edu/ubuntu/|g" \
+              /etc/apt/sources.list || true
+
+            echo "Replace sources.list.d/*.list (legacy)"
+            for f in /etc/apt/sources.list.d/*.list; do
+              sudo sed -i \
+                -e "s|https\?://azure\.archive\.ubuntu\.com/ubuntu/?|http://mirror.arizona.edu/ubuntu/|g" \
+                "$f"
+            done
+
+            echo "Replace sources.list.d/*.sources (deb822)"
+            for f in /etc/apt/sources.list.d/*.sources; do
+              sudo sed -i \
+                -e "s|https\?://azure\.archive\.ubuntu\.com/ubuntu/?|http://mirror.arizona.edu/ubuntu/|g" \
+                -e "s|https\?://azure\.archive\.ubuntu\.com|http://mirror.arizona.edu|g" \
+                "$f"
+            done
+
+            echo "Fix /etc/apt/apt-mirrors.txt (used by URIs: mirror+file:...)"
+            if grep -qE '^[[:space:]]*https?://azure\.archive\.ubuntu\.com/ubuntu/?' /etc/apt/apt-mirrors.txt; then
+              # Replace azure with our mirror (idempotent)
+              sudo sed -i 's|https\?://azure\.archive\.ubuntu\.com/ubuntu/|http://mirror.arizona.edu/ubuntu/|g' /etc/apt/apt-mirrors.txt
+            fi
+
+            # Peek (verify changes)
+            grep -RIn "azure.archive.ubuntu.com" /etc/apt || true
+            grep -RInE '^(deb|Types|URIs)' /etc/apt || true
+            echo "--- apt-mirrors.txt ---"
+            cat /etc/apt/apt-mirrors.txt || true
 
       - name: Update repository
-        run: sudo apt-get update
+        run: sudo apt-get update -o Acquire::Retries=3
 
       - name: Install cross compilers
         run: |

--- a/.github/workflows/test-sunnyday-simulator.yml
+++ b/.github/workflows/test-sunnyday-simulator.yml
@@ -17,10 +17,52 @@ jobs:
           submodules: true
 
       - name: Workaround for sources.list
-        run: sudo sed -i 's|http://azure.archive.ubuntu.com/ubuntu/|http://mirror.arizona.edu/ubuntu/|g' /etc/apt/sources.list
+        run: |
+            # Replace sources
+
+            set -euxo pipefail
+
+            # Peek (what repos are active now)
+            apt-cache policy
+            grep -RInE '^(deb|Types|URIs)' /etc/apt || true
+
+            # Enable nullglob so *.list/*.sources that don't exist don't break sed
+            shopt -s nullglob
+
+            echo "Replace sources.list (legacy)"
+            sudo sed -i \
+              -e "s|https\?://azure\.archive\.ubuntu\.com/ubuntu/?|http://mirror.arizona.edu/ubuntu/|g" \
+              /etc/apt/sources.list || true
+
+            echo "Replace sources.list.d/*.list (legacy)"
+            for f in /etc/apt/sources.list.d/*.list; do
+              sudo sed -i \
+                -e "s|https\?://azure\.archive\.ubuntu\.com/ubuntu/?|http://mirror.arizona.edu/ubuntu/|g" \
+                "$f"
+            done
+
+            echo "Replace sources.list.d/*.sources (deb822)"
+            for f in /etc/apt/sources.list.d/*.sources; do
+              sudo sed -i \
+                -e "s|https\?://azure\.archive\.ubuntu\.com/ubuntu/?|http://mirror.arizona.edu/ubuntu/|g" \
+                -e "s|https\?://azure\.archive\.ubuntu\.com|http://mirror.arizona.edu|g" \
+                "$f"
+            done
+
+            echo "Fix /etc/apt/apt-mirrors.txt (used by URIs: mirror+file:...)"
+            if grep -qE '^[[:space:]]*https?://azure\.archive\.ubuntu\.com/ubuntu/?' /etc/apt/apt-mirrors.txt; then
+              # Replace azure with our mirror (idempotent)
+              sudo sed -i 's|https\?://azure\.archive\.ubuntu\.com/ubuntu/|http://mirror.arizona.edu/ubuntu/|g' /etc/apt/apt-mirrors.txt
+            fi
+
+            # Peek (verify changes)
+            grep -RIn "azure.archive.ubuntu.com" /etc/apt || true
+            grep -RInE '^(deb|Types|URIs)' /etc/apt || true
+            echo "--- apt-mirrors.txt ---"
+            cat /etc/apt/apt-mirrors.txt || true
 
       - name: Update repository
-        run: sudo apt-get update
+        run: sudo apt-get update -o Acquire::Retries=3
 
       - name: Install 32-bit libc
         run: |

--- a/.github/workflows/test-wolfhsm-simulator.yml
+++ b/.github/workflows/test-wolfhsm-simulator.yml
@@ -34,7 +34,11 @@ jobs:
           submodules: true
 
       - name: Workaround for sources.list
-        run: sudo sed -i 's|http://azure.archive.ubuntu.com/ubuntu/|http://mirror.arizona.edu/ubuntu/|g' /etc/apt/sources.list
+        run: |
+            # workaround disabled, splitting the load between azure and arizona.edu to avoid timeouts
+
+            # See reference code in test-build.yml for various sources that may be updated. Enable as needed here.
+            echo "Workaround for sources.list disabled for this workflow"
 
       - name: Update repository
         run: sudo apt-get update


### PR DESCRIPTION

This PR replaces _some_ of the `Workaround for sources.list` steps, addressing the unexplained timeouts when workflows get stuck during `apt-get update`. My personal opinion, without proof, is that there's an (undocumented) azure throttle.

It appears that over time, the _actual_ sources were changed. None of the workarounds were actually doing replacements that the system used. Enclosed is a common block fix for most environments.

The current expected replace needed is _probably_ only in `/etc/apt/apt-mirrors.txt`.  (seems to vary with Ubuntu version)

In order to spread the bandwidth joy, this PR fixes `azure.archive.ubuntu.com` replacements with `mirror.arizona.edu` for only *HALF* of the workflow instances. The remainder will use the default azure source.

No timeout adjustments are included. (see below)

----
(original PR text for reference)

Adjusts the workflow timeout from 15 minutes to 30 minutes. (see my recent https://github.com/wolfSSL/wolfBoot/pull/600) 

Yesterday, I thought perhaps it was an intermittent azure/unbutu problem when doing an `agp-get update` after waiting 2+ hours.

I'm not convinced that this is a _job timeout_ problem. All of the workflows that were cancelled ended during the install phase. The install typically completes in 2 minutes.

Depending on the plan, there are [Job concurrency limits for GitHub-hosted runners](https://docs.github.com/en/actions/reference/limits#job-concurrency-limits-for-github-hosted-runners), also some maximums for [workflows](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax).

In any case, let's try 30 minutes here in this PR.

edit: see also: https://github.com/actions/runner-images/issues/12949
