### PR TITLE
Address workflow timeout, full apt-get source replacements

### DIFF
--- a/.github/workflows/test-build-aarch64.yml
+++ b/.github/workflows/test-build-aarch64.yml
@@ -18,7 +18,7 @@ jobs:
 
   build:
     runs-on: ubuntu-24.04
-    timeout-minutes: 15
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test-build-lms.yml
+++ b/.github/workflows/test-build-lms.yml
@@ -18,7 +18,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v4
@@ -27,10 +27,48 @@ jobs:
 
       - name: Workaround for sources.list
         run: |
-            # workaround disabled, splitting the load between azure and arizona.edu to avoid timeouts
+            # Replace sources
 
-            # See reference code in test-build.yml for various sources that may be updated. Enable as needed here.
-            echo "Workaround for sources.list disabled for this workflow"
+            set -euxo pipefail
+
+            # Peek (what repos are active now)
+            apt-cache policy
+            grep -RInE '^(deb|Types|URIs)' /etc/apt || true
+
+            # Enable nullglob so *.list/*.sources that don't exist don't break sed
+            shopt -s nullglob
+
+            echo "Replace sources.list (legacy)"
+            sudo sed -i \
+              -e "s|https\?://azure\.archive\.ubuntu\.com/ubuntu/?|http://mirror.arizona.edu/ubuntu/|g" \
+              /etc/apt/sources.list || true
+
+            echo "Replace sources.list.d/*.list (legacy)"
+            for f in /etc/apt/sources.list.d/*.list; do
+              sudo sed -i \
+                -e "s|https\?://azure\.archive\.ubuntu\.com/ubuntu/?|http://mirror.arizona.edu/ubuntu/|g" \
+                "$f"
+            done
+
+            echo "Replace sources.list.d/*.sources (deb822)"
+            for f in /etc/apt/sources.list.d/*.sources; do
+              sudo sed -i \
+                -e "s|https\?://azure\.archive\.ubuntu\.com/ubuntu/?|http://mirror.arizona.edu/ubuntu/|g" \
+                -e "s|https\?://azure\.archive\.ubuntu\.com|http://mirror.arizona.edu|g" \
+                "$f"
+            done
+
+            echo "Fix /etc/apt/apt-mirrors.txt (used by URIs: mirror+file:...)"
+            if grep -qE '^[[:space:]]*https?://azure\.archive\.ubuntu\.com/ubuntu/?' /etc/apt/apt-mirrors.txt; then
+              # Replace azure with our mirror (idempotent)
+              sudo sed -i 's|https\?://azure\.archive\.ubuntu\.com/ubuntu/|http://mirror.arizona.edu/ubuntu/|g' /etc/apt/apt-mirrors.txt
+            fi
+
+            # Peek (verify changes)
+            grep -RIn "azure.archive.ubuntu.com" /etc/apt || true
+            grep -RInE '^(deb|Types|URIs)' /etc/apt || true
+            echo "--- apt-mirrors.txt ---"
+            cat /etc/apt/apt-mirrors.txt || true
 
       - name: Update repository
         run: sudo apt-get update

--- a/.github/workflows/test-build-mcux-sdk.yml
+++ b/.github/workflows/test-build-mcux-sdk.yml
@@ -18,7 +18,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v4
@@ -37,10 +37,48 @@ jobs:
 
       - name: Workaround for sources.list
         run: |
-            # workaround disabled, splitting the load between azure and arizona.edu to avoid timeouts
+            # Replace sources
 
-            # See reference code in test-build.yml for various sources that may be updated. Enable as needed here.
-            echo "Workaround for sources.list disabled for this workflow"
+            set -euxo pipefail
+
+            # Peek (what repos are active now)
+            apt-cache policy
+            grep -RInE '^(deb|Types|URIs)' /etc/apt || true
+
+            # Enable nullglob so *.list/*.sources that don't exist don't break sed
+            shopt -s nullglob
+
+            echo "Replace sources.list (legacy)"
+            sudo sed -i \
+              -e "s|https\?://azure\.archive\.ubuntu\.com/ubuntu/?|http://mirror.arizona.edu/ubuntu/|g" \
+              /etc/apt/sources.list || true
+
+            echo "Replace sources.list.d/*.list (legacy)"
+            for f in /etc/apt/sources.list.d/*.list; do
+              sudo sed -i \
+                -e "s|https\?://azure\.archive\.ubuntu\.com/ubuntu/?|http://mirror.arizona.edu/ubuntu/|g" \
+                "$f"
+            done
+
+            echo "Replace sources.list.d/*.sources (deb822)"
+            for f in /etc/apt/sources.list.d/*.sources; do
+              sudo sed -i \
+                -e "s|https\?://azure\.archive\.ubuntu\.com/ubuntu/?|http://mirror.arizona.edu/ubuntu/|g" \
+                -e "s|https\?://azure\.archive\.ubuntu\.com|http://mirror.arizona.edu|g" \
+                "$f"
+            done
+
+            echo "Fix /etc/apt/apt-mirrors.txt (used by URIs: mirror+file:...)"
+            if grep -qE '^[[:space:]]*https?://azure\.archive\.ubuntu\.com/ubuntu/?' /etc/apt/apt-mirrors.txt; then
+              # Replace azure with our mirror (idempotent)
+              sudo sed -i 's|https\?://azure\.archive\.ubuntu\.com/ubuntu/|http://mirror.arizona.edu/ubuntu/|g' /etc/apt/apt-mirrors.txt
+            fi
+
+            # Peek (verify changes)
+            grep -RIn "azure.archive.ubuntu.com" /etc/apt || true
+            grep -RInE '^(deb|Types|URIs)' /etc/apt || true
+            echo "--- apt-mirrors.txt ---"
+            cat /etc/apt/apt-mirrors.txt || true
 
       - name: Update repository
         run: sudo apt-get update

--- a/.github/workflows/test-build-pico-sdk.yml
+++ b/.github/workflows/test-build-pico-sdk.yml
@@ -21,7 +21,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -18,7 +18,7 @@ jobs:
 
   build:
     runs-on: ubuntu-24.04
-    timeout-minutes: 15
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test-sunnyday-simulator.yml
+++ b/.github/workflows/test-sunnyday-simulator.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   simulator_tests:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test-wolfhsm-simulator.yml
+++ b/.github/workflows/test-wolfhsm-simulator.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
 
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v4
@@ -35,10 +35,48 @@ jobs:
 
       - name: Workaround for sources.list
         run: |
-            # workaround disabled, splitting the load between azure and arizona.edu to avoid timeouts
+            # Replace sources
 
-            # See reference code in test-build.yml for various sources that may be updated. Enable as needed here.
-            echo "Workaround for sources.list disabled for this workflow"
+            set -euxo pipefail
+
+            # Peek (what repos are active now)
+            apt-cache policy
+            grep -RInE '^(deb|Types|URIs)' /etc/apt || true
+
+            # Enable nullglob so *.list/*.sources that don't exist don't break sed
+            shopt -s nullglob
+
+            echo "Replace sources.list (legacy)"
+            sudo sed -i \
+              -e "s|https\?://azure\.archive\.ubuntu\.com/ubuntu/?|http://mirror.arizona.edu/ubuntu/|g" \
+              /etc/apt/sources.list || true
+
+            echo "Replace sources.list.d/*.list (legacy)"
+            for f in /etc/apt/sources.list.d/*.list; do
+              sudo sed -i \
+                -e "s|https\?://azure\.archive\.ubuntu\.com/ubuntu/?|http://mirror.arizona.edu/ubuntu/|g" \
+                "$f"
+            done
+
+            echo "Replace sources.list.d/*.sources (deb822)"
+            for f in /etc/apt/sources.list.d/*.sources; do
+              sudo sed -i \
+                -e "s|https\?://azure\.archive\.ubuntu\.com/ubuntu/?|http://mirror.arizona.edu/ubuntu/|g" \
+                -e "s|https\?://azure\.archive\.ubuntu\.com|http://mirror.arizona.edu|g" \
+                "$f"
+            done
+
+            echo "Fix /etc/apt/apt-mirrors.txt (used by URIs: mirror+file:...)"
+            if grep -qE '^[[:space:]]*https?://azure\.archive\.ubuntu\.com/ubuntu/?' /etc/apt/apt-mirrors.txt; then
+              # Replace azure with our mirror (idempotent)
+              sudo sed -i 's|https\?://azure\.archive\.ubuntu\.com/ubuntu/|http://mirror.arizona.edu/ubuntu/|g' /etc/apt/apt-mirrors.txt
+            fi
+
+            # Peek (verify changes)
+            grep -RIn "azure.archive.ubuntu.com" /etc/apt || true
+            grep -RInE '^(deb|Types|URIs)' /etc/apt || true
+            echo "--- apt-mirrors.txt ---"
+            cat /etc/apt/apt-mirrors.txt || true
 
       - name: Update repository
         run: sudo apt-get update


### PR DESCRIPTION
Similar to https://github.com/wolfSSL/wolfBoot/pull/603 and https://github.com/wolfSSL/wolfBoot/pull/600; We're still seeing timeouts.

I'm _still_ not convinced that the timeout limit is the root cause, even though seen on the [603](https://github.com/wolfSSL/wolfBoot/pull/601) merge [here](https://github.com/wolfSSL/wolfBoot/actions/runs/18356529437/job/52289938496?pr=601).

Note that again, the "timeout"occurs during a simple [Install cross compilers](https://github.com/wolfSSL/wolfBoot/blob/62ce4cf6796dee8004895955a35b2e4d30feac67/.github/workflows/test-build-mcux-sdk.yml#L50) step that typically takes only a couple of minutes.

In any case, this PR extends the timeout limit _and_ more importantly: replaces remaining `azure.archive.ubuntu.com` references.

Note that although the previous timeout was seen in [test-configs.yml](https://github.com/wolfSSL/wolfBoot/blob/62ce4cf6796dee8004895955a35b2e4d30feac67/.github/workflows/test-configs.yml#L76), _that_ config pulls in other config file templates. See the `uses` keyword. Those are the files with the updated timeout in this PR. (e.g. `test-build-mcux-sdk.yml`).

