### PR TITLE
Update Copyright year to 2025

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # CMakeLists.txt
 #
-# Copyright (C) 2022 wolfSSL Inc.
+# Copyright (C) 2025 wolfSSL Inc.
 #
 # This file is part of wolfBoot.
 #

--- a/IDE/CCS/TMS570LC43xx/target.h
+++ b/IDE/CCS/TMS570LC43xx/target.h
@@ -5,7 +5,7 @@
  * target.h is automatically generated using the template in target.h.in by running
  * "make config".
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/IDE/IAR/target.h
+++ b/IDE/IAR/target.h
@@ -5,7 +5,7 @@
  * target.h is automatically generated using the template in target.h.in by running
  * "make config".
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/IDE/MPLAB/bootloader/src/config/default/ATSAME51J20A.ld
+++ b/IDE/MPLAB/bootloader/src/config/default/ATSAME51J20A.ld
@@ -1,7 +1,7 @@
 /*--------------------------------------------------------------------------
  * MPLAB XC32 Compiler -  ATSAME51J20A linker script
  * 
- * Copyright (c) 2023, Microchip Technology Inc. and its subsidiaries ("Microchip")
+ * Copyright (C) 2025, Microchip Technology Inc. and its subsidiaries ("Microchip")
  * All rights reserved.
  * 
  * This software is developed by Microchip Technology Inc. and its

--- a/IDE/MPLAB/test-app/test-usb-updater.same51.X/app.c
+++ b/IDE/MPLAB/test-app/test-usb-updater.same51.X/app.c
@@ -1,6 +1,6 @@
 /* app.c
  *
- * Copyright (C) 2024 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/IDE/MPLAB/test-app/test-usb-updater.same51.X/main.c
+++ b/IDE/MPLAB/test-app/test-usb-updater.same51.X/main.c
@@ -1,6 +1,6 @@
 /* main.c
  *
- * Copyright (C) 2024 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/IDE/Renesas/e2studio/RA6M4/app_RA/src/SEGGER_RTT/myprint.c
+++ b/IDE/Renesas/e2studio/RA6M4/app_RA/src/SEGGER_RTT/myprint.c
@@ -1,6 +1,6 @@
 /* myprintf.c
  *
- * Copyright (C) 2006-2023 wolfSSL Inc.
+ * Copyright (C) 2006-2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/IDE/Renesas/e2studio/RA6M4/app_RA/src/app_RA.c
+++ b/IDE/Renesas/e2studio/RA6M4/app_RA/src/app_RA.c
@@ -2,7 +2,7 @@
  *
  * Test bare-metal application.
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/IDE/Renesas/e2studio/RA6M4/wolfBoot/src/target.h
+++ b/IDE/Renesas/e2studio/RA6M4/wolfBoot/src/target.h
@@ -4,7 +4,7 @@
  *
  * This is for Renesas RA6M4 board.
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/IDE/Renesas/e2studio/RA6M4/wolfBoot/src/user_settings.h
+++ b/IDE/Renesas/e2studio/RA6M4/wolfBoot/src/user_settings.h
@@ -4,7 +4,7 @@
  * Enabled via WOLFSSL_USER_SETTINGS.
  *
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/IDE/Renesas/e2studio/RX72N/app_RenesasRX01/src/app_RenesasRX01.c
+++ b/IDE/Renesas/e2studio/RX72N/app_RenesasRX01/src/app_RenesasRX01.c
@@ -2,7 +2,7 @@
  *
  * Test bare-metal application.
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/IDE/Renesas/e2studio/RX72N/include/target.h
+++ b/IDE/Renesas/e2studio/RX72N/include/target.h
@@ -5,7 +5,7 @@
  * target.h is automatically generated using the template in target.h.in by running
  * "make config".
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/IDE/Renesas/e2studio/RX72N/include/user_settings.h
+++ b/IDE/Renesas/e2studio/RX72N/include/user_settings.h
@@ -4,7 +4,7 @@
  * Enabled via WOLFSSL_USER_SETTINGS.
  *
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/IDE/Renesas/e2studio/RZN2L/app_RZ/src/hal_entry.c
+++ b/IDE/Renesas/e2studio/RZN2L/app_RZ/src/hal_entry.c
@@ -4,7 +4,7 @@
  * Enabled via WOLFSSL_USER_SETTINGS.
  *
  *
- * Copyright (C) 2024 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/IDE/Renesas/e2studio/RZN2L/app_RZ/src/local_system_init.c
+++ b/IDE/Renesas/e2studio/RZN2L/app_RZ/src/local_system_init.c
@@ -4,7 +4,7 @@
  * Enabled via WOLFSSL_USER_SETTINGS.
  *
  *
- * Copyright (C) 2024 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/IDE/Renesas/e2studio/RZN2L/flash_app/src/Flash_section.s
+++ b/IDE/Renesas/e2studio/RZN2L/flash_app/src/Flash_section.s
@@ -4,7 +4,7 @@
  * Enabled via WOLFSSL_USER_SETTINGS.
  *
  *
- * Copyright (C) 2024 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/IDE/Renesas/e2studio/RZN2L/flash_app/src/Flash_update.s
+++ b/IDE/Renesas/e2studio/RZN2L/flash_app/src/Flash_update.s
@@ -4,7 +4,7 @@
  * Enabled via WOLFSSL_USER_SETTINGS.
  *
  *
- * Copyright (C) 2024 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/IDE/Renesas/e2studio/RZN2L/flash_app/src/Flash_wrappedkey_public.s
+++ b/IDE/Renesas/e2studio/RZN2L/flash_app/src/Flash_wrappedkey_public.s
@@ -1,6 +1,6 @@
 /* Flash_wrappedkey_public.s
  *
- * Copyright (C) 2024 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/IDE/Renesas/e2studio/RZN2L/flash_app/src/hal_entry.c
+++ b/IDE/Renesas/e2studio/RZN2L/flash_app/src/hal_entry.c
@@ -4,7 +4,7 @@
  * Enabled via WOLFSSL_USER_SETTINGS.
  *
  *
- * Copyright (C) 2024 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/IDE/Renesas/e2studio/RZN2L/target.h
+++ b/IDE/Renesas/e2studio/RZN2L/target.h
@@ -4,7 +4,7 @@
  *
  * This is for Renesas RZN2L board.
  *
- * Copyright (C) 2024 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/IDE/Renesas/e2studio/RZN2L/user_settings.h
+++ b/IDE/Renesas/e2studio/RZN2L/user_settings.h
@@ -4,7 +4,7 @@
  * Enabled via WOLFSSL_USER_SETTINGS.
  *
  *
- * Copyright (C) 2024 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/IDE/Renesas/e2studio/RZN2L/wolfboot/src/hal_entry.c
+++ b/IDE/Renesas/e2studio/RZN2L/wolfboot/src/hal_entry.c
@@ -5,7 +5,7 @@
  * Enabled via WOLFSSL_USER_SETTINGS.
  *
  *
- * Copyright (C) 2024 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/cmake/functions.cmake
+++ b/cmake/functions.cmake
@@ -1,6 +1,6 @@
 # functions.cmake
 #
-# Copyright (C) 2022 wolfSSL Inc.
+# Copyright (C) 2025 wolfSSL Inc.
 #
 # This file is part of wolfBoot.
 #

--- a/cmake/toolchain_aarch64-none-elf.cmake
+++ b/cmake/toolchain_aarch64-none-elf.cmake
@@ -1,6 +1,6 @@
 # toolchain_aarch64-none-elf.cmake
 #
-# Copyright (C) 2022 wolfSSL Inc.
+# Copyright (C) 2025 wolfSSL Inc.
 #
 # This file is part of wolfBoot.
 #

--- a/cmake/toolchain_arm-none-eabi.cmake
+++ b/cmake/toolchain_arm-none-eabi.cmake
@@ -1,6 +1,6 @@
 # toolchain_arm-none-eabi.cmake
 #
-# Copyright (C) 2022 wolfSSL Inc.
+# Copyright (C) 2025 wolfSSL Inc.
 #
 # This file is part of wolfBoot.
 #

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -1,6 +1,6 @@
 # utils.cmake
 #
-# Copyright (C) 2022 wolfSSL Inc.
+# Copyright (C) 2025 wolfSSL Inc.
 #
 # This file is part of wolfBoot.
 #

--- a/cmake/wolfboot.cmake
+++ b/cmake/wolfboot.cmake
@@ -1,6 +1,6 @@
 # wolfboot.cmake
 #
-# Copyright (C) 2022 wolfSSL Inc.
+# Copyright (C) 2025 wolfSSL Inc.
 #
 # This file is part of wolfBoot.
 #

--- a/hal/armv8m_tz.h
+++ b/hal/armv8m_tz.h
@@ -1,6 +1,6 @@
 /* armv8m_tz.h
  *
- * Copyright (C) 2024 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/cc26x2.c
+++ b/hal/cc26x2.c
@@ -1,6 +1,6 @@
 /* cc26x2.c
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/hal.c
+++ b/hal/hal.c
@@ -1,6 +1,6 @@
 /* hal.c
  *
- * Copyright (C) 2024 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/hifive1.c
+++ b/hal/hifive1.c
@@ -1,6 +1,6 @@
 /* hifive1.c
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/imx_rt.c
+++ b/hal/imx_rt.c
@@ -3,7 +3,7 @@
  * Custom HAL implementation. Defines the
  * functions used by wolfboot for a specific target.
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/kinetis.c
+++ b/hal/kinetis.c
@@ -1,6 +1,6 @@
 /* kinetis.c
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/kontron_vx3060_s2.c
+++ b/hal/kontron_vx3060_s2.c
@@ -1,6 +1,6 @@
 /* kontron_vx3060_s2.c
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/kontron_vx3060_s2_loader.c
+++ b/hal/kontron_vx3060_s2_loader.c
@@ -1,6 +1,6 @@
 /* kontron_vx3060_s2_loader.c
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/library.c
+++ b/hal/library.c
@@ -1,6 +1,6 @@
 /* library.c
  *
- * Copyright (C) 2022 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/lpc.c
+++ b/hal/lpc.c
@@ -1,6 +1,6 @@
 /* lpc.c
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/mcxa.c
+++ b/hal/mcxa.c
@@ -1,6 +1,6 @@
 /* mcxa.c
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/nrf52.c
+++ b/hal/nrf52.c
@@ -1,6 +1,6 @@
 /* nrf52.c
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/nrf52.h
+++ b/hal/nrf52.h
@@ -1,6 +1,6 @@
 /* nrf52.h
  *
- * Copyright (C) 2024 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/nrf5340.c
+++ b/hal/nrf5340.c
@@ -1,6 +1,6 @@
 /* nrf5340.c
  *
- * Copyright (C) 2024 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/nrf5340.h
+++ b/hal/nrf5340.h
@@ -1,6 +1,6 @@
 /* nrf5340.h
  *
- * Copyright (C) 2024 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/nrf5340_net.c
+++ b/hal/nrf5340_net.c
@@ -1,6 +1,6 @@
 /* nrf5340_net.c
  *
- * Copyright (C) 2024 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/nxp_ls1028a.c
+++ b/hal/nxp_ls1028a.c
@@ -1,6 +1,6 @@
 /* nxp_ls1028a.c
  *
- * Copyright (C) 2024 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/nxp_ls1028a.h
+++ b/hal/nxp_ls1028a.h
@@ -1,6 +1,6 @@
 /* nxp_ls1028a.h
  *
- * Copyright (C) 2024 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/nxp_p1021.c
+++ b/hal/nxp_p1021.c
@@ -1,6 +1,6 @@
 /* nxp_p1021.c
  *
- * Copyright (C) 2022 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/nxp_ppc.c
+++ b/hal/nxp_ppc.c
@@ -1,6 +1,6 @@
 /* nxp_ppc.c
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/nxp_ppc.h
+++ b/hal/nxp_ppc.h
@@ -1,6 +1,6 @@
 /* nxp_ppc.h
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/nxp_t1024.c
+++ b/hal/nxp_t1024.c
@@ -1,6 +1,6 @@
 /* nxp_t1024.c
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/nxp_t2080.c
+++ b/hal/nxp_t2080.c
@@ -1,6 +1,6 @@
 /* nxp_t2080.c
  *
- * Copyright (C) 2022 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/pic32cz.c
+++ b/hal/pic32cz.c
@@ -1,6 +1,6 @@
 /* pic32cz.c
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/psoc6.c
+++ b/hal/psoc6.c
@@ -1,6 +1,6 @@
 /* psoc6.c
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/raspi3.c
+++ b/hal/raspi3.c
@@ -1,6 +1,6 @@
 /* raspi3.c
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/renesas-ra.c
+++ b/hal/renesas-ra.c
@@ -3,7 +3,7 @@
  * Stubs for custom HAL implementation. Defines the
  * functions used by wolfboot for a specific target.
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/renesas-rx.c
+++ b/hal/renesas-rx.c
@@ -3,7 +3,7 @@
  * Stubs for custom HAL implementation. Defines the
  * functions used by wolfBoot for a specific target.
  *
- * Copyright (C) 2022 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/renesas-rx.h
+++ b/hal/renesas-rx.h
@@ -1,6 +1,6 @@
 /* renesas-rx.h
  *
- * Copyright (C) 2024 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/renesas-rz.c
+++ b/hal/renesas-rz.c
@@ -3,7 +3,7 @@
  * Stubs for custom HAL implementation. Defines the
  * functions used by wolfboot for a specific target.
  *
- * Copyright (C) 2024 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/rx65n.c
+++ b/hal/rx65n.c
@@ -1,6 +1,6 @@
 /* rx65n.c
  *
- * Copyright (C) 2024 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/rx72n.c
+++ b/hal/rx72n.c
@@ -1,6 +1,6 @@
 /* rx72n.c
  *
- * Copyright (C) 2024 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/sama5d3.c
+++ b/hal/sama5d3.c
@@ -1,6 +1,6 @@
 /* atsama5d3.c
  *
- * Copyright (C) 2024 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/sama5d3.h
+++ b/hal/sama5d3.h
@@ -2,7 +2,7 @@
  *
  * Header file for SAMA5D3 HAL
  *
- * Copyright (C) 2024 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/same51.c
+++ b/hal/same51.c
@@ -1,6 +1,6 @@
 /* same51.c
  *
- * Copyright (C) 2024 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/samr21.c
+++ b/hal/samr21.c
@@ -1,6 +1,6 @@
 /* samr21.c
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/sim.c
+++ b/hal/sim.c
@@ -1,6 +1,6 @@
 /* sim.c
  *
- * Copyright (C) 2022 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/skeleton.c
+++ b/hal/skeleton.c
@@ -3,7 +3,7 @@
  * Stubs for custom HAL implementation. Defines the 
  * functions used by wolfboot for a specific target.
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/spi/spi_drv_nrf52.c
+++ b/hal/spi/spi_drv_nrf52.c
@@ -6,7 +6,7 @@
  *
  * Pinout: see spi_drv_nrf52.h
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/spi/spi_drv_nrf5340.c
+++ b/hal/spi/spi_drv_nrf5340.c
@@ -6,7 +6,7 @@
  *
  * Pinout: see spi_drv_nrf5340.h
  *
- * Copyright (C) 2024 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/spi/spi_drv_nxp.c
+++ b/hal/spi/spi_drv_nxp.c
@@ -4,7 +4,7 @@
  *
  * Pinout: see spi_drv_nxp.h
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/spi/spi_drv_renesas_rx.c
+++ b/hal/spi/spi_drv_renesas_rx.c
@@ -4,7 +4,7 @@
  *
  * Example implementation for Renesas RX65N.
  *
- * Copyright (C) 2024 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/spi/spi_drv_stm32.c
+++ b/hal/spi/spi_drv_stm32.c
@@ -6,7 +6,7 @@
  *
  * Pinout: see spi_drv_stm32.h
  *
- * Copyright (C) 2022 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/spi/spi_drv_zynq.c
+++ b/hal/spi/spi_drv_zynq.c
@@ -1,6 +1,6 @@
 /* spi_drv_zynq.c
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/stm32_tz.c
+++ b/hal/stm32_tz.c
@@ -1,6 +1,6 @@
 /* stm32_tz.c
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/stm32c0.c
+++ b/hal/stm32c0.c
@@ -1,6 +1,6 @@
 /* stm32c0.c
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/stm32f4.c
+++ b/hal/stm32f4.c
@@ -1,6 +1,6 @@
 /* stm32f4.c
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/stm32f7.c
+++ b/hal/stm32f7.c
@@ -1,6 +1,6 @@
 /* stm32f7.c
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/stm32g0.c
+++ b/hal/stm32g0.c
@@ -1,6 +1,6 @@
 /* stm32g0.c
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/stm32h5.c
+++ b/hal/stm32h5.c
@@ -1,6 +1,6 @@
 /* stm32h5.c
  *
- * Copyright (C) 2024 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/stm32h5.h
+++ b/hal/stm32h5.h
@@ -1,6 +1,6 @@
 /* stm32h5.h
  *
- * Copyright (C) 2024 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/stm32h7.c
+++ b/hal/stm32h7.c
@@ -1,6 +1,6 @@
 /* stm32h7.c
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/stm32h7.h
+++ b/hal/stm32h7.h
@@ -1,6 +1,6 @@
 /* stm32h7.h
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/stm32l0.c
+++ b/hal/stm32l0.c
@@ -1,6 +1,6 @@
 /* stm32l0.c
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/stm32l4.c
+++ b/hal/stm32l4.c
@@ -1,6 +1,6 @@
 /* stm32l4.c
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/stm32l4xx_hal_conf.h
+++ b/hal/stm32l4xx_hal_conf.h
@@ -1,6 +1,6 @@
 /* stm32-4xx_hal_conf.h
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/stm32l5.c
+++ b/hal/stm32l5.c
@@ -1,6 +1,6 @@
 /* stm32l5.c
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/stm32l5.h
+++ b/hal/stm32l5.h
@@ -1,6 +1,6 @@
 /* stm32l5.h
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/stm32u5.c
+++ b/hal/stm32u5.c
@@ -1,6 +1,6 @@
 /* stm32u5.c
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/stm32u5.h
+++ b/hal/stm32u5.h
@@ -1,6 +1,6 @@
 /* stm32u5.h
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/stm32u5_partition.h
+++ b/hal/stm32u5_partition.h
@@ -1,6 +1,6 @@
 /* stm32u5_partition.h
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/stm32wb.c
+++ b/hal/stm32wb.c
@@ -1,6 +1,6 @@
 /* stm32wb.c
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/ti_hercules.c
+++ b/hal/ti_hercules.c
@@ -1,6 +1,6 @@
 /* ti_hercules.c
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/uart/uart_drv_lpc.c
+++ b/hal/uart/uart_drv_lpc.c
@@ -4,7 +4,7 @@
  *
  * Example implementation for LPC54xxx, using UART0.
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/uart/uart_drv_stm32f4.c
+++ b/hal/uart/uart_drv_stm32f4.c
@@ -6,7 +6,7 @@
  *
  * Pinout: RX=PD9, TX=PD8
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/uart/uart_drv_stm32h5.c
+++ b/hal/uart/uart_drv_stm32h5.c
@@ -6,7 +6,7 @@
  * using LPUART1 (VCS port through USB).
  *
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/uart/uart_drv_stm32l0.c
+++ b/hal/uart/uart_drv_stm32l0.c
@@ -6,7 +6,7 @@
  *
  * Pinout: RX=PA3, TX=PA2
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/uart/uart_drv_stm32l5.c
+++ b/hal/uart/uart_drv_stm32l5.c
@@ -6,7 +6,7 @@
  * using LPUART1 (VCS port through USB).
  *
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/uart/uart_drv_stm32wb.c
+++ b/hal/uart/uart_drv_stm32wb.c
@@ -6,7 +6,7 @@
  *
  * Pinout: RX=PB7, TX=PB6 (VCOM port UART1 -> STLINK USB)
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/x86_64_efi.c
+++ b/hal/x86_64_efi.c
@@ -1,7 +1,7 @@
 
 /* x86_64_efi.c
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/x86_fsp_qemu.c
+++ b/hal/x86_fsp_qemu.c
@@ -1,6 +1,6 @@
 /* x86_fsp_qemu.c
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/x86_fsp_qemu_loader.c
+++ b/hal/x86_fsp_qemu_loader.c
@@ -1,6 +1,6 @@
 /* x86_fsp_qemu_loader.c
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/x86_fsp_tgl.c
+++ b/hal/x86_fsp_tgl.c
@@ -1,6 +1,6 @@
 /* fsp_tgl.c
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/x86_uart.c
+++ b/hal/x86_uart.c
@@ -2,7 +2,7 @@
  *
  * Implementation of a very basic 8250 UART driver for x86
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/zynq.c
+++ b/hal/zynq.c
@@ -1,6 +1,6 @@
 /* zynq.c
  *
- * Copyright (C) 2024 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/hal/zynq.h
+++ b/hal/zynq.h
@@ -1,6 +1,6 @@
 /* zynq.h
  *
- * Copyright (C) 2024 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/include/MPLAB/target.h
+++ b/include/MPLAB/target.h
@@ -5,7 +5,7 @@
  * target.h is automatically generated using the template in target.h.in by running
  * "make config".
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/include/delta.h
+++ b/include/delta.h
@@ -14,7 +14,7 @@
  * --delta option.
  *
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/include/elf.h
+++ b/include/elf.h
@@ -1,6 +1,6 @@
 /* elf.h
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/include/encrypt.h
+++ b/include/encrypt.h
@@ -2,7 +2,7 @@
  *
  * Functions to encrypt/decrypt external flash content
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/include/fdt.h
+++ b/include/fdt.h
@@ -3,7 +3,7 @@
  * Functions to help with flattened device tree (DTB) parsing
  *
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/include/hal.h
+++ b/include/hal.h
@@ -2,7 +2,7 @@
  *
  * The HAL API definitions.
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/include/image.h
+++ b/include/image.h
@@ -3,7 +3,7 @@
  * Functions to help with wolfBoot image header
  *
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/include/keystore.h
+++ b/include/keystore.h
@@ -3,7 +3,7 @@
  * API's for key store
  *
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/include/loader.h
+++ b/include/loader.h
@@ -3,7 +3,7 @@
  * Public key information for the signed images
  *
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/include/multiboot.h
+++ b/include/multiboot.h
@@ -1,6 +1,6 @@
 /* 
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/include/otp_keystore.h
+++ b/include/otp_keystore.h
@@ -3,7 +3,7 @@
  * Helper for storing/retrieving Trust Anchor to/from OTP flash
  *
  *
- * Copyright (C) 2024 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/include/pci.h
+++ b/include/pci.h
@@ -1,6 +1,6 @@
 /* pci.h
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/include/printf.h
+++ b/include/printf.h
@@ -2,7 +2,7 @@
  *
  * The HAL API definitions.
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/include/spi_drv.h
+++ b/include/spi_drv.h
@@ -7,7 +7,7 @@
  *     implementing the spi_ calls below.
  *
  *
- * Copyright (C) 2022 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/include/spi_flash.h
+++ b/include/spi_flash.h
@@ -6,7 +6,7 @@
  * Compile with SPI_FLASH=1
  *
  *
- * Copyright (C) 2022 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/include/stage2_params.h
+++ b/include/stage2_params.h
@@ -1,6 +1,6 @@
 /* stage2_params.h
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/include/target.h.in
+++ b/include/target.h.in
@@ -5,7 +5,7 @@
  * target.h is automatically generated using the template in target.h.in by running
  * "make config".
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/include/tpm.h
+++ b/include/tpm.h
@@ -1,6 +1,6 @@
 /* tpm.h
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/include/uart_drv.h
+++ b/include/uart_drv.h
@@ -2,7 +2,7 @@
  *
  * The HAL API definitions for UART driver extension.
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/include/uart_flash.h
+++ b/include/uart_flash.h
@@ -9,7 +9,7 @@
  * emulated non-volatile image via UART.
  *
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/include/user_settings.h
+++ b/include/user_settings.h
@@ -4,7 +4,7 @@
  * Enabled via WOLFSSL_USER_SETTINGS.
  *
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/include/wolfboot/version.h
+++ b/include/wolfboot/version.h
@@ -2,7 +2,7 @@
  *
  * The wolfBoot library version
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/include/wolfboot/wc_secure.h
+++ b/include/wolfboot/wc_secure.h
@@ -2,7 +2,7 @@
  *
  * The wolfBoot library version
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/include/wolfboot/wcs_pkcs11.h
+++ b/include/wolfboot/wcs_pkcs11.h
@@ -2,7 +2,7 @@
  *
  * The wolfBoot library version
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/include/wolfboot/wolfboot.h
+++ b/include/wolfboot/wolfboot.h
@@ -2,7 +2,7 @@
  *
  * The wolfBoot API definitions.
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/include/x86/ahci.h
+++ b/include/x86/ahci.h
@@ -1,6 +1,6 @@
 /* ahci.h
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/include/x86/ata.h
+++ b/include/x86/ata.h
@@ -1,6 +1,6 @@
 /* ata.h
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/include/x86/common.h
+++ b/include/x86/common.h
@@ -1,6 +1,6 @@
 /* common.h
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/include/x86/exceptions.h
+++ b/include/x86/exceptions.h
@@ -1,6 +1,6 @@
 /* exceptions.h
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/include/x86/fsp.h
+++ b/include/x86/fsp.h
@@ -1,6 +1,6 @@
 /* fsp.h
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/include/x86/fsp/FspCommon.h
+++ b/include/x86/fsp/FspCommon.h
@@ -1,6 +1,6 @@
 /* FspCommon.h
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/include/x86/fsp/stdtype_mapping.h
+++ b/include/x86/fsp/stdtype_mapping.h
@@ -1,5 +1,5 @@
 /* stdtype_mapping.h.c
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/include/x86/gdt.h
+++ b/include/x86/gdt.h
@@ -1,6 +1,6 @@
 /* gdt.h
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/include/x86/gpt.h
+++ b/include/x86/gpt.h
@@ -1,6 +1,6 @@
 /* gpt.h
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/include/x86/hob.h
+++ b/include/x86/hob.h
@@ -2,7 +2,7 @@
  *
  * Headers for Hand-off Block (HOB) objects
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/include/x86/linux_loader.h
+++ b/include/x86/linux_loader.h
@@ -2,7 +2,7 @@
  *
  * Headers for linux boot parameters
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/include/x86/mptable.h
+++ b/include/x86/mptable.h
@@ -1,6 +1,6 @@
 /* mptable.h
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/include/x86/paging.h
+++ b/include/x86/paging.h
@@ -1,6 +1,6 @@
 /* paging.h
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/include/x86/tgl_fsp.h
+++ b/include/x86/tgl_fsp.h
@@ -1,6 +1,6 @@
 /* tgl_fsp.h
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,6 +1,6 @@
 # CMakeLists.txt
 #
-# Copyright (C) 2022 wolfSSL Inc.
+# Copyright (C) 2025 wolfSSL Inc.
 #
 # This file is part of wolfBoot.
 #

--- a/src/boot_aarch64_start.S
+++ b/src/boot_aarch64_start.S
@@ -1,6 +1,6 @@
 /**
  * Aarch64 bootup
- * Copyright (C) 2024 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/src/boot_arm.c
+++ b/src/boot_arm.c
@@ -1,6 +1,6 @@
 /* boot_arm.c
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/src/boot_arm32.c
+++ b/src/boot_arm32.c
@@ -2,7 +2,7 @@
  *
  * Bring up, vectors and do_boot for 32bit Cortex-A microprocessors.
  *
- * Copyright (C) 2024 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/src/boot_arm32_start.S
+++ b/src/boot_arm32_start.S
@@ -1,6 +1,6 @@
 /**
  * Arm32 (32bit Cortex-A) boot up 
- * Copyright (C) 2024 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/src/boot_ppc.c
+++ b/src/boot_ppc.c
@@ -1,6 +1,6 @@
 /* boot_ppc.c
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/src/boot_ppc_mp.S
+++ b/src/boot_ppc_mp.S
@@ -1,6 +1,6 @@
 /* boot_ppc_mp.S
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/src/boot_ppc_start.S
+++ b/src/boot_ppc_start.S
@@ -1,6 +1,6 @@
 /* boot_ppc_start.S
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/src/boot_renesas.c
+++ b/src/boot_renesas.c
@@ -1,6 +1,6 @@
 /* boot_renesas.c
  *
- * Copyright (C) 2024 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/src/boot_renesas_start.S
+++ b/src/boot_renesas_start.S
@@ -1,6 +1,6 @@
 /* boot_renesas_start.S
  *
- * Copyright (C) 2024 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/src/boot_riscv.c
+++ b/src/boot_riscv.c
@@ -1,6 +1,6 @@
 /* boot_riscv.c
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/src/boot_x86_64.c
+++ b/src/boot_x86_64.c
@@ -1,6 +1,6 @@
 /* boot_x86_64.c
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/src/boot_x86_fsp.c
+++ b/src/boot_x86_fsp.c
@@ -1,6 +1,6 @@
 /* boot_x86_fsp.c
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/src/boot_x86_fsp_payload.c
+++ b/src/boot_x86_fsp_payload.c
@@ -1,6 +1,6 @@
 /* boot_x86_fsp_payload.c
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/src/boot_x86_fsp_start.S
+++ b/src/boot_x86_fsp_start.S
@@ -1,6 +1,6 @@
 ;; boot_x86_fsp_start.S
 ;;
-;; Copyright (C) 2023 wolfSSL Inc.
+;; Copyright (C) 2025 wolfSSL Inc.
 ;;
 ;; This file is part of wolfBoot.
 ;;

--- a/src/delta.c
+++ b/src/delta.c
@@ -1,6 +1,6 @@
 /* delta.c
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/src/elf.c
+++ b/src/elf.c
@@ -1,6 +1,6 @@
 /* elf.c
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/src/fdt.c
+++ b/src/fdt.c
@@ -3,7 +3,7 @@
  * Functions to help with flattened device tree (DTB) parsing
  *
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/src/flash_otp_keystore.c
+++ b/src/flash_otp_keystore.c
@@ -3,7 +3,7 @@
  * Implementation for Flash based OTP keystore used as trust anchor
  *
  *
- * Copyright (C) 2024 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/src/image.c
+++ b/src/image.c
@@ -1,6 +1,6 @@
 /* image.c
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/src/libwolfboot.c
+++ b/src/libwolfboot.c
@@ -1,6 +1,6 @@
 /* libwolfboot.c
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/src/loader.c
+++ b/src/loader.c
@@ -1,6 +1,6 @@
 /* loader.c
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/src/multiboot.c
+++ b/src/multiboot.c
@@ -1,6 +1,6 @@
 /* multiboot.c
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/src/pci.c
+++ b/src/pci.c
@@ -1,6 +1,6 @@
 /* pci.c
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/src/pkcs11_callable.c
+++ b/src/pkcs11_callable.c
@@ -1,6 +1,6 @@
 /* pkcs11_callable.c
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/src/pkcs11_store.c
+++ b/src/pkcs11_store.c
@@ -1,6 +1,6 @@
 /* pkcs11_store.c
  *
- * Copyright (C) 2024 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/src/qspi_flash.c
+++ b/src/qspi_flash.c
@@ -4,7 +4,7 @@
  * functionalities, on top of the spi_drv.h HAL.
  *
  *
- * Copyright (C) 2022 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/src/spi_flash.c
+++ b/src/spi_flash.c
@@ -4,7 +4,7 @@
  * functionalities, on top of the spi_drv.h HAL.
  *
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/src/stage2_params.c
+++ b/src/stage2_params.c
@@ -1,6 +1,6 @@
 /* stage2_params.c
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/src/string.c
+++ b/src/string.c
@@ -3,7 +3,7 @@
  * Implementations of standard library functions to eliminate external dependencies.
  *
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/src/tpm.c
+++ b/src/tpm.c
@@ -1,6 +1,6 @@
 /* tpm.c
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/src/uart_flash.c
+++ b/src/uart_flash.c
@@ -8,7 +8,7 @@
  * interface.
  *
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/src/update_disk.c
+++ b/src/update_disk.c
@@ -4,7 +4,7 @@
  * drives and partition mapping.
  *
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/src/update_flash.c
+++ b/src/update_flash.c
@@ -3,7 +3,7 @@
  * Implementation for Flash based updater
  *
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/src/update_flash_hwswap.c
+++ b/src/update_flash_hwswap.c
@@ -3,7 +3,7 @@
  * Implementation for hardware assisted updater
  *
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/src/update_ram.c
+++ b/src/update_ram.c
@@ -3,7 +3,7 @@
  * Implementation for RAM based updater
  *
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/src/vector_riscv.S
+++ b/src/vector_riscv.S
@@ -1,6 +1,6 @@
 /**
  * RISC-V bootup
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/src/wc_callable.c
+++ b/src/wc_callable.c
@@ -1,6 +1,6 @@
 /* wc_callable.c
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/src/x86/ahci.c
+++ b/src/x86/ahci.c
@@ -1,6 +1,6 @@
 /* ahci.c
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/src/x86/ata.c
+++ b/src/x86/ata.c
@@ -1,6 +1,6 @@
 /* ata.c
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/src/x86/common.c
+++ b/src/x86/common.c
@@ -1,6 +1,6 @@
 /* common.c
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/src/x86/exceptions.c
+++ b/src/x86/exceptions.c
@@ -1,6 +1,6 @@
 /* exceptions.c
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/src/x86/fsp.c
+++ b/src/x86/fsp.c
@@ -1,6 +1,6 @@
 /* fsp_tgl.c
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/src/x86/gdt.c
+++ b/src/x86/gdt.c
@@ -1,6 +1,6 @@
 /* gdt.c
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/src/x86/gpt.c
+++ b/src/x86/gpt.c
@@ -1,6 +1,6 @@
 /* gpt.c
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/src/x86/hob.c
+++ b/src/x86/hob.c
@@ -2,7 +2,7 @@
  *
  * Functions to encrypt/decrypt external flash content
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/src/x86/linux_loader.c
+++ b/src/x86/linux_loader.c
@@ -1,5 +1,5 @@
 /* linux_loader.c
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/src/x86/mptable.c
+++ b/src/x86/mptable.c
@@ -1,6 +1,6 @@
 /* mptable.c
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/src/x86/paging.c
+++ b/src/x86/paging.c
@@ -1,6 +1,6 @@
 /* paging.c
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/src/x86/qemu_fsp.c
+++ b/src/x86/qemu_fsp.c
@@ -1,5 +1,5 @@
 /* qemu_fsp.c
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/src/x86/tgl_fsp.c
+++ b/src/x86/tgl_fsp.c
@@ -1,5 +1,5 @@
 /* tgl_fsp.c
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/src/xmalloc.c
+++ b/src/xmalloc.c
@@ -3,7 +3,7 @@
  * Fixed-pool implementation of malloc/free for wolfBoot
  *
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/stage1/loader_stage1.c
+++ b/stage1/loader_stage1.c
@@ -1,7 +1,7 @@
 
 /* loader_stage1.c
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/test-app/CMakeLists.txt
+++ b/test-app/CMakeLists.txt
@@ -1,6 +1,6 @@
 # CMakeLists.txt
 #
-# Copyright (C) 2022 wolfSSL Inc.
+# Copyright (C) 2025 wolfSSL Inc.
 #
 # This file is part of wolfBoot.
 #

--- a/test-app/app_hifive1.c
+++ b/test-app/app_hifive1.c
@@ -1,6 +1,6 @@
 /* hifive1.c
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/test-app/app_imx_rt.c
+++ b/test-app/app_imx_rt.c
@@ -1,6 +1,6 @@
 /* wolfBoot test application for iMX-RT1060-EVK
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * wolfSSL is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/test-app/app_kinetis.c
+++ b/test-app/app_kinetis.c
@@ -1,6 +1,6 @@
 /* kinetis.c
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/test-app/app_lpc.c
+++ b/test-app/app_lpc.c
@@ -2,7 +2,7 @@
  *
  * Test bare-metal boot-led-on application
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/test-app/app_mcxa.c
+++ b/test-app/app_mcxa.c
@@ -2,7 +2,7 @@
  *
  * Test bare-metal boot-led-on application
  *
- * Copyright (C) 2024 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/test-app/app_mcxw.c
+++ b/test-app/app_mcxw.c
@@ -2,7 +2,7 @@
  *
  * Test bare-metal boot-led-on application
  *
- * Copyright (C) 2024 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/test-app/app_nrf52.c
+++ b/test-app/app_nrf52.c
@@ -1,6 +1,6 @@
 /* nrf52.c
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/test-app/app_nrf5340.c
+++ b/test-app/app_nrf5340.c
@@ -1,6 +1,6 @@
 /* nrf5340.c
  *
- * Copyright (C) 2024 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/test-app/app_nrf5340_net.c
+++ b/test-app/app_nrf5340_net.c
@@ -1,6 +1,6 @@
 /* nrf5340.c
  *
- * Copyright (C) 2024 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/test-app/app_nxp_ls1028a.c
+++ b/test-app/app_nxp_ls1028a.c
@@ -1,6 +1,6 @@
 /* app_nxp_ls1028a.c
  *
- * Copyright (C) 2024 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/test-app/app_nxp_p1021.c
+++ b/test-app/app_nxp_p1021.c
@@ -1,6 +1,6 @@
 /* app_nxp_p1021.c
  *
- * Copyright (C) 2022 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/test-app/app_nxp_t1024.c
+++ b/test-app/app_nxp_t1024.c
@@ -1,6 +1,6 @@
 /* app_nxp_t1024.c
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/test-app/app_nxp_t2080.c
+++ b/test-app/app_nxp_t2080.c
@@ -1,6 +1,6 @@
 /* app_nxp_t2080.c
  *
- * Copyright (C) 2022 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/test-app/app_psoc6.c
+++ b/test-app/app_psoc6.c
@@ -2,7 +2,7 @@
  *
  * Test bare-metal boot-led-on application
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/test-app/app_raspi3.c
+++ b/test-app/app_raspi3.c
@@ -2,7 +2,7 @@
  *
  * Test bare-metal boot application
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/test-app/app_renesas_rx.c
+++ b/test-app/app_renesas_rx.c
@@ -2,7 +2,7 @@
  *
  * Test bare-metal application.
  *
- * Copyright (C) 2024 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/test-app/app_sama5d3.c
+++ b/test-app/app_sama5d3.c
@@ -2,7 +2,7 @@
  *
  * Test bare-metal boot application
  *
- * Copyright (C) 2024 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/test-app/app_same51.c
+++ b/test-app/app_same51.c
@@ -1,6 +1,6 @@
 /* same51.c
  *
- * Copyright (C) 2024 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/test-app/app_samr21.c
+++ b/test-app/app_samr21.c
@@ -1,6 +1,6 @@
 /* samr21.c
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/test-app/app_sim.c
+++ b/test-app/app_sim.c
@@ -2,7 +2,7 @@
  *
  * Test bare-metal boot-led-on application
  *
- * Copyright (C) 2022 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/test-app/app_stm32c0.c
+++ b/test-app/app_stm32c0.c
@@ -2,7 +2,7 @@
  *
  * Test bare-metal boot-led-on application
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/test-app/app_stm32f4.c
+++ b/test-app/app_stm32f4.c
@@ -2,7 +2,7 @@
  *
  * Test bare-metal blinking led application
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/test-app/app_stm32g0.c
+++ b/test-app/app_stm32g0.c
@@ -2,7 +2,7 @@
  *
  * Test bare-metal boot-led-on application
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/test-app/app_stm32h5.c
+++ b/test-app/app_stm32h5.c
@@ -2,7 +2,7 @@
  *
  * Test bare-metal application.
  *
- * Copyright (C) 2024 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/test-app/app_stm32h7.c
+++ b/test-app/app_stm32h7.c
@@ -2,7 +2,7 @@
  *
  * Test bare-metal application.
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/test-app/app_stm32l0.c
+++ b/test-app/app_stm32l0.c
@@ -2,7 +2,7 @@
  *
  * Test bare-metal boot-led-on application
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/test-app/app_stm32l5.c
+++ b/test-app/app_stm32l5.c
@@ -2,7 +2,7 @@
  *
  * Test bare-metal application.
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/test-app/app_stm32u5.c
+++ b/test-app/app_stm32u5.c
@@ -2,7 +2,7 @@
  *
  * Test bare-metal application.
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/test-app/app_stm32wb.c
+++ b/test-app/app_stm32wb.c
@@ -2,7 +2,7 @@
  *
  * Test bare-metal boot-led-on application
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/test-app/app_ti_hercules.c
+++ b/test-app/app_ti_hercules.c
@@ -2,7 +2,7 @@
  *
  * Test bare-metal boot application
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/test-app/app_x86_fsp_qemu.c
+++ b/test-app/app_x86_fsp_qemu.c
@@ -2,7 +2,7 @@
  *
  * Test bare-metal boot application
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/test-app/app_zynq.c
+++ b/test-app/app_zynq.c
@@ -2,7 +2,7 @@
  *
  * Test bare-metal boot application
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/test-app/boot_arm32_start.S
+++ b/test-app/boot_arm32_start.S
@@ -1,6 +1,6 @@
 /**
  * Arm32 (32bit Cortex-A) boot up 
- * Copyright (C) 2024 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/test-app/imx_rt_clock_config.c
+++ b/test-app/imx_rt_clock_config.c
@@ -1,6 +1,6 @@
 /* wolfBoot test application for i.MX RT1060-EVK
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * wolfSSL is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/test-app/led.c
+++ b/test-app/led.c
@@ -2,7 +2,7 @@
  *
  * Test bare-metal blinking led application
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/test-app/led.h
+++ b/test-app/led.h
@@ -2,7 +2,7 @@
  *
  * Test bare-metal blinking led application
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/test-app/startup_arm.c
+++ b/test-app/startup_arm.c
@@ -2,7 +2,7 @@
  *
  * Test bare-metal blinking led application
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/test-app/startup_riscv.c
+++ b/test-app/startup_riscv.c
@@ -1,6 +1,6 @@
 /* startup_riscv.c
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/test-app/system.c
+++ b/test-app/system.c
@@ -2,7 +2,7 @@
  *
  * Test bare-metal blinking led application
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/test-app/system.h
+++ b/test-app/system.h
@@ -1,7 +1,7 @@
 /* system.h
  *
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/test-app/timer.c
+++ b/test-app/timer.c
@@ -2,7 +2,7 @@
  *
  * Test bare-metal blinking led application
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/test-app/timer.h
+++ b/test-app/timer.h
@@ -2,7 +2,7 @@
  *
  * Test bare-metal blinking led application
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/test-app/vector_riscv.S
+++ b/test-app/vector_riscv.S
@@ -1,6 +1,6 @@
 /**
  * RISC-V bootup
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/test-app/wcs/pkcs11_test_ecc.c
+++ b/test-app/wcs/pkcs11_test_ecc.c
@@ -1,6 +1,6 @@
 /* pkcs11_test_ecc.c
  *
- * Copyright (C) 2006-2020 wolfSSL Inc.
+ * Copyright (C) 2006-2025 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/test-app/wcs/user_settings.h
+++ b/test-app/wcs/user_settings.h
@@ -3,7 +3,7 @@
  * Custom configuration for wolfCrypt/wolfSSL (PKCS11 client example)
  *
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/test-app/wcs/wolfcrypt_secure.c
+++ b/test-app/wcs/wolfcrypt_secure.c
@@ -1,6 +1,6 @@
 /* wolfcrypt-secure.c
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/tools/bin-assemble/bin-assemble.c
+++ b/tools/bin-assemble/bin-assemble.c
@@ -1,6 +1,6 @@
 /* bin-assemble.c
  *
- * Copyright (C) 2006-2021 wolfSSL Inc.
+ * Copyright (C) 2006-2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/tools/check_config/check_config.c
+++ b/tools/check_config/check_config.c
@@ -3,7 +3,7 @@
  * Show configuration
  *
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/tools/delta/bmdiff.c
+++ b/tools/delta/bmdiff.c
@@ -3,7 +3,7 @@
  * diff/patch tool for wolfBoot
  *
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/tools/elf-parser/elf-parser.c
+++ b/tools/elf-parser/elf-parser.c
@@ -1,6 +1,6 @@
 /* elf-parser.c
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/tools/fdt-parser/fdt-parser.c
+++ b/tools/fdt-parser/fdt-parser.c
@@ -1,6 +1,6 @@
 /* fdt-parser.c
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/tools/keytools/keygen.c
+++ b/tools/keytools/keygen.c
@@ -3,7 +3,7 @@
  * C native key generation tool
  *
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/tools/keytools/keygen.py
+++ b/tools/keytools/keygen.py
@@ -2,7 +2,7 @@
 '''
  * keygen.py
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/tools/keytools/otp/otp-keystore-gen.c
+++ b/tools/keytools/otp/otp-keystore-gen.c
@@ -3,7 +3,7 @@
  * Command line utility to create a OTP image
  *
  *
- * Copyright (C) 2024 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/tools/keytools/otp/otp-keystore-primer.c
+++ b/tools/keytools/otp/otp-keystore-primer.c
@@ -3,7 +3,7 @@
  * Primer app to provision public keys into OTP flash
  *
  *
- * Copyright (C) 2024 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/tools/keytools/otp/startup.c
+++ b/tools/keytools/otp/startup.c
@@ -2,7 +2,7 @@
  *
  * Test bare-metal blinking led application
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/tools/keytools/sign.c
+++ b/tools/keytools/sign.c
@@ -3,7 +3,7 @@
  * C native signing tool
  *
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/tools/keytools/sign.py
+++ b/tools/keytools/sign.py
@@ -2,7 +2,7 @@
 '''
  * sign.py
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/tools/keytools/user_settings.h
+++ b/tools/keytools/user_settings.h
@@ -4,7 +4,7 @@
  * Enabled via WOLFSSL_USER_SETTINGS.
  *
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/tools/lms/lms_common.h
+++ b/tools/lms/lms_common.h
@@ -4,7 +4,7 @@
  * key file.
  *
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/tools/test-expect-version/test-expect-version.c
+++ b/tools/test-expect-version/test-expect-version.c
@@ -1,6 +1,6 @@
 /* test-update-server.c
  *
- * Copyright (C) 2006-2021 wolfSSL Inc.
+ * Copyright (C) 2006-2025 wolfSSL Inc.
  *
  * This file is part of wolfSSL. (formerly known as CyaSSL)
  *

--- a/tools/test-update-server/server.c
+++ b/tools/test-update-server/server.c
@@ -1,6 +1,6 @@
 /* test-update-server.c
  *
- * Copyright (C) 2006-2021 wolfSSL Inc.
+ * Copyright (C) 2006-2025 wolfSSL Inc.
  *
  * This file is part of wolfSSL. (formerly known as CyaSSL)
  *

--- a/tools/tpm/policy_create.c
+++ b/tools/tpm/policy_create.c
@@ -1,6 +1,6 @@
 /* policy_create.c
  *
- * Copyright (C) 2006-2023 wolfSSL Inc.
+ * Copyright (C) 2006-2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/tools/tpm/policy_sign.c
+++ b/tools/tpm/policy_sign.c
@@ -1,6 +1,6 @@
 /* policy_sign.c
  *
- * Copyright (C) 2006-2023 wolfSSL Inc.
+ * Copyright (C) 2006-2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/tools/tpm/rot.c
+++ b/tools/tpm/rot.c
@@ -1,6 +1,6 @@
 /* rot.c
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/tools/tpm/user_settings.h
+++ b/tools/tpm/user_settings.h
@@ -3,7 +3,7 @@
  * Configuration for wolfBoot TPM tools.
  * Enabled via WOLFSSL_USER_SETTINGS.
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/tools/uart-flash-server/ufserver.c
+++ b/tools/uart-flash-server/ufserver.c
@@ -4,7 +4,7 @@
  *
  * Run on HOST machine to export an emulated external, non-volatile memory.
  *
- * Copyright (C) 2022 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/tools/unit-tests/target.h
+++ b/tools/unit-tests/target.h
@@ -5,7 +5,7 @@
  * target.h is automatically generated using the template in target.h.in by running
  * "make config".
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/tools/unit-tests/unit-common.c
+++ b/tools/unit-tests/unit-common.c
@@ -3,7 +3,7 @@
  * Unit test common tools 
  *
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/tools/unit-tests/unit-delta.c
+++ b/tools/unit-tests/unit-delta.c
@@ -2,7 +2,7 @@
  *
  * unit tests for delta updates module
  *
- * Copyright (C) 2024 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/tools/unit-tests/unit-enc-nvm.c
+++ b/tools/unit-tests/unit-enc-nvm.c
@@ -2,7 +2,7 @@
  *
  * unit tests for encrypted updates with nvm_flash_writeonce fix
  *
- * Copyright (C) 2024 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/tools/unit-tests/unit-extflash.c
+++ b/tools/unit-tests/unit-extflash.c
@@ -3,7 +3,7 @@
  * Unit test for parser functions in libwolfboot.c
  *
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/tools/unit-tests/unit-image.c
+++ b/tools/unit-tests/unit-image.c
@@ -3,7 +3,7 @@
  * Unit test for parser functions in image.c
  *
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/tools/unit-tests/unit-keystore.c
+++ b/tools/unit-tests/unit-keystore.c
@@ -3,7 +3,7 @@
  * example keystore used for image.c unit tests
  *
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/tools/unit-tests/unit-mock-flash.c
+++ b/tools/unit-tests/unit-mock-flash.c
@@ -4,7 +4,7 @@
  * usage: #include "unit-mock-flash.c"
  *
  *
- * Copyright (C) 2024 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/tools/unit-tests/unit-mock-state.c
+++ b/tools/unit-tests/unit-mock-state.c
@@ -3,7 +3,7 @@
  * Unit test for parser functions in libwolfboot.c
  *
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/tools/unit-tests/unit-nvm.c
+++ b/tools/unit-tests/unit-nvm.c
@@ -2,7 +2,7 @@
  *
  * unit tests for nvm_flash_writeonce workaround.
  *
- * Copyright (C) 2024 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/tools/unit-tests/unit-parser.c
+++ b/tools/unit-tests/unit-parser.c
@@ -3,7 +3,7 @@
  * Unit test for parser functions in libwolfboot.c
  *
  *
- * Copyright (C) 2021 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/tools/unit-tests/unit-pci.c
+++ b/tools/unit-tests/unit-pci.c
@@ -3,7 +3,7 @@
  * Unit test for pci functions
  *
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/tools/unit-tests/unit-pkcs11_store.c
+++ b/tools/unit-tests/unit-pkcs11_store.c
@@ -3,7 +3,7 @@
  * Unit test for PKCS11 storage module
  *
  *
- * Copyright (C) 2024 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/tools/unit-tests/unit-sectorflags.c
+++ b/tools/unit-tests/unit-sectorflags.c
@@ -3,7 +3,7 @@
  * Unit test for sector flags functions in libwolfboot.c
  *
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/tools/unit-tests/unit-update-flash.c
+++ b/tools/unit-tests/unit-update-flash.c
@@ -2,7 +2,7 @@
  *
  * unit tests for update procedures in update_flash.c
  *
- * Copyright (C) 2024 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/tools/unit-tests/unit-update-ram.c
+++ b/tools/unit-tests/unit-update-ram.c
@@ -2,7 +2,7 @@
  *
  * unit tests for update procedures in update_ram.c
  *
- * Copyright (C) 2024 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *

--- a/tools/xmss/xmss_common.h
+++ b/tools/xmss/xmss_common.h
@@ -4,7 +4,7 @@
  * key file.
  *
  *
- * Copyright (C) 2023 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfBoot.
  *


### PR DESCRIPTION
Updates Copyright year to 2025 as noted in [#598](https://github.com/wolfSSL/wolfBoot/pull/598#discussion_r2431699309).

Should the copyright be 

`Copyright (C) 2006-2025 wolfSSL Inc.` 

instead of 

`Copyright (C) 2025 wolfSSL Inc.` 

... for all files?