### PR TITLE
Set max-parallel 12 to address runner concurrency saturation, cleanup, use math matrix

### DIFF
--- a/.github/workflows/test-library.yml
+++ b/.github/workflows/test-library.yml
@@ -33,6 +33,11 @@ jobs:
         asym: [ed25519, ecc256, ecc384, ecc521, rsa2048, rsa3072, rsa4096, ed448]
         hash: [sha256, sha384, sha3]
 
+        # See https://github.com/wolfSSL/wolfBoot/issues/614 regarding exclusions:
+        exclude:
+          - math: "SPMATH=1 WOLFBOOT_SMALL_STACK=1"
+          - math: "SPMATHALL=1 WOLFBOOT_SMALL_STACK=1"
+
     steps:
       - uses: actions/checkout@v4
         with:
@@ -70,13 +75,18 @@ jobs:
 
           # First attempt
           if build_once >build.out 2>build.err; then
-            echo "Success on first attempt"
+            echo "Success on first attempt, WOLFBOOT_HUGE_STACK not applied."
             exit 0
           fi
 
           # If it failed due to the TFM huge stack guard, retry with the flag
-          if grep -q 'If this is OK, please compile with WOLFBOOT_HUGE_STACK=1' build.err; then
-            echo "Retrying with WOLFBOOT_HUGE_STACK=1 due to TFM stack requirement"
+          if grep -Fq 'If this is OK, please compile with WOLFBOOT_HUGE_STACK=1' build.err; then
+            echo "Retrying with WOLFBOOT_HUGE_STACK=1 due to stack requirement error."
+
+            # Always print the entire message
+            grep -Fn 'If this is OK, please compile with WOLFBOOT_HUGE_STACK=1' build.err || true
+
+            # Try again with huge stack allowed
             build_once WOLFBOOT_HUGE_STACK=1
           else
             echo "Build failed for another reason:"


### PR DESCRIPTION
Latest in a series of pull requests to address various timeout and workflow cancellation issues.

This one is in response to a [cancellation](https://github.com/gojimmypi/wolfBoot/actions/runs/18691683650/job/53298707729) that is suspected of being related to runner concurrency saturation limits.

```
The job was not acquired by Runner of type hosted even after multiple attempts
Internal server error. Correlation ID: 3694f37c-df70-4a94-9a86-62a446b313b7
```

Also: it appears the prior `math` matrix was defined, but not used? This PR appends the value to the `make test-lib ...`., but perhaps this belongs in a separate PR? Particularly considering https://github.com/wolfSSL/wolfBoot/issues/614 .

See also:

- https://github.com/wolfSSL/wolfBoot/pull/605
- https://github.com/wolfSSL/wolfBoot/pull/603
- https://github.com/wolfSSL/wolfBoot/pull/600

### Edit: the first iteration of this PR had:

```
    concurrency:
      # Avoid duplicate runs on the same ref
      group: ${{ github.workflow }}-${{ github.ref }}
      cancel-in-progress: true
```

This resulted in almost all matrix jobs cancelled right away (for example [this one](https://github.com/wolfSSL/wolfBoot/actions/runs/18693756318/job/53305793930?pr=613)) with the message:

```
Canceling since a higher priority waiting request for wolfBoot as Library test-refs/pull/613/merge exists
```

So I've updated it to `cancel-in-progress: false`:

```
    concurrency:
      # Avoid duplicate runs on the same ref
      group: ${{ github.workflow }}-${{ github.ref }}
      cancel-in-progress: false
```

That didn't help, so I expanded the definition of concurrency detection:

```
    concurrency:
      # Avoid duplicate runs on the same ref
    group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.head.sha || github.sha }}
    cancel-in-progress: true
```

In the end, I gave up on concurrency, as I could not get more than 2 jobs running. See [docs](https://docs.github.com/en/enterprise-server@3.17/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency).

### Edit (2):  The `math` part of the matrix appeared to not be actually used in the test matrix. 

I cleaned up the list, adding quotes around the line items. Then encountered sets of non-intuitive errors:

```
Run details
Annotations
2 errors
The job was not acquired by Runner of type hosted even after multiple attempts
Internal server error. Correlation ID: 3694f37c-df70-4a94-9a86-62a446b313b7
```

When manually re-running, I (oddly) observed much more detail, for [example](https://github.com/wolfSSL/wolfBoot/actions/runs/18694704150/job/53310168559?pr=613#logs):

```
Run cp config/examples/library.config .config
  cp config/examples/library.config .config
  make keytools
  ./tools/keytools/keygen --${ASYM} -g wolfboot_signing_private_key.der
  echo "Test" > test.bin
  ./tools/keytools/sign --${ASYM} --${HASH} test.bin wolfboot_signing_private_key.der 1
  # Convert asym and hash to upper case
  make test-lib SIGN=${ASYM^^} HASH=${HASH^^} ${MATH}
  shell: /usr/bin/bash -e {0}
  env:
    ASYM: rsa4096
    HASH: sha256
    MATH: SPMATH=0 SPMATHALL=0 WOLFBOOT_SMALL_STACK=0
Building key tools
make[1]: Entering directory '/home/runner/work/wolfBoot/wolfBoot/tools/keytools'
Building signing tool
Building keygen tool
make[1]: Leaving directory '/home/runner/work/wolfBoot/wolfBoot/tools/keytools'
Keystore size: 2608
Keytype: RSA4096
Generating key (type: RSA4096)
RSA public key len: 550 bytes
Associated key file:   wolfboot_signing_private_key.der
Partition ids mask:   ffffffff
Key type   :           RSA4096
Public key slot:       0
Done.
wolfBoot KeyTools (Compiled C version)
wolfBoot version 2060000
Update type:          Firmware
Input image:          test.bin
Selected cipher:      RSA4096
Selected hash  :      SHA256
Private key:           wolfboot_signing_private_key.der
Output  image:        test_v1_signed.bin
Target partition id : 1 
Manifest header size: 1024
Found RSA4096 key
Hashing primary pubkey, size: 550
Calculating SHA256 digest...
Signing the digest...
Sign: 04
Output image(s) successfully created.
	[CC sim] src/string.o
	[CC sim] src/image.o
src/image.c:359:6: error: #error "TFM will allocate 70+ KB in the stack with this configuration." "If this is OK, please compile with WOLFBOOT_HUGE_STACK=1"
  359 |     #error "TFM will allocate 70+ KB in the stack with this configuration." \
      |      ^~~~~
make: *** [Makefile:539: src/image.o] Error 1
Error: Process completed with exit code 2.
```

I added an automatic retry to append `WOLFBOOT_HUGE_STACK=1` . Yet still some are failing, for [example](https://github.com/wolfSSL/wolfBoot/actions/runs/18695617102/job/53312132389?pr=613):

```
Run ./test-lib test_v1_signed.bin
  ./test-lib test_v1_signed.bin
  ./test-lib test_v1_signed.bin 2>&1 | grep "Firmware Valid"
  shell: /usr/bin/bash -e {0}
Boot partition: 0x55d76aeb7490 (sz 5, ver 0x1, type 0x201)
Failure -2: Hdr 1, Hash 1, Sig 0
Error: Process completed with exit code 1.
```

Some of the retries work, but there are still some failures. Temporarily added exclusions:

```
        exclude:
          - math: "SPMATH=1 WOLFBOOT_SMALL_STACK=1"
          - math: "SPMATHALL=1 WOLFBOOT_SMALL_STACK=1"
```