### PR TITLE
Hard fail if the wrong user settings is detected

### DIFF
--- a/hal/library.c
+++ b/hal/library.c
@@ -46,6 +46,12 @@
     #undef NO_FILESYSTEM
 #endif
 
+#ifdef WOLFBOOT_KEYTOOLS
+    /* this code needs to use the Use ./include/user_settings.h file */
+    #error "The wrong user_settings.h has been included."
+#endif
+
+
 /* HAL Stubs */
 void hal_init(void)
 {

--- a/src/image.c
+++ b/src/image.c
@@ -30,6 +30,11 @@
 #include <stdio.h>
 #endif
 #include <wolfssl/wolfcrypt/settings.h> /* for wolfCrypt hash/sign routines */
+#ifdef WOLFBOOT_KEYTOOLS
+    /* this code needs to use the Use ./include/user_settings.h, not keytools */
+    #error "The wrong user_settings.h has been included."
+#endif
+
 
 #include <stddef.h>
 #include <string.h>


### PR DESCRIPTION
I spent an embarrassingly large amount of time troubleshooting a signature problem that was rooted in an unexpected `user_settings.h` being compiled into the app.

This PR detects if the `WOLFBOOT_KEYTOOLS` user settings is included, instead of the desired one in the .`/include` directory.