### PR TITLE
Introduce keyfile check scripts

### DIFF
--- a/tools/scripts/keystore_file_check.bat
+++ b/tools/scripts/keystore_file_check.bat
@@ -1,0 +1,168 @@
+@echo off
+rem keystore_file_check.bat
+rem Find files with the same name as given targets in any other local branch.
+
+rem Defaults for wolfBoot if no args are given
+set DEF1=wolfboot_signing_private_key.der
+set DEF2=keystore.der
+set DEF3=keystore.c
+
+if "%~1"=="" (
+    set T1=%DEF1%
+    set T2=%DEF2%
+    set T3=%DEF3%
+    set TARGET_COUNT=3
+) else (
+    set T1=%~1
+    set T2=%~2
+    set T3=%~3
+    set TARGET_COUNT=0
+    if not "%~1"=="" set TARGET_COUNT=1
+    if not "%~2"=="" set TARGET_COUNT=2
+    if not "%~3"=="" set TARGET_COUNT=3
+)
+
+:: -------------------------------------------------------------------------------------------
+:: Begin common section to start at repo root
+:: -------------------------------------------------------------------------------------------
+setlocal EnableExtensions EnableDelayedExpansion
+
+rem === Resolve script path/dir ===
+set "SCRIPT_PATH=%~f0"
+for %%I in ("%~dp0") do set "SCRIPT_DIR=%%~fI"
+
+rem === Repo root is parent of /tools/scripts ===
+for %%I in ("%SCRIPT_DIR%\..\..") do set "REPO_ROOT=%%~fI"
+
+rem === Caller's current directory ===
+for %%I in ("%CD%") do set "CALLER_CWD=%%~fI"
+
+rem === (Optional) Normalize to physical paths via PowerShell to resolve junctions/symlinks ===
+rem call :physpath "%SCRIPT_DIR%" SCRIPT_DIR_P
+rem call :physpath "%REPO_ROOT%" REPO_ROOT_P
+rem call :physpath "%CALLER_CWD%" CALLER_CWD_P
+set "SCRIPT_DIR_P=%SCRIPT_DIR%"
+set "REPO_ROOT_P=%REPO_ROOT%"
+set "CALLER_CWD_P=%CALLER_CWD%"
+
+rem === Print only if caller CWD is neither [root] nor [root]\scripts ===
+if /I "%CALLER_CWD_P%"=="%REPO_ROOT_P%" goto after_print
+if /I "%CALLER_CWD_P%"=="%REPO_ROOT_P%\scripts" goto after_print
+
+echo Caller CWD = %CALLER_CWD_P%
+echo SCRIPT_DIR  = %SCRIPT_DIR_P%
+echo REPO_ROOT   = %REPO_ROOT_P%
+
+:after_print
+rem === Always work from repo root ===
+pushd "%REPO_ROOT_P%" || goto :err
+echo Starting %~nx0 from %CD%
+:: -------------------------------------------------------------------------------------------
+:: End common section to start at repo root
+:: -------------------------------------------------------------------------------------------
+
+
+rem Ensure we are in a git repo
+git rev-parse --git-dir >nul 2>&1
+if errorlevel 1 (
+    echo Error: not inside a git repository.
+    exit /b 2
+)
+
+rem Determine current branch (may be detached)
+for /f "usebackq tokens=*" %%B in (`git rev-parse --abbrev-ref HEAD 2^>nul`) do set CUR_BRANCH=%%B
+if "%CUR_BRANCH%"=="" set CUR_BRANCH=HEAD
+
+rem Build list of local branches (excluding current, unless detached)
+set "BR_LIST="
+for /f "usebackq tokens=*" %%R in (`git for-each-ref --format^="%%(refname:short)" refs/heads/`) do (
+    if /i "%CUR_BRANCH%"=="HEAD" (
+        set "BR_LIST=!BR_LIST!;;%%R"
+    ) else (
+        if /i not "%%R"=="%CUR_BRANCH%" (
+            set "BR_LIST=!BR_LIST!;;%%R"
+        )
+    )
+)
+
+set EXIT_CODE=0
+
+call :PROCESS_TARGET "%T1%"
+if %TARGET_COUNT% LSS 2 goto DONE
+call :PROCESS_TARGET "%T2%"
+if %TARGET_COUNT% LSS 3 goto DONE
+call :PROCESS_TARGET "%T3%"
+goto DONE
+
+:PROCESS_TARGET
+set "TARGET=%~1"
+if "%TARGET%"=="" goto :eof
+
+rem Normalize and get basename
+set "TMPP=%TARGET:/=\%"
+for %%G in ("%TMPP%") do set "BASENAME=%%~nxG"
+
+echo === Searching for name: %BASENAME% ===
+
+rem -------- FAST CURRENT WORKING TREE SCAN (tracked + untracked + ignored) --------
+set CCNT=0
+
+rem Tracked + staged + untracked (excluding ignored)
+for /f "usebackq delims=" %%P in (`
+  git ls-files -co --exclude-standard
+`) do (
+    set "PTH=%%P"
+    set "PTHB=!PTH:/=\!"
+    for %%Q in ("!PTHB!") do set "NM=%%~nxQ"
+    if /i "!NM!"=="%BASENAME%" (
+        if !CCNT! EQU 0 echo Paths in current branch:
+        echo   .\!PTHB!
+        set /a CCNT+=1
+    )
+)
+
+rem Ignored files too (in case the file is generated and ignored)
+for /f "usebackq delims=" %%P in (`
+  git ls-files -i --others --exclude-standard
+`) do (
+    set "PTH=%%P"
+    set "PTHB=!PTH:/=\!"
+    for %%Q in ("!PTHB!") do set "NM=%%~nxQ"
+    if /i "!NM!"=="%BASENAME%" (
+        if !CCNT! EQU 0 echo Paths in current branch:
+        echo   .\!PTHB!
+        set /a CCNT+=1
+    )
+)
+
+echo Current branch %CUR_BRANCH% has %CCNT% file(s) named %BASENAME%
+
+rem -------- OTHER BRANCHES (tracked only) --------
+set FOUND_ANY=0
+for %%B in (%BR_LIST:;;= %) do (
+    for /f "usebackq delims=" %%F in (`
+      git ls-tree -r --name-only "%%B"
+    `) do (
+        set "OP=%%F"
+        set "OPB=!OP:/=\!"
+        for %%H in ("!OPB!") do set "ON=%%~nxH"
+        if /i "!ON!"=="%BASENAME%" (
+            if "!FOUND_ANY!"=="0" (
+                echo Matches in other branches:
+                set FOUND_ANY=1
+            )
+            echo   %%B:%%F
+        )
+    )
+)
+
+if "%FOUND_ANY%"=="0" (
+    echo No matches in other branches.
+) else (
+    set EXIT_CODE=1
+)
+echo.
+goto :eof
+
+:DONE
+endlocal & exit /b %EXIT_CODE%

--- a/tools/scripts/keystore_file_check.sh
+++ b/tools/scripts/keystore_file_check.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+#
+# keystore_file_check.sh
+# Find files with the same name as given targets in any other local branch.
+
+echo "$0 v1.0"
+echo ""
+
+# Specify the executable shell checker you want to use:
+MY_SHELLCHECK="shellcheck"
+
+# Check if the executable is available in the PATH
+if command -v "$MY_SHELLCHECK" >/dev/null 2>&1; then
+    # Run your command here
+    shellcheck "$0" || exit 1
+else
+    echo "$MY_SHELLCHECK is not installed. Please install it if changes to this script have been made."
+fi
+
+if git --version >/dev/null 2>&1; then
+    # Run your command here
+    echo "Confirmed git is installed: $(git --version)"
+else
+    echo "git is not installed. Please install it to use this script."  >&2
+    exit 1
+fi
+
+
+set -euo pipefail
+
+# Defaults for wolfBoot, used when no args are given
+DEFAULTS=(
+    "wolfboot_signing_private_key.der"
+    "keystore.der"
+    "keystore.c"
+)
+
+usage() {
+    echo "Usage: $0 [file1 [file2 ...]]"
+    echo "If no files are provided, the defaults are:"
+    printf "  %s\n" "${DEFAULTS[@]}"
+}
+
+
+# --------------------------------------------------------------------------------------------
+# Begin common section to start at repo root, for /tools/scripts
+# --------------------------------------------------------------------------------------------
+# Resolve this script's absolute path and its directories
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_PATH="${SCRIPT_DIR}/$(basename -- "${BASH_SOURCE[0]}")"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../.." && pwd)"
+
+# Normalize to physical paths (no symlinks, no trailing slashes)
+# SCRIPT_DIR_P="$(cd -- "$SCRIPT_DIR" && pwd -P)"
+REPO_ROOT_P="$(cd -- "$REPO_ROOT" && pwd -P)"
+CALLER_CWD_P="$(pwd -P)"   # where the user ran the script from
+
+# Print only if caller's cwd is neither REPO_ROOT nor REPO_ROOT/scripts
+case "$CALLER_CWD_P" in
+    "$REPO_ROOT_P" | "$REPO_ROOT_P"/scripts)
+        : # silent
+        ;;
+    *)
+        echo "Script paths:"
+        echo "-- SCRIPT_PATH =$SCRIPT_PATH"
+        echo "-- SCRIPT_DIR  =$SCRIPT_DIR"
+        echo "-- REPO_ROOT   =$REPO_ROOT"
+        ;;
+esac
+
+# Always work from the repo root, regardless of where the script was invoked
+cd -- "$REPO_ROOT_P" || { printf 'Failed to cd to: %s\n' "$REPO_ROOT_P" >&2; exit 1; }
+echo "Starting $0 from $(pwd -P)"
+# --------------------------------------------------------------------------------------------
+# End common section to start at repo root, for /tools/scripts
+# --------------------------------------------------------------------------------------------
+
+
+
+
+
+# Resolve targets
+if [ "$#" -eq 0 ]; then
+    TARGETS=("${DEFAULTS[@]}")
+else
+    TARGETS=("$@")
+fi
+
+# Ensure we are in a git repo
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+    echo "Error: not inside a git repository."
+    exit 2
+fi
+
+# Determine current branch (may be detached)
+CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")"
+
+# Get list of local branches
+mapfile -t BRANCHES < <(git for-each-ref --format="%(refname:short)" refs/heads/)
+
+# Filter out current branch if named
+OTHER_BRANCHES=()
+for b in "${BRANCHES[@]}"; do
+    if [ "$CURRENT_BRANCH" != "HEAD" ] && [ -n "$CURRENT_BRANCH" ]; then
+        if [ "$b" != "$CURRENT_BRANCH" ]; then
+            OTHER_BRANCHES+=("$b")
+        fi
+    else
+        # Detached HEAD, consider all branches
+        OTHER_BRANCHES+=("$b")
+    fi
+done
+
+# Helper to list and count files with this basename in the current working tree
+# Includes tracked, untracked, and ignored files (fast: no disk crawl)
+list_and_count_in_current_branch() {
+    local base="$1"
+    local count=0
+    local printed=0
+    # Collect working-tree paths: tracked + untracked + ignored, unique
+    while IFS= read -r path; do
+        name="${path##*/}"
+        if [ "$name" = "$base" ]; then
+            if [ $printed -eq 0 ]; then
+                echo "Paths in current branch ${CURRENT_BRANCH:-(detached)}:"
+                printed=1
+            fi
+            echo "  ./$path"
+            count=$((count + 1))
+        fi
+    done < <( { git ls-files -co --exclude-standard; git ls-files -i --others --exclude-standard; } | sort -u )
+    echo "$count"
+}
+
+
+exit_code=0
+
+for target in "${TARGETS[@]}"; do
+    base="${target##*/}"
+
+    echo "=== Searching for name: ${base} ==="
+
+    # Report presence count on current branch
+    cur_count="$(list_and_count_in_current_branch  "$base")"
+    echo "Current branch ${CURRENT_BRANCH:-(detached)} has ${cur_count} file(s) named ${base}"
+
+    # Search other branches
+    found_any=0
+    for br in "${OTHER_BRANCHES[@]}"; do
+        # List all names in branch and print matches by basename
+        while IFS= read -r path; do
+            name="${path##*/}"
+            if [ "$name" = "$base" ]; then
+                if [ "$found_any" -eq 0 ]; then
+                    echo "Matches in other branches:"
+                    found_any=1
+                fi
+                echo "  ${br}:${path}"
+            fi
+        done < <(git ls-tree -r --name-only "$br")
+    done
+
+    if [ "$found_any" -eq 0 ]; then
+        echo "No matches in other branches."
+    else
+        exit_code=1
+    fi
+
+    echo
+done
+
+exit "$exit_code"


### PR DESCRIPTION
After several occasions where I had (undesired, unexpected) keystore test files in varying directories....

Here are DOS and Bash scripts to check for the default keystore files in the entire tree (and other branches):

- `wolfboot_signing_private_key.der`
- `keystore.der`
- `keystore.c`

Required `git` and run in repo directory.

## Example, bash

```
gojimmypi:/mnt/c/workspace/wolfboot-gojimmypi
$ ./tools/scripts/keystore_file_check.sh
./tools/scripts/keystore_file_check.sh v1.0

Confirmed git is installed: git version 2.34.1
Starting ./tools/scripts/keystore_file_check.sh from /mnt/c/workspace/wolfboot-gojimmypi
=== Searching for name: wolfboot_signing_private_key.der ===
Current branch dev has Paths in current branch dev:
  ./wolfboot_signing_private_key.der
1 file(s) named wolfboot_signing_private_key.der
No matches in other branches.

=== Searching for name: keystore.der ===
Current branch dev has Paths in current branch dev:
  ./include/keystore.der
1 file(s) named keystore.der
No matches in other branches.

=== Searching for name: keystore.c ===
Current branch dev has Paths in current branch dev:
  ./keystore.c
  ./src/keystore.c
2 file(s) named keystore.c
Matches in other branches:
  master:IDE/MPLAB/test/keystore.c
  pr-visualgdb-stm32l4-makefile:IDE/MPLAB/test/keystore.c
```

## Example, DOS batch file:

```
C:\workspace\wolfBoot-gojimmypi>.\tools\scripts\keystore_file_check.bat
Starting keystore_file_check.bat from C:\workspace\wolfBoot-gojimmypi
=== Searching for name: wolfboot_signing_private_key.der ===
Paths in current branch:
  .\wolfboot_signing_private_key.der
Current branch dev has 1 file(s) named wolfboot_signing_private_key.der
No matches in other branches.

=== Searching for name: keystore.der ===
Paths in current branch:
  .\include\keystore.der
Current branch dev has 1 file(s) named keystore.der
No matches in other branches.

=== Searching for name: keystore.c ===
Paths in current branch:
  .\keystore.c
  .\src\keystore.c
Current branch dev has 2 file(s) named keystore.c
Matches in other branches:
  master:IDE/MPLAB/test/keystore.c
  pr-visualgdb-stm32l4-makefile:IDE/MPLAB/test/keystore.c
```