### PR TITLE
Vorago VA416x0: simplify iram_write/iram_fill (single RMW path)

### DIFF
--- a/hal/va416x0.c
+++ b/hal/va416x0.c
@@ -362,41 +362,20 @@ void ext_flash_unlock(void)
 }
 
 /* The VA416xx code RAM (IRAM, 0x00000000-0x0003FFFF) silently drops 8/16-bit
- * stores when WREN=1 - only word-aligned 32-bit stores stick (the ECC
+ * stores when WREN=1 -- only word-aligned 32-bit stores stick (the ECC
  * machinery computes parity per word and rejects sub-word writes without
- * fault). A generic byte-wise memcpy/memset on the IRAM shadow appears
- * to succeed but leaves the destination unchanged. These helpers copy/fill
- * with 32-bit stores so the IRAM shadow update actually takes effect.
- *
- * Partition addresses (boot/update/swap) are sector-aligned (0x800) and the
- * swap engine moves whole sector-sized blocks, so in practice the IRAM
- * shadow path is always word-aligned. The unaligned head/tail fallbacks
- * exist for defense-in-depth. */
+ * fault). A generic byte-wise memcpy/memset on the IRAM shadow appears to
+ * succeed but leaves the destination unchanged. These helpers do a
+ * read-modify-write of the containing word for each up-to-4-byte group, so
+ * the only stores emitted are 32-bit STR through a volatile pointer (which
+ * the compiler is required to emit verbatim, i.e. exactly one STR). */
 static void iram_write(void *dst, const void *src, int len)
 {
-    uintptr_t d = (uintptr_t)dst;
-    uintptr_t s = (uintptr_t)src;
-    /* Word-aligned bulk copy. The destination is marked volatile so the
-     * compiler cannot lower a 32-bit assignment into byte/halfword stores
-     * (which would be silently dropped by the IRAM ECC machinery). */
-    if (((d | s) & (uintptr_t)3u) == 0u) {
-        volatile uint32_t *wd = (volatile uint32_t *)dst;
-        const uint32_t *ws = (const uint32_t *)src;
-        while (len >= 4) {
-            *wd++ = *ws++;
-            len -= 4;
-        }
-        /* Fall through with byte tail (typically zero on this target) */
-        dst = (void *)wd;
-        src = ws;
-    }
-    /* Byte tail/unaligned: do read-modify-write of the containing word
-     * (sub-word stores are dropped by the hardware). */
     while (len > 0) {
-        uintptr_t addr = (uintptr_t)dst & ~(uintptr_t)3u;
-        uint32_t off = (uint32_t)((uintptr_t)dst & (uintptr_t)3u);
-        uint32_t word = *(volatile uint32_t *)addr;
-        uint8_t *wp = (uint8_t *)&word;
+        uintptr_t addr = (uintptr_t)dst & ~3u;
+        uint32_t  off  = (uintptr_t)dst &  3u;
+        uint32_t  word = *(volatile uint32_t *)addr;
+        uint8_t  *wp   = (uint8_t *)&word;
         while (len > 0 && off < 4u) {
             wp[off++] = *(const uint8_t *)src;
             src = (const uint8_t *)src + 1;
@@ -409,23 +388,11 @@ static void iram_write(void *dst, const void *src, int len)
 
 static void iram_fill(void *dst, uint8_t val, int len)
 {
-    uint32_t pattern = ((uint32_t)val << 24) | ((uint32_t)val << 16) |
-                       ((uint32_t)val << 8)  |  (uint32_t)val;
-    uintptr_t d = (uintptr_t)dst;
-    /* Word-aligned bulk fill via volatile to guarantee 32-bit stores. */
-    if ((d & (uintptr_t)3u) == 0u) {
-        volatile uint32_t *wd = (volatile uint32_t *)dst;
-        while (len >= 4) {
-            *wd++ = pattern;
-            len -= 4;
-        }
-        dst = (void *)wd;
-    }
     while (len > 0) {
-        uintptr_t addr = (uintptr_t)dst & ~(uintptr_t)3u;
-        uint32_t off = (uint32_t)((uintptr_t)dst & (uintptr_t)3u);
-        uint32_t word = *(volatile uint32_t *)addr;
-        uint8_t *wp = (uint8_t *)&word;
+        uintptr_t addr = (uintptr_t)dst & ~3u;
+        uint32_t  off  = (uintptr_t)dst &  3u;
+        uint32_t  word = *(volatile uint32_t *)addr;
+        uint8_t  *wp   = (uint8_t *)&word;
         while (len > 0 && off < 4u) {
             wp[off++] = val;
             dst = (uint8_t *)dst + 1;


### PR DESCRIPTION
Continuation of https://github.com/wolfSSL/wolfBoot/pull/778

Round-2 cleanup on the IRAM shadow helpers:

- Drop the word-aligned fast path. The volatile uint32_t * RMW path already minimizes word traffic (one ldr + one str per output word through grouped byte merges), and the fast path required BOTH src AND dst aligned -- ext_flash_write/read pass through the caller's source buffer, so an unaligned caller dropped the whole copy to the slow path anyway.

- Drop the d/s alignment snapshot locals (only fed the fast-path test).

- Drop the (uintptr_t)3u casts. uintptr_t is 32-bit on Cortex-M4 (same as unsigned int); the casts were defensive portability noise on a hardware-specific helper.

The volatile uint32_t store guarantee from round 1 is retained -- it is the load-bearing part (one STR per store, which the IRAM ECC requires).

Code-size win on wolfboot.elf (ECC384/SHA384 config):
  .text 42348 -> 42292 (-56 B)
  iram_write  94 -> 64 B (-30 B)
  ext_flash_erase (inlined iram_fill) 96 -> 72 B (-24 B)

Verified on EVK hardware (vorago_va416x0.config):
  build_test.sh clean  -- v1 boots, signature OK, state NEW
  build_test.sh update -- v1->v2 swap, signature OK, state TESTING,
                          "Booting new firmware, marking successful boot"
                          (5-byte pBOOT confirmation write -- exercises
                          byte-tail of the RMW loop)