### PR TITLE
Fix mcxn build by providing the RNG for TZ_PSA builds

### DIFF
--- a/test-app/Makefile
+++ b/test-app/Makefile
@@ -16,7 +16,9 @@ TARGET?=none
 ARCH?=ARM
 MCUXPRESSO_CMSIS?=$(MCUXPRESSO)/CMSIS
 ifneq (,$(filter $(TARGET),mcxa mcxw mcxn))
-  TEST_APP_NO_RNG?=1
+  ifneq ($(WOLFCRYPT_TZ_PSA),1)
+    TEST_APP_NO_RNG?=1
+  endif
 endif
 ifeq ($(TZEN),1)
   # wcs directory contains a user_settings.h, which will conflict with

--- a/test-app/wcs/user_settings.h
+++ b/test-app/wcs/user_settings.h
@@ -166,6 +166,24 @@ static inline int wcs_cmse_get_random(unsigned char* output, int sz)
 #define CUSTOM_RAND_GENERATE_BLOCK wcs_cmse_get_random
 #endif
 
+#ifdef WOLFCRYPT_TZ_PSA
+
+extern int hal_trng_get_entropy(unsigned char *out, unsigned int len);
+
+static inline int wcs_psa_rand_block(unsigned char *output, int sz)
+{
+    if (sz <= 0 || output == (unsigned char*)0)
+        return -1;
+
+    if (hal_trng_get_entropy(output, (unsigned int)sz) != 0)
+        return -1;
+
+    return 0;
+}
+
+#define CUSTOM_RAND_GENERATE_BLOCK wcs_psa_rand_block
+#endif
+
 /* Disable VLAs */
 #define WOLFSSL_SP_NO_DYN_STACK
 


### PR DESCRIPTION
## Summary

Fixes the `nxp_mcxn_tz_psa_test` and `nxp_mcxn_tz_psa_hw_test` builds, which started failing after the wolfSSL submodule bump to 5.8.2. The new release added a compile-time check that refuses `WC_NO_RNG` together with any blinding macro (`WC_RSA_BLINDING` / `WOLFSSL_CURVE25519_BLINDING` / `WOLFSSL_ECC_BLIND_K`) — and the MCXN TZ-PSA test-app build was hitting exactly that combination.

## Changes

- **`test-app/Makefile`**: stop defaulting `TEST_APP_NO_RNG=1` for `mcxn` when `WOLFCRYPT_TZ_PSA=1`. The TZ-PSA build already has a PSA-backed entropy source on the NS side (`hal_trng_psa.c` → `psa_generate_random`), so there's no reason to force-disable the RNG. The default is unchanged for `mcxa`/`mcxw` and for the non-PSA `mcxn` configs.

- **`test-app/wcs/user_settings.h`**: when `WOLFCRYPT_TZ_PSA` is set, wire `CUSTOM_RAND_GENERATE_BLOCK` to a thin shim over `hal_trng_get_entropy()`. This gives wolfCrypt a working RNG without pulling in HASHDRBG, and routes every random byte through the PSA TRNG.

## Note

I don't have the hardware to test this change