### PR TITLE
fix broken unit test

### DIFF
--- a/tools/unit-tests/unit-elf-bss-guard.c
+++ b/tools/unit-tests/unit-elf-bss-guard.c
@@ -84,7 +84,7 @@ START_TEST(test_elf_bss_guard_no_header_corruption)
      *   → write proceeds; memset zeroes ph[1].
      * With the fixed guard (mem_size check):
      *   vaddr + mem_size   = ph[1]_start + 56 > ph[1]_start                  → FALSE
-     *   → write is skipped; ph[1] intact.
+     *   → load is aborted (-5) before any write; ph[1] intact.
      */
     ph[0].type      = ELF_PT_LOAD;
     ph[0].flags     = 0;
@@ -106,7 +106,10 @@ START_TEST(test_elf_bss_guard_no_header_corruption)
     }
 
     ret = elf_load_image_mmu(g_image, sizeof(g_image), &entry, NULL);
-    ck_assert_int_eq(ret, 0);
+
+    /* The loader should reject this image instead of loading it, because the
+     * segment would overwrite part of the image it has not read yet. */
+    ck_assert_int_eq(ret, -5);
 
     /*
      * ph[1].type must not have been zeroed by the BSS memset from ph[0].


### PR DESCRIPTION
Fixes broken unit tests on master causing all current PRs to fail. 

Seems that two separate PRs came together to break unit tests on master.

#746 changed the ELF loader's collision guard: when a segment would overwrite program headers that haven't been read yet, the loader after this PR fails with -5 instead of the old behavior of silently skipping the segment and returning 0.

The F-4418 regression test (added in #792 ) still expected the old skip-and-succeed behavior. Neither PR failed individually since they never tested each others changes, but now all PRs are failing.

Fix: update the test to expect the loader to reject the image (ret == -5) rather than return success.