### PR TITLE
Add WOLFBOOT_TZ_TEST_BKPT=1 to fix wolfHSM nightly test

### DIFF
--- a/port/stmicro/stm32h5-tz-wolfhsm/Makefile
+++ b/port/stmicro/stm32h5-tz-wolfhsm/Makefile
@@ -69,7 +69,7 @@ build: stage-config
 	@echo "==> wolfBoot build (stm32h5-tz-wolfhsm)"
 	@echo "==> WOLFBOOT_LIB_WOLFHSM=$(WOLFBOOT_LIB_WOLFHSM)"
 	cd $(WOLFBOOT_ROOT) && $(MAKE) wolfboot.bin WOLFBOOT_LIB_WOLFHSM=$(WOLFBOOT_LIB_WOLFHSM) $(WOLFBOOT_MAKE_FLAGS)
-	cd $(WOLFBOOT_ROOT) && $(MAKE) test-app/image_v1_signed.bin WOLFBOOT_LIB_WOLFHSM=$(WOLFBOOT_LIB_WOLFHSM) $(WOLFBOOT_MAKE_FLAGS)
+	cd $(WOLFBOOT_ROOT) && $(MAKE) test-app/image_v1_signed.bin WOLFBOOT_LIB_WOLFHSM=$(WOLFBOOT_LIB_WOLFHSM) WOLFBOOT_TZ_TEST_BKPT=1 $(WOLFBOOT_MAKE_FLAGS)
 
 # Force-overwrite .config every build so a stale config from a
 # previous CI step (PKCS11, fwTPM, DICE) cannot bleed through.


### PR DESCRIPTION
Set `WOLFBOOT_TZ_TEST_BKPT` in the build per the docs to avoid an endless loop at the end of the test.

This change is the first of two steps to fix the failing wolfHSM nightly.

https://github.com/wolfSSL/wolfHSM/actions/workflows/wolfboot-tz-integration.yml