### PR TITLE
Remove argc <= 14 limit in signing tool

### DIFF
--- a/tools/keytools/sign.c
+++ b/tools/keytools/sign.c
@@ -2916,7 +2916,7 @@ int main(int argc, char** argv)
     printf("wolfBoot version %X\n", WOLFBOOT_VERSION);
 
     /* Check arguments and print usage */
-    if (argc < 4 || argc > 14) {
+    if (argc < 4) {
         printf("Usage: %s [options] image key version\n", argv[0]);
         printf("For full usage manual, see 'docs/Signing.md'\n");
         exit(1);


### PR DESCRIPTION
This is a legacy limit that's not needed anymore, since it can be overcome with valid arguments.