### PR TITLE
Small max32666 fixes

### DIFF
--- a/hal/max32666.c
+++ b/hal/max32666.c
@@ -105,8 +105,9 @@ static void RAMFUNCTION icc_disable(void)
 
 static void RAMFUNCTION icc_enable(void)
 {
-    /* Invalidate and re-enable cache */
+    /* Invalidate cache, wait for completion, then re-enable */
     ICC0_INVALIDATE = 1;
+    while (!(ICC0_CTRL & ICC_CTRL_RDY)) {}
     ICC0_CTRL |= ICC_CTRL_EN;
     while (!(ICC0_CTRL & ICC_CTRL_RDY)) {}
 }
@@ -324,6 +325,14 @@ void hal_init(void)
     /* Set FLC clock dividers for both banks */
     FLC0_CLKDIV = FLC_CLKDIV_VALUE;
     FLC1_CLKDIV = FLC_CLKDIV_VALUE;
+
+    /* Point VTOR at our vector table so faults hit our handlers */
+    *(volatile uint32_t *)0xE000ED08 = 0x10000000;
+
+    /* Disable the ICC read buffer via TME before enabling the cache */
+    TME_CTRL = 1;
+    SIR_TRIM_ICC = SIR_TRIM_ICC_RB_DIS;
+    TME_CTRL = 0;
 
     /* Enable instruction cache */
     icc_enable();

--- a/hal/max32666.h
+++ b/hal/max32666.h
@@ -170,6 +170,11 @@
 #define ICC_CTRL_EN             (1UL << 0)          /* Cache enable */
 #define ICC_CTRL_RDY            (1UL << 16)         /* Cache ready */
 
+/* Test mode / trim registers */
+#define TME_CTRL                (*(volatile uint32_t *)0x40000C00UL)
+#define SIR_TRIM_ICC            (*(volatile uint32_t *)0x4000040CUL)
+#define SIR_TRIM_ICC_RB_DIS     (1UL << 6)          /* Read buffer disable */
+
 /* ============== WDT - Watchdog Timer ============== */
 /* MSDK: wdt_regs.h */
 #define WDT0_BASE               0x40003000UL

--- a/src/libwolfboot.c
+++ b/src/libwolfboot.c
@@ -178,7 +178,8 @@ int wolfBoot_initialize_encryption(void)
 #undef WOLFBOOT_FIXED_PARTITIONS
 #endif
 
-#if defined(EXT_FLASH) && !defined(WOLFBOOT_NO_PARTITIONS)
+#if defined(EXT_FLASH) && !defined(WOLFBOOT_NO_PARTITIONS) && \
+    !defined(CUSTOM_PARTITION_TRAILER)
 static uint32_t ext_cache;
 #endif
 

--- a/src/update_flash.c
+++ b/src/update_flash.c
@@ -914,6 +914,9 @@ static int RAMFUNCTION wolfBoot_update(int fallback_allowed)
     int fallback_image = 0;
 #ifndef DISABLE_BACKUP
     int rollback_needed = 0;
+#ifdef CUSTOM_PARTITION_TRAILER
+    (void)rollback_needed;
+#endif
     int bootStateRet = -1;
     uint8_t bootState = 0;
 #endif
@@ -1444,7 +1447,7 @@ void RAMFUNCTION wolfBoot_start(void)
     int bootRet;
 #ifndef WOLFBOOT_SELF_UPDATE_MONOLITHIC
     int updateRet;
-#ifndef DISABLE_BACKUP
+#if !defined(DISABLE_BACKUP) && !defined(CUSTOM_PARTITION_TRAILER)
     int resumedFinalErase;
 #endif
     uint8_t bootState;


### PR DESCRIPTION
Discovered while working on custom board, but generic to MAX32666. All three reproduce behavior the MSDK adopts by default.

- Set VTOR to wolfBoot's vector table. The boot ROM leaves VTOR pointing to 0, and flash is not aliased at address 0, so any fault while wolfBoot runs was handled by the ROM's handlers instead of wolfBoot's.

- Wait for the ICC invalidation to complete before setting the enable bit. The cache was previously enabled while the invalidation was still in progress (taken from MSDK).

- Disable the ICC read buffer through the TME registers.

The second commit fixes some compile warnings with `CUSTOM_PARTITION_TRAILER` which probably went unnoticed because we don't have any `config/examples` that use it.