### PR TITLE
tc3: fix debug uart macro protection

### DIFF
--- a/test-app/Makefile
+++ b/test-app/Makefile
@@ -175,6 +175,11 @@ ifeq ($(DEBUG_UART),1)
     APP_NEEDS_STRING:=1
 endif
 
+ifeq ($(ARCH),AURIX_TC3)
+# AURIX RAM_CODE HAL flash drivers need wolfBoot memcpy
+    APP_NEEDS_STRING:=1
+endif
+
 ifeq ($(APP_NEEDS_STRING),1)
     APP_OBJS+=../src/string.o
 endif

--- a/test-app/app_aurix_tc3xx.c
+++ b/test-app/app_aurix_tc3xx.c
@@ -66,7 +66,9 @@ void tc3tc_main(void)
     /* disable external WATCHDOG on the board */
     bsp_board_wdg_Disable();
 
+#ifdef DEBUG_UART
     uart_init();
+#endif
     wolfBoot_printf("TC3xx Test Application\n");
     wolfBoot_printf("Version: %d\n", wolfBoot_current_firmware_version());
 
@@ -122,7 +124,9 @@ void tc3arm_main(void)
     /* disable external WATCHDOG on the board */
     bsp_board_wdg_Disable();
 
+#ifdef DEBUG_UART
     uart_init();
+#endif
     wolfBoot_printf("TC3xx HSM Test Application\n");
     wolfBoot_printf("Version: %d\n", wolfBoot_current_firmware_version());
 


### PR DESCRIPTION
Fixes missing debug uart macro protection and forces use of RAM-resident memcpy