### PR TITLE
Enable UART_QSPI_PROGRAM by default in polarfire_mpfs250_hss_l2lim.config

### DIFF
--- a/config/examples/polarfire_mpfs250_hss_l2lim.config
+++ b/config/examples/polarfire_mpfs250_hss_l2lim.config
@@ -90,3 +90,12 @@ CFLAGS_EXTRA+=-DWOLFBOOT_SHA_BLOCK_SIZE=4096
 # Optional QSPI flash test (erase/write/read on update partition)
 # Uncomment to run test during hal_init()
 #CFLAGS_EXTRA+=-DTEST_EXT_FLASH
+
+# UART QSPI programmer (enabled for the HSS/L2-LIM demo flow)
+# The documented bring-up loads the signed test-app into QSPI over UART, so this
+# is enabled by default. wolfBoot prompts on UART at startup ("Press P within 3s")
+# to receive a signed firmware image and write it to QSPI flash.
+# Use: python3 tools/scripts/mpfs_qspi_prog.py <port> <image.bin> [qspi_offset]
+# Requires EXT_FLASH=1 (already set) and DEBUG_UART=1 (already set).
+# Set to 0 once the flash contents are stable to skip the 3-second boot pause.
+UART_QSPI_PROGRAM?=1

--- a/docs/Targets.md
+++ b/docs/Targets.md
@@ -1118,13 +1118,15 @@ sudo dd if=wolfboot.bin of=/dev/sdc1 bs=512 && sudo cmp wolfboot.bin /dev/sdc1
 make test-app/image_v1_signed.bin
 ```
 
-**Flash the signed application to QSPI:**
+**Flash the signed application to QSPI** using the UART programmer (enabled by default via
+`UART_QSPI_PROGRAM=1`; requires `pyserial` installed):
 ```sh
 python3 tools/scripts/mpfs_qspi_prog.py /dev/ttyUSB1 \
     test-app/image_v1_signed.bin 0x20000
 ```
 
 **Notes:**
+- `UART_QSPI_PROGRAM=1` adds a 3-second boot pause every time. Set to `0` once the flash contents are stable.
 - `ELF=0` is required: the test-app linker script (`test-app/RISCV64-mpfs250.ld`) places `.init`
   (containing `_reset()`) first so the raw binary entry point is at offset 0. The full ELF with
   debug symbols exceeds L2-LIM capacity.


### PR DESCRIPTION
Fixes https://github.com/polarfire-soc/hart-software-services/pull/99#issuecomment-5071365753