### PR TITLE
Fenrir fixes 2026 08 24

### DIFF
--- a/.github/workflows/test-library.yml
+++ b/.github/workflows/test-library.yml
@@ -174,16 +174,8 @@ jobs:
 
           echo "$output"
 
-          # TODO hal/library.c does not currently return an error code during failure
-          # Test only looks for the word "Failure"
-          # See https://github.com/wolfSSL/wolfBoot/pull/625
-
-          # If the tool printed "Failure", treat it as a failure regardless of exit code
-          if echo "$output" | grep -F "Failure" >/dev/null; then
-              status=1
-          fi
-
-          # Must have failed (non-zero exit)
+          # A rejected image must exit non-zero: wolfBoot_start() propagates
+          # the verify error to the process exit code
           if [ "$status" -eq 0 ]; then
             echo "Expected failure, but exit code was 0"
             exit 1

--- a/hal/hifive1.c
+++ b/hal/hifive1.c
@@ -492,7 +492,9 @@ int RAMFUNCTION hal_flash_write(uint32_t address, const uint8_t *data, int len)
     page = address >> 8;
 
     while (j < (uint32_t)len) {
-        if ((off > 0) || (len < FLASH_PAGE_SIZE)) {
+        uint32_t remaining = (uint32_t)len - j;
+
+        if ((off > 0) || (remaining < FLASH_PAGE_SIZE)) {
             uint8_t *orig = (uint8_t *)(FLASH_BASE + (page << 8));
             int rel_len;
             rel_len = FLASH_PAGE_SIZE - off;
@@ -500,8 +502,8 @@ int RAMFUNCTION hal_flash_write(uint32_t address, const uint8_t *data, int len)
                 fespi_hwmode();
                 swmode = 0;
             }
-            if (rel_len > len)
-                rel_len = len;
+            if (rel_len > (int)remaining)
+                rel_len = (int)remaining;
             for (i = 0; i < off; i++)
                 data_copy[i] = orig[i];
             for (i = off; i < off + rel_len; i++)

--- a/hal/library.c
+++ b/hal/library.c
@@ -165,7 +165,9 @@ int wolfBoot_start(void)
                         (int)os_image.signature_ok);
     }
 
-    return 0;
+    /* The error paths reach this point with ret < 0; propagate it so a
+     * rejected image does not look like a successful boot to the caller. */
+    return ret;
 }
 
 

--- a/hal/nxp_p1021.c
+++ b/hal/nxp_p1021.c
@@ -1835,6 +1835,7 @@ int ext_flash_erase(uintptr_t address, int len)
         wolfBoot_printf("erase page %d, status %x\n", page, status);
 #endif
         (void)status;
+        address += block_size;
         len -= block_size;
     }
 

--- a/hal/nxp_t10xx.c
+++ b/hal/nxp_t10xx.c
@@ -3249,6 +3249,7 @@ static int hal_flash_status_wait(uint32_t sector, uint16_t mask, uint32_t timeou
 int hal_flash_write(uint32_t address, const uint8_t *data, int len)
 {
     uint32_t i, pos, sector, offset, xfer, nwords;
+    int ret = 0;
 
     /* adjust for flash base */
     if (address >= FLASH_BASE_ADDR)
@@ -3288,7 +3289,9 @@ int hal_flash_write(uint32_t address, const uint8_t *data, int len)
             FLASH_IO16_WRITE(sector, offset, 0);
             FLASH_IO16_WRITE(sector, offset, word);
             FLASH_IO8_WRITE(sector, offset, AMD_CMD_WRITE_BUFFER_CONFIRM);
-            hal_flash_status_wait(sector, 0x44, 200*1000);
+            ret = hal_flash_status_wait(sector, 0x44, 200*1000);
+            if (ret != 0)
+                return ret;
             address++;
             pos++;
             len--;
@@ -3317,7 +3320,9 @@ int hal_flash_write(uint32_t address, const uint8_t *data, int len)
         /* Typical 410us */
 
         /* poll for program completion - max 200ms */
-        hal_flash_status_wait(sector, 0x44, 200*1000);
+        ret = hal_flash_status_wait(sector, 0x44, 200*1000);
+        if (ret != 0)
+            return ret;
 
         address += xfer;
         len -= xfer;
@@ -3328,6 +3333,7 @@ int hal_flash_write(uint32_t address, const uint8_t *data, int len)
 int hal_flash_erase(uint32_t address, int len)
 {
     uint32_t sector;
+    int ret = 0;
 
     /* adjust for flash base */
     if (address >= FLASH_BASE_ADDR)
@@ -3350,7 +3356,9 @@ int hal_flash_erase(uint32_t address, int len)
         /* Typical is 200ms (max 1100ms) */
 
         /* poll for erase completion - max 1.1 sec */
-        hal_flash_status_wait(sector, 0x4C, 1100*1000);
+        ret = hal_flash_status_wait(sector, 0x4C, 1100*1000);
+        if (ret != 0)
+            return ret;
 
         address += FLASH_SECTOR_SIZE;
         len -= FLASH_SECTOR_SIZE;

--- a/hal/stm32c0.c
+++ b/hal/stm32c0.c
@@ -150,7 +150,7 @@ int RAMFUNCTION hal_flash_write(uint32_t address, const uint8_t *data, int len)
 
     while (i < len) {
         flash_clear_errors();
-        if ((len - i > 3) && ((((address + i) & 0x07) == 0) &&
+        if ((len - i >= 8) && ((((address + i) & 0x07) == 0) &&
                 ((((uint32_t)data) + i) & 0x07) == 0)) {
             src = (uint32_t *)data;
             dst = (uint32_t *)(address + FLASHMEM_ADDRESS_SPACE);

--- a/hal/stm32g0.c
+++ b/hal/stm32g0.c
@@ -140,7 +140,7 @@ int RAMFUNCTION hal_flash_write(uint32_t address, const uint8_t *data, int len)
 
     while (i < len) {
         flash_clear_errors();
-        if ((len - i > 3) && ((((address + i) & 0x07) == 0) &&
+        if ((len - i >= 8) && ((((address + i) & 0x07) == 0) &&
                 ((((uint32_t)data) + i) & 0x07) == 0)) {
             src = (uint32_t *)data;
             dst = (uint32_t *)address;

--- a/hal/stm32g4.c
+++ b/hal/stm32g4.c
@@ -54,7 +54,7 @@ int RAMFUNCTION hal_flash_write(uint32_t address, const uint8_t *data, int len)
 
     while (i < len) {
         flash_clear_errors();
-        if ((len - i > 3) && ((((address + i) & 0x07) == 0) &&
+        if ((len - i >= 8) && ((((address + i) & 0x07) == 0) &&
                 ((((uint32_t)data) + i) & 0x07) == 0)) {
             src = (uint32_t *)data;
             dst = (uint32_t *)address;

--- a/src/elf.c
+++ b/src/elf.c
@@ -183,12 +183,14 @@ int elf_load_image_mmu(uint8_t *image, uint32_t image_sz, uintptr_t *pentry,
 #ifndef ELF_PARSER
         if (mmu_cb != NULL) {
             if (mmu_cb(vaddr, paddr, mem_size) != 0) {
-#ifdef DEBUG_ELF
-            wolfBoot_printf(
-                "Fail to map %u bytes to %p (p %p)\r\n",
-                (uint32_t)mem_size, (void*)vaddr, (void*)paddr);
-#endif
-            continue;
+                /* Never silently drop a PT_LOAD segment: a failed mapping
+                 * leaves a hole in the image, and publishing the entry
+                 * point for a partially loaded ELF is worse than failing
+                 * the load. */
+                wolfBoot_printf("ELF: failed to map %u bytes to %p "
+                    "(p %p) -- aborting ELF load\r\n",
+                    (uint32_t)mem_size, (void*)vaddr, (void*)paddr);
+                return -6;
             }
         }
 

--- a/src/fdt.c
+++ b/src/fdt.c
@@ -864,7 +864,7 @@ int fdt_add_mem_rsv(void* fdt, uint64_t address, uint64_t size)
     uint32_t off_str;
     uint32_t size_str;
     uint32_t total;
-    uint32_t data_end;
+    uint64_t data_end;
     uint32_t shift;
     uint32_t i;
 
@@ -877,9 +877,18 @@ int fdt_add_mem_rsv(void* fdt, uint64_t address, uint64_t size)
     off_str     = fdt_off_dt_strings(fdt);
     size_str    = fdt_size_dt_strings(fdt);
     total       = fdt_totalsize(fdt);
-    data_end    = off_str + size_str;
+    /* 64-bit: a wrapped 32-bit end would slip past the checks below
+     * and re-wrap into the memmove length. */
+    data_end    = (uint64_t)off_str + (uint64_t)size_str;
     shift       = (uint32_t)sizeof(struct fdt_reserve_entry); /* 16 */
 
+    /* Validate the layout before using it: the structure block must
+     * start after the reserve map's terminator, and the string block
+     * after the structure block. 64-bit comparisons: a wrapped 32-bit
+     * sum would pass the check. */
+    if (((uint64_t)off_rsv + shift > off_dt) || (off_str < off_dt)) {
+        return -FDT_ERR_BADSTRUCTURE;
+    }
     if ((data_end + shift) > total) {
         return -FDT_ERR_NOSPACE;
     }
@@ -889,14 +898,15 @@ int fdt_add_mem_rsv(void* fdt, uint64_t address, uint64_t size)
     i = 0;
     while ((rsv[i].address != 0ULL) || (rsv[i].size != 0ULL)) {
         i++;
-        if ((off_rsv + (i + 1U) * shift) > off_dt) {
+        if (((uint64_t)off_rsv + (uint64_t)(i + 1U) * shift) > off_dt) {
             return -FDT_ERR_BADSTRUCTURE;
         }
     }
 
-    /* Shift structure + strings down by 16 bytes. memmove handles overlap. */
+    /* Shift structure + strings down by 16 bytes. memmove handles overlap.
+     * The length comes from the validated 64-bit end. */
     memmove(base + off_dt + shift, base + off_dt,
-        (size_t)((off_str + size_str) - off_dt));
+        (size_t)(data_end - off_dt));
 
     /* Insert new entry where the old terminator was, write new terminator. */
     rsv[i].address = cpu_to_fdt64(address);

--- a/src/fwtpm_callable.c
+++ b/src/fwtpm_callable.c
@@ -49,6 +49,12 @@ static int fwtpm_ready;
  * checked against the snapshotted capacity. */
 static uint8_t g_fwtpm_rsp_stage[WCS_FWTPM_MAX_COMMAND_SIZE];
 
+/* Command staging: the processor parses the packet more than once
+ * (authentication, then execution), and a DMA-capable non-secure
+ * attacker cannot rewrite secure memory, so both parses see the same
+ * bytes even if the NS command buffer changes in between. */
+static uint8_t g_fwtpm_cmd_stage[WCS_FWTPM_MAX_COMMAND_SIZE];
+
 extern unsigned int _start_heap;
 extern unsigned int _heap_size;
 
@@ -171,8 +177,12 @@ int CSME_NSE_API wcs_fwtpm_transmit(const uint8_t *cmd, uint32_t cmdSz,
         return BAD_FUNC_ARG;
     }
 
+    /* Stage the command before invoking the processor (see the staging
+     * buffer comment above). */
+    memcpy(g_fwtpm_cmd_stage, cmd, cmdSz);
+
     rspLen = (int)WCS_FWTPM_MAX_COMMAND_SIZE;
-    rc = FWTPM_ProcessCommand(&fwtpm_ctx, cmd, (int)cmdSz,
+    rc = FWTPM_ProcessCommand(&fwtpm_ctx, g_fwtpm_cmd_stage, (int)cmdSz,
                               g_fwtpm_rsp_stage, &rspLen, 0);
     if (rc == TPM_RC_SUCCESS) {
         wireSz = fwtpm_rsp_size(g_fwtpm_rsp_stage, rspLen);
@@ -188,6 +198,10 @@ int CSME_NSE_API wcs_fwtpm_transmit(const uint8_t *cmd, uint32_t cmdSz,
             rc = TPM_RC_FAILURE;
         }
     }
+    /* Zero the staging before returning: the response may carry
+     * sensitive material (auth tags, unsealed data). */
+    memset(g_fwtpm_cmd_stage, 0, sizeof(g_fwtpm_cmd_stage));
+    memset(g_fwtpm_rsp_stage, 0, sizeof(g_fwtpm_rsp_stage));
     return rc;
 }
 

--- a/src/fwtpm_callable.c
+++ b/src/fwtpm_callable.c
@@ -42,6 +42,13 @@
 static FWTPM_CTX fwtpm_ctx;
 static int fwtpm_ready;
 
+/* Staging buffer for FWTPM_ProcessCommand(): the processor writes up to
+ * a max-sized response regardless of the capacity the caller offers, so
+ * it must never write into the caller's (possibly shorter) buffer. The
+ * response is copied out only after the produced length has been
+ * checked against the snapshotted capacity. */
+static uint8_t g_fwtpm_rsp_stage[WCS_FWTPM_MAX_COMMAND_SIZE];
+
 extern unsigned int _start_heap;
 extern unsigned int _heap_size;
 
@@ -164,14 +171,17 @@ int CSME_NSE_API wcs_fwtpm_transmit(const uint8_t *cmd, uint32_t cmdSz,
         return BAD_FUNC_ARG;
     }
 
-    rspLen = (int)rspCapacity;
-    rc = FWTPM_ProcessCommand(&fwtpm_ctx, cmd, (int)cmdSz, rsp, &rspLen, 0);
+    rspLen = (int)WCS_FWTPM_MAX_COMMAND_SIZE;
+    rc = FWTPM_ProcessCommand(&fwtpm_ctx, cmd, (int)cmdSz,
+                              g_fwtpm_rsp_stage, &rspLen, 0);
     if (rc == TPM_RC_SUCCESS) {
-        wireSz = fwtpm_rsp_size(rsp, rspLen);
+        wireSz = fwtpm_rsp_size(g_fwtpm_rsp_stage, rspLen);
         if (wireSz > 0U && wireSz <= rspCapacity) {
+            memcpy(rsp, g_fwtpm_rsp_stage, wireSz);
             *rspSz = wireSz;
         }
         else if (rspLen >= 0 && (uint32_t)rspLen <= rspCapacity) {
+            memcpy(rsp, g_fwtpm_rsp_stage, (uint32_t)rspLen);
             *rspSz = (uint32_t)rspLen;
         }
         else {

--- a/src/image.c
+++ b/src/image.c
@@ -382,15 +382,12 @@ static void wolfBoot_verify_signature_ecc(uint8_t key_slot,
     #endif /* WOLFBOOT_ENABLE_WOLFHSM_CLIENT || (SERVER && CERT_CHAIN) */
         /* wc_ecc_verify_hash_ex() doesn't trigger a crypto callback, so we need
            to use wc_ecc_verify_hash instead. Unfortunately, that requires
-           converting the signature to intermediate DER format first */
-        mp_init(&r);
-        mp_init(&s);
-        mp_read_unsigned_bin(&r, sig, point_sz);
-        mp_read_unsigned_bin(&s, sig + point_sz, point_sz);
-        uint32_t rSz = mp_unsigned_bin_size(&r);
-        uint32_t sSz = mp_unsigned_bin_size(&s);
-        ret          = wc_ecc_rs_raw_to_sig(sig, rSz, &sig[point_sz], sSz,
-                                            (byte*)&tmpSigBuf, (word32*)&tmpSigSz);
+           converting the signature to intermediate DER format first. Both
+           fields are passed at full width: the raw signature is fixed-width
+           and left-zero-padded, and the conversion strips the padding. */
+        ret = wc_ecc_rs_raw_to_sig(sig, (word32)point_sz, &sig[point_sz],
+                                   (word32)point_sz,
+                                   (byte*)&tmpSigBuf, (word32*)&tmpSigSz);
         /* Verify the (temporary) DER representation of the signature */
         if (ret == 0) {
             VERIFY_FN(img, &verify_res, wc_ecc_verify_hash, tmpSigBuf, tmpSigSz,

--- a/src/riscv_sbi.c
+++ b/src/riscv_sbi.c
@@ -157,10 +157,18 @@ typedef struct {
     volatile uint32_t init_magic;
     volatile int      hart_state[MPFS_NUM_HARTS];
     volatile uint32_t ipi_ops[MPFS_NUM_HARTS];
+    /* Fence-completion protocol: ipi_done[h] is incremented by hart h
+     * only after it has executed the fence ops it consumed; a requester
+     * snapshots it into ipi_wait_gen[h] before posting and waits until
+     * ipi_done[h] passes the snapshot. */
+    volatile uint32_t ipi_done[MPFS_NUM_HARTS];
+    volatile uint32_t ipi_wait_gen[MPFS_NUM_HARTS];
 } sbi_shared_state_t;
 #define SBI_SHARED ((sbi_shared_state_t *)SBI_SHARED_DTIM_ADDR)
-#define sbi_hart_state (SBI_SHARED->hart_state)
-#define sbi_ipi_ops    (SBI_SHARED->ipi_ops)
+#define sbi_hart_state   (SBI_SHARED->hart_state)
+#define sbi_ipi_ops      (SBI_SHARED->ipi_ops)
+#define sbi_ipi_done     (SBI_SHARED->ipi_done)
+#define sbi_ipi_wait_gen (SBI_SHARED->ipi_wait_gen)
 
 /* Per-hart IPI work flags, set by a requesting hart and consumed in the
  * target hart's M-mode software-interrupt handler. */
@@ -189,6 +197,8 @@ void sbi_hart_mark_started(unsigned long hartid)
         for (k = 0; k < (unsigned int)MPFS_NUM_HARTS; k++) {
             sbi_hart_state[k] = SBI_HSM_STOPPED;
             sbi_ipi_ops[k] = 0;
+            sbi_ipi_done[k] = 0;
+            sbi_ipi_wait_gen[k] = 0;
         }
         __asm__ volatile("fence rw, rw" ::: "memory");
         SBI_SHARED->init_magic = SBI_SHARED_MAGIC;
@@ -465,6 +475,12 @@ void sbi_ipi_irq(unsigned long hartid)
     if ((ops & SBI_IPI_OP_SSIP) != 0U || ops == 0U) {
         csr_set_bits(mip, MIP_SSIP);
     }
+    /* Publish completion only after the requested fences have executed:
+     * a requester treats the increment as this hart being done. */
+    if ((ops & (SBI_IPI_OP_FENCE_I | SBI_IPI_OP_SFENCE)) != 0U) {
+        (void)__atomic_add_fetch(&sbi_ipi_done[hartid], 1U,
+                                 __ATOMIC_ACQ_REL);
+    }
 }
 
 /* Post an IPI op to every hart in (mask << base) and ring its MSIP.
@@ -501,6 +517,11 @@ static void sbi_post_ipi(unsigned long mask, unsigned long base,
         if (sbi_hart_state[h] != SBI_HSM_STARTED) {
             continue; /* parked harts consume MSIP in their wake loop */
         }
+        /* Snapshot the completion counter before posting: the wait below
+         * completes when the target increments past this value. */
+        if ((op & (SBI_IPI_OP_FENCE_I | SBI_IPI_OP_SFENCE)) != 0U) {
+            sbi_ipi_wait_gen[h] = sbi_ipi_done[h];
+        }
         /* Atomic OR (amoor.w, rv64a): two harts may post to the same target
          * concurrently, and the target may be consuming (sbi_ipi_irq) at the
          * same time - a plain |= read-modify-write could drop an op. */
@@ -511,9 +532,11 @@ static void sbi_post_ipi(unsigned long mask, unsigned long base,
     __asm__ volatile("fence iorw, iorw" ::: "memory");
 }
 
-/* Wait (bounded) for the posted fence ops to be consumed by the targets.
- * The SBI remote-fence calls are synchronous; the bound guards against a
- * wedged target turning into a wedged caller. */
+/* Wait (bounded) for the posted fence ops to be consumed by the targets:
+ * the targets increment ipi_done after executing the fences, so this
+ * completes only when every target has finished its fence. The SBI
+ * remote-fence calls are synchronous; the bound guards against a wedged
+ * target turning into a wedged caller. */
 static void sbi_wait_ipi_done(unsigned long mask, unsigned long base,
     unsigned long self)
 {
@@ -535,7 +558,7 @@ static void sbi_wait_ipi_done(unsigned long mask, unsigned long base,
             continue;
         }
         spin = 10000000U;
-        while (sbi_ipi_ops[h] != 0U && spin > 0U) {
+        while (sbi_ipi_done[h] <= sbi_ipi_wait_gen[h] && spin > 0U) {
             spin--;
         }
     }

--- a/src/update_ram.c
+++ b/src/update_ram.c
@@ -269,6 +269,9 @@ static int uboot_legacy_header_valid(const uint8_t *hdr, uint32_t total)
 void RAMFUNCTION wolfBoot_start(void)
 {
     int active = -1, ret = 0;
+    /* Candidates already tried this boot; a failed RAM image cannot be
+     * erased to invalidate it like the flash path does. */
+    int tried_boot = 0, tried_update = 0;
     struct wolfBoot_image os_image;
     BENCHMARK_DECLARE();
 #ifdef WOLFBOOT_UBOOT_LEGACY
@@ -425,12 +428,24 @@ backup_on_failure:
             wolfBoot_printf("Impossible recovery with fallback.\n");
             wolfBoot_panic();
             break;
-        } else {
-            /* Invalidate failing image and switch to the other partition */
-            active ^= 1;
-            wolfBoot_printf("Active is now: %d\n", active);
-            continue;
         }
+        if (active == PART_BOOT)
+            tried_boot = 1;
+        else
+            tried_update = 1;
+        if (tried_boot && tried_update) {
+            /* Both partitions were tried and both failed: the images that
+             * made fallback look possible are invalid, and nothing left to
+             * boot. */
+            wolfBoot_printf(
+                "Both images failed verification; no valid image to boot.\n");
+            wolfBoot_panic();
+            break;
+        }
+        /* Switch to the other partition */
+        active ^= 1;
+        wolfBoot_printf("Active is now: %d\n", active);
+        continue;
     }
 #ifdef UNIT_TEST
     if (wolfBoot_panicked != 0) {

--- a/tools/unit-tests/Makefile
+++ b/tools/unit-tests/Makefile
@@ -113,6 +113,7 @@ TESTS+=unit-zynq-ext-write
 TESTS+=unit-versal-qspi-dma
 TESTS+=unit-versal-ext-write
 TESTS+=unit-t10xx-qe-firmware
+TESTS+=unit-t10xx-flash-status
 TESTS+=unit-aurix-erased-fill
 TESTS+=unit-aurix-erased-fill-invert
 TESTS+=unit-t2080-fman-loader
@@ -1004,6 +1005,19 @@ stm32g4_write_extract.h: ../../hal/stm32g4.c
 
 unit-stm32g4-write: unit-stm32g4-write.c stm32g4_write_extract.h
 	gcc -o $@ unit-stm32g4-write.c $(CFLAGS) $(LDFLAGS)
+
+# unit-t10xx-flash-status runs the real hal_flash_write()/hal_flash_erase()
+# and hal_flash_status_wait() from hal/nxp_t10xx.c against a mock QPI
+# status model (F-11033: a timed-out program/erase used to report
+# success because the wait result was discarded).
+t10xx_flash_status_extract.h: ../../hal/nxp_t10xx.c
+	sed -n '/^static void hal_flash_unlock_sector/,/^}/p' $< > $@
+	sed -n '/^static int hal_flash_status_wait/,/^}/p' $< >> $@
+	sed -n '/^int hal_flash_write/,/^}/p' $< >> $@
+	sed -n '/^int hal_flash_erase/,/^}/p' $< >> $@
+
+unit-t10xx-flash-status: unit-t10xx-flash-status.c t10xx_flash_status_extract.h
+	gcc -o $@ unit-t10xx-flash-status.c $(CFLAGS) $(LDFLAGS)
 
 # unit-ecc-raw-der runs the real wolfCrypt raw-to-DER conversion and
 # verification (F-11024: the wolfHSM verify path in src/image.c passed

--- a/tools/unit-tests/Makefile
+++ b/tools/unit-tests/Makefile
@@ -1296,11 +1296,14 @@ covclean:
 
 # Sources the extraction rules generate into this directory. Listed here
 # so "clean" removes them and so there is one place that names them.
-GENERATED_SRC:=aurix_erased_extract.h nvm_cache_scrub_extract.h \
+GENERATED_SRC:=aurix_erased_extract.h fdt_memrsv_extract.h \
+	hifive1_flash_write_extract.h nvm_cache_scrub_extract.h \
 	nxp_ls1028a_host.c nxp_p1021_host.c nxp_t10xx_fixup_extract.h \
-	sdhci_host.c stm32g4_write_extract.h stm32l5_write_extract.h \
+	p1021_erase_extract.h p1021_erase_fn_extract.h sdhci_host.c \
+	stm32g4_write_extract.h stm32l5_write_extract.h \
 	stm32u5_write_extract.h \
-	t10xx_qe_firmware_extract.h t2080_fman_extract.h \
+	t10xx_flash_status_extract.h t10xx_qe_firmware_extract.h \
+	t2080_fman_extract.h \
 	ti_hercules_write_extract.h versal_ext_write_extract.h versal_host.c \
 	versal_host.h versal_qspidev_extract.h zynq_erase_extract.h \
 	zynq_write_extract.h

--- a/tools/unit-tests/Makefile
+++ b/tools/unit-tests/Makefile
@@ -115,6 +115,7 @@ TESTS+=unit-versal-ext-write
 TESTS+=unit-t10xx-qe-firmware
 TESTS+=unit-t10xx-flash-status
 TESTS+=unit-p1021-erase-advance
+TESTS+=unit-hifive1-flash-write
 TESTS+=unit-aurix-erased-fill
 TESTS+=unit-aurix-erased-fill-invert
 TESTS+=unit-t2080-fman-loader
@@ -1047,6 +1048,16 @@ p1021_erase_fn_extract.h: ../../hal/nxp_p1021.c
 unit-p1021-erase-advance: unit-p1021-erase-advance.c p1021_erase_extract.h \
 	p1021_erase_fn_extract.h
 	gcc -o $@ unit-p1021-erase-advance.c $(CFLAGS) $(LDFLAGS)
+
+# unit-hifive1-flash-write runs the real hal_flash_write() from
+# hal/hifive1.c against a mock fespi model (F-11035: the final partial
+# page of a multi-page write took the full-page branch, over-reading
+# the input and over-programming flash).
+hifive1_flash_write_extract.h: ../../hal/hifive1.c
+	sed -n '/^int RAMFUNCTION hal_flash_write/,/^}/p' $< > $@
+
+unit-hifive1-flash-write: unit-hifive1-flash-write.c hifive1_flash_write_extract.h
+	gcc -o $@ unit-hifive1-flash-write.c $(CFLAGS) $(LDFLAGS)
 
 # unit-ecc-raw-der runs the real wolfCrypt raw-to-DER conversion and
 # verification (F-11024: the wolfHSM verify path in src/image.c passed

--- a/tools/unit-tests/Makefile
+++ b/tools/unit-tests/Makefile
@@ -115,6 +115,7 @@ TESTS+=unit-t10xx-qe-firmware
 TESTS+=unit-aurix-erased-fill
 TESTS+=unit-aurix-erased-fill-invert
 TESTS+=unit-t2080-fman-loader
+TESTS+=unit-stm32g4-write
 TESTS+=unit-stm32l5-write
 TESTS+=unit-stm32u5-write
 TESTS+=unit-nvm-cache-scrub
@@ -989,6 +990,19 @@ t2080_fman_extract.h: ../../hal/nxp_t2080.c
 unit-t2080-fman-loader: unit-t2080-fman-loader.c t2080_fman_extract.h
 	gcc -o $@ unit-t2080-fman-loader.c $(CFLAGS) $(LDFLAGS)
 
+# unit-stm32g4-write runs the real hal_flash_write() from hal/stm32g4.c
+# (F-11023: the double-word fast path was selected on "len - i > 3" but
+# consumed eight bytes, so an aligned 4-7 byte tail over-read the
+# caller's buffer and over-programmed flash). Same harness as the
+# STM32L5/STM32U5 twins; the g4 helpers are static and un-prefixed.
+stm32g4_write_extract.h: ../../hal/stm32g4.c
+	sed -n '/^static RAMFUNCTION void flash_wait_complete/,/^}/p' $< > $@
+	sed -n '/^static void RAMFUNCTION flash_clear_errors/,/^}/p' $< >> $@
+	sed -n '/^int RAMFUNCTION hal_flash_write/,/^}/p' $< >> $@
+
+unit-stm32g4-write: unit-stm32g4-write.c stm32g4_write_extract.h
+	gcc -o $@ unit-stm32g4-write.c $(CFLAGS) $(LDFLAGS)
+
 # unit-stm32l5-write runs the real hal_flash_write() from hal/stm32l5.c
 # (an 8-byte program unit was read whole even when len left a
 # partial unit, over-reading the caller's buffer and writing the excess
@@ -1157,7 +1171,8 @@ covclean:
 # so "clean" removes them and so there is one place that names them.
 GENERATED_SRC:=aurix_erased_extract.h nvm_cache_scrub_extract.h \
 	nxp_ls1028a_host.c nxp_p1021_host.c nxp_t10xx_fixup_extract.h \
-	sdhci_host.c stm32l5_write_extract.h stm32u5_write_extract.h \
+	sdhci_host.c stm32g4_write_extract.h stm32l5_write_extract.h \
+	stm32u5_write_extract.h \
 	t10xx_qe_firmware_extract.h t2080_fman_extract.h \
 	ti_hercules_write_extract.h versal_ext_write_extract.h versal_host.c \
 	versal_host.h versal_qspidev_extract.h zynq_erase_extract.h \

--- a/tools/unit-tests/Makefile
+++ b/tools/unit-tests/Makefile
@@ -115,6 +115,7 @@ TESTS+=unit-t10xx-qe-firmware
 TESTS+=unit-aurix-erased-fill
 TESTS+=unit-aurix-erased-fill-invert
 TESTS+=unit-t2080-fman-loader
+TESTS+=unit-ecc-raw-der
 TESTS+=unit-stm32g4-write
 TESTS+=unit-stm32l5-write
 TESTS+=unit-stm32u5-write
@@ -1002,6 +1003,41 @@ stm32g4_write_extract.h: ../../hal/stm32g4.c
 
 unit-stm32g4-write: unit-stm32g4-write.c stm32g4_write_extract.h
 	gcc -o $@ unit-stm32g4-write.c $(CFLAGS) $(LDFLAGS)
+
+# unit-ecc-raw-der runs the real wolfCrypt raw-to-DER conversion and
+# verification (F-11024: the wolfHSM verify path in src/image.c passed
+# minimal field sizes with field-start pointers to
+# wc_ecc_rs_raw_to_sig, corrupting signatures with leading zeros). It
+# links the same wolfSSL sources the sign tool uses.
+unit-ecc-raw-der: unit-ecc-raw-der.c
+	# WOLFSSL_NO_DER_TO_PEM: the test config's NO_CODING drops base64, which
+	# DER-to-PEM (pulled in by WOLFSSL_KEY_GEN) needs; the test uses no PEM.
+	gcc -o $@ unit-ecc-raw-der.c $(CFLAGS) -DWOLFCRYPT_TEST -DWOLFSSL_NO_DER_TO_PEM \
+		$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/aes.c \
+		$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/asn.c \
+		$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/chacha.c \
+		$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/coding.c \
+		$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/ecc.c \
+		$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/ed25519.c \
+		$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/ed448.c \
+		$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/fe_448.c \
+		$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/fe_operations.c \
+		$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/ge_448.c \
+		$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/ge_operations.c \
+		$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/hash.c \
+		$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/logging.c \
+		$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/memory.c \
+		$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/random.c \
+		$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/rsa.c \
+		$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/sha256.c \
+		$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/sha3.c \
+		$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/sha512.c \
+		$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/sp_c32.c \
+		$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/sp_c64.c \
+		$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/sp_int.c \
+		$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/tfm.c \
+		$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/wc_port.c \
+		$(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/wolfmath.c $(LDFLAGS)
 
 # unit-stm32l5-write runs the real hal_flash_write() from hal/stm32l5.c
 # (an 8-byte program unit was read whole even when len left a

--- a/tools/unit-tests/Makefile
+++ b/tools/unit-tests/Makefile
@@ -118,6 +118,7 @@ TESTS+=unit-p1021-erase-advance
 TESTS+=unit-hifive1-flash-write
 TESTS+=unit-fwtpm-rsp-overrun
 TESTS+=unit-fwtpm-cmd-toctou
+TESTS+=unit-fdt-memrsv-wrap
 TESTS+=unit-aurix-erased-fill
 TESTS+=unit-aurix-erased-fill-invert
 TESTS+=unit-t2080-fman-loader
@@ -392,6 +393,18 @@ unit-fwtpm-rsp-overrun: ../../include/target.h unit-fwtpm-rsp-overrun.c
 unit-fwtpm-cmd-toctou: ../../include/target.h unit-fwtpm-cmd-toctou.c
 	gcc -o $@ $^ $(CFLAGS) -I$(WOLFBOOT_LIB_WOLFTPM) \
 		-DWOLFTPM_USER_SETTINGS $(LDFLAGS)
+
+# unit-fdt-memrsv-wrap: a wrapped string-block end in fdt_add_mem_rsv()
+# must be rejected, not turned into a huge memmove (F-11045).
+fdt_memrsv_extract.h: ../../src/fdt.c
+	sed -n '/^uint32_t cpu_to_fdt32/,/^}/p' $< > $@
+	sed -n '/^uint64_t cpu_to_fdt64/,/^}/p' $< >> $@
+	sed -n '/^uint32_t fdt32_to_cpu/,/^}/p' $< >> $@
+	sed -n '/^uint64_t fdt64_to_cpu/,/^}/p' $< >> $@
+	sed -n '/^int fdt_add_mem_rsv/,/^}/p' $< >> $@
+
+unit-fdt-memrsv-wrap: unit-fdt-memrsv-wrap.c fdt_memrsv_extract.h
+	gcc -o $@ unit-fdt-memrsv-wrap.c -I../../include $(CFLAGS) $(LDFLAGS)
 
 unit-tpm-blob: ../../include/target.h unit-tpm-blob.c
 	gcc -o $@ $^ $(CFLAGS) -I$(WOLFBOOT_LIB_WOLFTPM) -DWOLFBOOT_TPM \

--- a/tools/unit-tests/Makefile
+++ b/tools/unit-tests/Makefile
@@ -117,6 +117,7 @@ TESTS+=unit-t10xx-flash-status
 TESTS+=unit-p1021-erase-advance
 TESTS+=unit-hifive1-flash-write
 TESTS+=unit-fwtpm-rsp-overrun
+TESTS+=unit-fwtpm-cmd-toctou
 TESTS+=unit-aurix-erased-fill
 TESTS+=unit-aurix-erased-fill-invert
 TESTS+=unit-t2080-fman-loader
@@ -382,6 +383,13 @@ unit-fwtpm-nv-oob: ../../include/target.h unit-fwtpm-nv-oob.c
 # response must not be overrun by the fwTPM processor (F-11043); the
 # veneer processes into a staging buffer and copies only what fits.
 unit-fwtpm-rsp-overrun: ../../include/target.h unit-fwtpm-rsp-overrun.c
+	gcc -o $@ $^ $(CFLAGS) -I$(WOLFBOOT_LIB_WOLFTPM) \
+		-DWOLFTPM_USER_SETTINGS $(LDFLAGS)
+
+# unit-fwtpm-cmd-toctou: a midflight NS rewrite of the command buffer
+# must not change what the processor executes (F-11044); the veneer
+# stages the command in secure memory before processing.
+unit-fwtpm-cmd-toctou: ../../include/target.h unit-fwtpm-cmd-toctou.c
 	gcc -o $@ $^ $(CFLAGS) -I$(WOLFBOOT_LIB_WOLFTPM) \
 		-DWOLFTPM_USER_SETTINGS $(LDFLAGS)
 

--- a/tools/unit-tests/Makefile
+++ b/tools/unit-tests/Makefile
@@ -99,6 +99,7 @@ TESTS+=unit-ata-security-passphrase-zeroize
 TESTS+=unit-fwtpm-nv-oob
 TESTS+=unit-elf-bss-guard
 TESTS+=unit-elf-entry-inplace
+TESTS+=unit-elf-mmu-fail
 TESTS+=unit-image-elf-scatter
 TESTS+=unit-arm-tee-psa-ipc
 TESTS+=unit-dice-token-size
@@ -1190,6 +1191,13 @@ unit-elf-bss-guard: unit-elf-bss-guard.c
 unit-elf-entry-inplace: unit-elf-entry-inplace.c
 	gcc -o $@ $< -I../../include -DWOLFBOOT_ELF -DARCH_FLASH_OFFSET=0 \
 		-DWOLFBOOT_NO_PRINTF -g $(LDFLAGS)
+
+# unit-elf-mmu-fail: a failing mmu_cb must abort the whole ELF load
+# (F-11027: the failed mapping used to be skipped with continue, and
+# the entry point was published for a partially loaded image).
+unit-elf-mmu-fail: unit-elf-mmu-fail.c ../../src/elf.c
+	gcc -o $@ unit-elf-mmu-fail.c -I../../include -DWOLFBOOT_ELF \
+		-DARCH_FLASH_OFFSET=0 -DWOLFBOOT_NO_PRINTF -g $(LDFLAGS)
 
 unit-image-elf-scatter: ../../include/target.h unit-image-elf-scatter.c
 	gcc -o $@ unit-image-elf-scatter.c $(WOLFBOOT_LIB_WOLFSSL)/wolfcrypt/src/sha256.c \

--- a/tools/unit-tests/Makefile
+++ b/tools/unit-tests/Makefile
@@ -116,6 +116,7 @@ TESTS+=unit-t10xx-qe-firmware
 TESTS+=unit-t10xx-flash-status
 TESTS+=unit-p1021-erase-advance
 TESTS+=unit-hifive1-flash-write
+TESTS+=unit-fwtpm-rsp-overrun
 TESTS+=unit-aurix-erased-fill
 TESTS+=unit-aurix-erased-fill-invert
 TESTS+=unit-t2080-fman-loader
@@ -374,6 +375,13 @@ unit-fwtpm-stub: ../../include/target.h unit-fwtpm-stub.c
 		$(LDFLAGS) -Wl,--gc-sections
 
 unit-fwtpm-nv-oob: ../../include/target.h unit-fwtpm-nv-oob.c
+	gcc -o $@ $^ $(CFLAGS) -I$(WOLFBOOT_LIB_WOLFTPM) \
+		-DWOLFTPM_USER_SETTINGS $(LDFLAGS)
+
+# unit-fwtpm-rsp-overrun: a response capacity below the 10-byte minimum
+# response must not be overrun by the fwTPM processor (F-11043); the
+# veneer processes into a staging buffer and copies only what fits.
+unit-fwtpm-rsp-overrun: ../../include/target.h unit-fwtpm-rsp-overrun.c
 	gcc -o $@ $^ $(CFLAGS) -I$(WOLFBOOT_LIB_WOLFTPM) \
 		-DWOLFTPM_USER_SETTINGS $(LDFLAGS)
 

--- a/tools/unit-tests/Makefile
+++ b/tools/unit-tests/Makefile
@@ -114,6 +114,7 @@ TESTS+=unit-versal-qspi-dma
 TESTS+=unit-versal-ext-write
 TESTS+=unit-t10xx-qe-firmware
 TESTS+=unit-t10xx-flash-status
+TESTS+=unit-p1021-erase-advance
 TESTS+=unit-aurix-erased-fill
 TESTS+=unit-aurix-erased-fill-invert
 TESTS+=unit-t2080-fman-loader
@@ -1018,6 +1019,34 @@ t10xx_flash_status_extract.h: ../../hal/nxp_t10xx.c
 
 unit-t10xx-flash-status: unit-t10xx-flash-status.c t10xx_flash_status_extract.h
 	gcc -o $@ unit-t10xx-flash-status.c $(CFLAGS) $(LDFLAGS)
+
+# unit-p1021-erase-advance runs the real ext_flash_erase() from
+# hal/nxp_p1021.c against mocked ELBC access (F-11034: the loop never
+# advanced the address, re-erasing the first block of the range).
+p1021_erase_extract.h: ../../hal/nxp_p1021.c
+	sed -n '/#define ELBC_BASE /p' $< > $@
+	sed -n '/#define ELBC_MDR /p' $< >> $@
+	sed -n '/#define ELBC_FIR /p' $< >> $@
+	sed -n '/#define ELBC_FCR /p' $< >> $@
+	sed -n '/#define ELBC_FBCR /p' $< >> $@
+	sed -n '/#define ELBC_FIR_OP(/p' $< >> $@
+	sed -n '/#define ELBC_FIR_OP_PA /p' $< >> $@
+	sed -n '/#define ELBC_FIR_OP_CM0 /p' $< >> $@
+	sed -n '/#define ELBC_FIR_OP_CM2 /p' $< >> $@
+	sed -n '/#define ELBC_FIR_OP_CW1 /p' $< >> $@
+	sed -n '/#define ELBC_FIR_OP_RS /p' $< >> $@
+	sed -n '/#define ELBC_FCR_CMD(/p' $< >> $@
+	sed -n '/#define NAND_CMD_STATUS /p' $< >> $@
+	sed -n '/#define NAND_CMD_BLOCK_ERASE1 /p' $< >> $@
+	sed -n '/#define NAND_CMD_BLOCK_ERASE2 /p' $< >> $@
+	sed -n '/#define FLASH_PAGE_SIZE /p' $< >> $@
+
+p1021_erase_fn_extract.h: ../../hal/nxp_p1021.c
+	sed -n '/^int ext_flash_erase/,/^}/p' $< > $@
+
+unit-p1021-erase-advance: unit-p1021-erase-advance.c p1021_erase_extract.h \
+	p1021_erase_fn_extract.h
+	gcc -o $@ unit-p1021-erase-advance.c $(CFLAGS) $(LDFLAGS)
 
 # unit-ecc-raw-der runs the real wolfCrypt raw-to-DER conversion and
 # verification (F-11024: the wolfHSM verify path in src/image.c passed

--- a/tools/unit-tests/unit-ecc-raw-der.c
+++ b/tools/unit-tests/unit-ecc-raw-der.c
@@ -1,0 +1,289 @@
+/* unit-ecc-raw-der.c
+ *
+ * Regression test for F-11024: the wolfHSM verify path of
+ * wolfBoot_verify_signature_ecc() (src/image.c) converts the fixed-width
+ * raw R||S signature to DER with wc_ecc_rs_raw_to_sig(). It passed the
+ * minimal field sizes (mp_unsigned_bin_size) while leaving the pointers
+ * at the start of each fixed-width field, so whenever R or S had a
+ * leading zero byte the conversion encoded a zero-padded integer with
+ * the low bytes truncated, and wc_ecc_verify_hash() rejected an
+ * otherwise valid signature.
+ *
+ * The fix passes the full-width fields (point_sz for both) and drops
+ * the now-unused multiprecision sizing. This test runs the real
+ * wolfCrypt conversion and verification: it signs until a signature
+ * with a leading zero shows up, then asserts that the minimal-size
+ * pattern rejects it while the full-width pattern accepts the same
+ * signature. Both patterns must also accept leading-zero-free
+ * signatures, so the fix does not change the common case.
+ *
+ * Notes on the build: WOLFCRYPT_TEST pulls in the full ECC (sign and
+ * verify) and the deterministic-k mode (WOLFSSL_ECDSA_SET_K), so the
+ * digest varies per iteration to get independent signatures, and
+ * wc_ecc_sign_hash() emits DER here and is decoded back to the
+ * fixed-width raw layout wolfBoot stores in the image header. The
+ * check harness does not keep globals between tests, so the search
+ * runs in every setup.
+ * Copyright (C) 2026 wolfSSL Inc.
+ *
+ * This file is part of wolfBoot.
+ *
+ * wolfBoot is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfBoot is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+#include <check.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <wolfssl/wolfcrypt/ecc.h>
+#include <wolfssl/wolfcrypt/random.h>
+
+/* The test build config wires the RNG block generator to this hook
+ * (include/user_settings.h, CUSTOM_RAND_GENERATE_BLOCK); it only feeds
+ * the DRBG seed, never the signature bytes. */
+int my_rng_seed_gen(unsigned char* output, unsigned int sz)
+{
+    int i;
+
+    for (i = 0; i < (int)sz; i++)
+        output[i] = (unsigned char)(i * 37 + 11);
+    return 0;
+}
+
+#define POINT_SZ  32
+#define DIGEST_SZ 32
+#define MAX_SIGS  1000
+
+static WC_RNG g_rng;
+static ecc_key g_ecc;
+static byte g_digest[DIGEST_SZ];
+static byte g_raw_sig[2 * POINT_SZ];
+static byte g_search_digest[DIGEST_SZ];
+static int g_have_leading_zero_sig;
+
+static void find_leading_zero_sig(void);
+static int sign_raw(const byte* digest);
+static int leading_zeros(const byte* field);
+static int convert_and_verify(const byte* raw, const byte* digest,
+                              int full_width, int* valid);
+
+/* Sign the digest and pack the result as fixed-width raw R||S, the
+ * layout wolfBoot stores in the image header. wc_ecc_sign_hash() emits
+ * DER in this build, so the components are decoded and re-padded. */
+static int sign_raw(const byte* digest)
+{
+    byte der[255];
+    byte r[POINT_SZ];
+    byte s[POINT_SZ];
+    word32 derSz = sizeof(der);
+    word32 rSz = sizeof(r);
+    word32 sSz = sizeof(s);
+    int ret;
+
+    ret = wc_ecc_sign_hash(digest, DIGEST_SZ, der, &derSz, &g_rng, &g_ecc);
+    if (ret != 0)
+        return ret;
+    ret = wc_ecc_sig_to_rs(der, derSz, r, &rSz, s, &sSz);
+    if (ret != 0)
+        return ret;
+    memset(g_raw_sig, 0, sizeof(g_raw_sig));
+    memcpy(g_raw_sig + (POINT_SZ - rSz), r, rSz);
+    memcpy(g_raw_sig + POINT_SZ + (POINT_SZ - sSz), s, sSz);
+    return 0;
+}
+
+/* Number of leading zero bytes of a fixed-width field. */
+static int leading_zeros(const byte* field)
+{
+    int n = 0;
+
+    while ((n < POINT_SZ) && (field[n] == 0))
+        n++;
+    return n;
+}
+
+/* Convert raw R||S to DER and verify it against the digest the
+ * signature was made over.
+ * full_width: pass point_sz for both fields (the fix);
+ * otherwise pass the minimal sizes with the field-start pointers
+ * (the pre-fix pattern). */
+static int convert_and_verify(const byte* raw, const byte* digest,
+                              int full_width, int* valid)
+{
+    int ret;
+    int res = 0;
+    word32 rSz = POINT_SZ;
+    word32 sSz = POINT_SZ;
+    word32 derSz = 255;
+    byte der[255];
+
+    if (!full_width) {
+        rSz = (word32)(POINT_SZ - leading_zeros(raw));
+        sSz = (word32)(POINT_SZ - leading_zeros(raw + POINT_SZ));
+    }
+    ret = wc_ecc_rs_raw_to_sig(raw, rSz, raw + POINT_SZ, sSz, der, &derSz);
+    if (ret != 0)
+        return ret;
+
+    ret = wc_ecc_verify_hash(der, derSz, digest, DIGEST_SZ, &res, &g_ecc);
+    *valid = res;
+    return ret;
+}
+
+/* Sign until a signature has a leading zero in R or S (the trigger for
+ * the pre-fix bug); keep the signature in g_raw_sig and its digest in
+ * g_search_digest. The build uses deterministic k (WOLFSSL_ECDSA_SET_K),
+ * so the digest varies per iteration to get independent signatures.
+ * With a ~1/128 chance per signature, 1000 iterations come up short
+ * ~0.04% of the time; the dependent test skips itself in that case. */
+static void find_leading_zero_sig(void)
+{
+    byte digest[DIGEST_SZ];
+    int i;
+
+    g_have_leading_zero_sig = 0;
+    for (i = 0; i < MAX_SIGS; i++) {
+        memcpy(digest, g_digest, sizeof(digest));
+        digest[DIGEST_SZ - 1] = (byte)i;
+        if (sign_raw(digest) != 0)
+            return;
+        if ((g_raw_sig[0] == 0) || (g_raw_sig[POINT_SZ] == 0)) {
+            g_have_leading_zero_sig = 1;
+            memcpy(g_search_digest, digest, sizeof(digest));
+            return;
+        }
+    }
+}
+
+static void setup(void)
+{
+    int i;
+
+    for (i = 0; i < DIGEST_SZ; i++)
+        g_digest[i] = (byte)(i + 1);
+
+    ck_assert_int_eq(wc_InitRng(&g_rng), 0);
+    ck_assert_int_eq(wc_ecc_init(&g_ecc), 0);
+    ck_assert_int_eq(wc_ecc_make_key(&g_rng, POINT_SZ, &g_ecc), 0);
+    find_leading_zero_sig();
+}
+
+static void teardown(void)
+{
+    wc_ecc_free(&g_ecc);
+    wc_FreeRng(&g_rng);
+}
+
+/* The full-width conversion verifies every signature, including the
+ * leading-zero one: the fix is correct. */
+START_TEST(test_full_width_always_verifies)
+{
+    int i;
+    int valid;
+
+    /* First: the search signature from setup, before the loop below
+     * overwrites g_raw_sig. */
+    if (g_have_leading_zero_sig) {
+        ck_assert_int_eq(convert_and_verify(g_raw_sig, g_search_digest, 1,
+                                            &valid), 0);
+        ck_assert_int_eq(valid, 1);
+    }
+
+    for (i = 0; i < 16; i++) {
+        ck_assert_int_eq(sign_raw(g_digest), 0);
+        ck_assert_int_eq(convert_and_verify(g_raw_sig, g_digest, 1,
+                                            &valid), 0);
+        ck_assert_int_eq(valid, 1);
+    }
+}
+END_TEST
+
+/* The pre-fix pattern (minimal sizes, field-start pointers) rejects
+ * the same leading-zero signature that the full-width pattern
+ * accepts: the signature is valid, the conversion was wrong. */
+START_TEST(test_minimal_pattern_rejects_leading_zero_sig)
+{
+    int valid;
+
+    if (!g_have_leading_zero_sig) {
+        printf("no leading-zero signature found, skipping\n");
+        return;
+    }
+
+    ck_assert_int_eq(convert_and_verify(g_raw_sig, g_search_digest, 1,
+                                        &valid), 0);
+    ck_assert_int_eq(valid, 1);
+
+    ck_assert_int_eq(convert_and_verify(g_raw_sig, g_search_digest, 0,
+                                        &valid), 0);
+    ck_assert_int_eq(valid, 0);
+}
+END_TEST
+
+/* Without leading zeros both patterns agree and the signature
+ * verifies: the common case is untouched by the fix. */
+START_TEST(test_no_leading_zero_both_patterns_agree)
+{
+    byte digest[DIGEST_SZ];
+    int valid;
+    int i;
+    int checked;
+
+    for (i = 0, checked = 0; i < 8 && checked < 4; i++) {
+        memcpy(digest, g_digest, sizeof(digest));
+        digest[DIGEST_SZ - 1] = (byte)(0xC0 + i);
+        ck_assert_int_eq(sign_raw(digest), 0);
+        if ((g_raw_sig[0] == 0) || (g_raw_sig[POINT_SZ] == 0))
+            continue;
+
+        ck_assert_int_eq(convert_and_verify(g_raw_sig, digest, 1,
+                                            &valid), 0);
+        ck_assert_int_eq(valid, 1);
+        ck_assert_int_eq(convert_and_verify(g_raw_sig, digest, 0,
+                                            &valid), 0);
+        ck_assert_int_eq(valid, 1);
+        checked++;
+    }
+    ck_assert_int_gt(checked, 0);
+}
+END_TEST
+
+Suite *ecc_raw_der_suite(void)
+{
+    Suite *s = suite_create("ecc-raw-der");
+    TCase *tc = tcase_create("ecc-raw-der");
+
+    tcase_add_checked_fixture(tc, setup, teardown);
+    tcase_add_test(tc, test_full_width_always_verifies);
+    tcase_add_test(tc, test_minimal_pattern_rejects_leading_zero_sig);
+    tcase_add_test(tc, test_no_leading_zero_both_patterns_agree);
+    suite_add_tcase(s, tc);
+
+    return s;
+}
+
+int main(void)
+{
+    int fails;
+    Suite *s = ecc_raw_der_suite();
+    SRunner *sr = srunner_create(s);
+
+    srunner_run_all(sr, CK_NORMAL);
+    fails = srunner_ntests_failed(sr);
+    srunner_free(sr);
+
+    return fails;
+}

--- a/tools/unit-tests/unit-elf-mmu-fail.c
+++ b/tools/unit-tests/unit-elf-mmu-fail.c
@@ -1,0 +1,175 @@
+/* unit-elf-mmu-fail.c
+ *
+ * Regression test for F-11027: elf_load_image_mmu() skipped a segment
+ * when its mmu_cb mapping failed (continue) instead of aborting, so it
+ * could publish the ELF entry point and return success for a partially
+ * loaded image. The x86 FSP payload path (boot_x86_fsp_payload.c)
+ * passes a real mmu_cb and panics only on a non-zero return, so the
+ * buggy continue booted a payload with a missing segment.
+ *
+ * The loader must fail the whole load when a mapping fails, matching
+ * the program-header clobber guard that aborts for the same reason:
+ * never silently drop a PT_LOAD segment.
+ *
+ * Copyright (C) 2026 wolfSSL Inc.
+ *
+ * This file is part of wolfBoot.
+ *
+ * wolfBoot is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfBoot is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+#include <stdint.h>
+#include <string.h>
+#include <check.h>
+
+#include "elf.h"
+
+/* Pull in elf.c directly (avoids a separate link step). */
+#include "../../src/elf.c"
+
+/* 4 KiB is plenty for the ELF64 header + 2 program headers + segment data. */
+#define TEST_IMG_SIZE 4096
+
+static uint8_t g_image[TEST_IMG_SIZE];
+static uint8_t g_target[64];
+
+/* Fail the mapping of the first segment only, on the first call. */
+static int g_fail_first;
+
+static int mmu_cb_fail_first(uint64_t vaddr, uint64_t paddr, uint32_t size)
+{
+    (void)vaddr;
+    (void)paddr;
+    (void)size;
+
+    if (g_fail_first) {
+        g_fail_first = 0;
+        return -1;
+    }
+    return 0;
+}
+
+static int mmu_cb_ok(uint64_t vaddr, uint64_t paddr, uint32_t size)
+{
+    (void)vaddr;
+    (void)paddr;
+    (void)size;
+    return 0;
+}
+
+/* Build a minimal ELF64 with two 8-byte PT_LOAD segments, with their
+ * data at image offsets 256 and 264, mapped onto g_target. */
+static void build_elf(void)
+{
+    elf64_header        *hdr;
+    elf64_program_header *ph;
+
+    memset(g_image, 0, sizeof(g_image));
+    memset(g_target, 0, sizeof(g_target));
+
+    hdr = (elf64_header *)g_image;
+    memcpy(hdr->ident, ELF_IDENT_STR, 4);
+    hdr->ident[ELF_CLASS_OFF]   = ELF_CLASS_64;
+    hdr->ident[5]               = ELF_ENDIAN_LITTLE;
+    hdr->type                   = ELF_HET_EXEC;
+    hdr->version                = 1;
+    hdr->entry                  = 0x1000;
+    hdr->ph_offset              = sizeof(elf64_header);          /* 64 */
+    hdr->ph_entry_size          = sizeof(elf64_program_header);  /* 56 */
+    hdr->ph_entry_count         = 2;
+
+    ph = (elf64_program_header *)(g_image + sizeof(elf64_header));
+
+    ph[0].type      = ELF_PT_LOAD;
+    ph[0].flags     = 0;
+    ph[0].offset    = 256;
+    ph[0].vaddr     = (uint64_t)(uintptr_t)g_target;
+    ph[0].paddr     = ph[0].vaddr;
+    ph[0].file_size = 8;
+    ph[0].mem_size  = 8;
+    ph[0].align     = 1;
+
+    ph[1].type      = ELF_PT_LOAD;
+    ph[1].flags     = 0;
+    ph[1].offset    = 264;
+    ph[1].vaddr     = (uint64_t)(uintptr_t)(g_target + 16);
+    ph[1].paddr     = ph[1].vaddr;
+    ph[1].file_size = 8;
+    ph[1].mem_size  = 8;
+    ph[1].align     = 1;
+
+    /* Segment payloads: recognizable bytes. */
+    memset(g_image + 256, 0xA5, 8);
+    memset(g_image + 264, 0x5A, 8);
+}
+
+/* A failed mapping must fail the whole load: no entry point published,
+ * no success returned. */
+START_TEST(test_mmu_failure_aborts_load)
+{
+    uintptr_t entry = 0;
+    int ret;
+
+    build_elf();
+    g_fail_first = 1;
+
+    ret = elf_load_image_mmu(g_image, sizeof(g_image), &entry,
+                             mmu_cb_fail_first);
+
+    ck_assert_int_ne(ret, 0);
+    ck_assert_msg(entry == 0,
+        "entry point published despite a failed mmu mapping");
+}
+END_TEST
+
+/* With successful mappings the load completes and the entry point is
+ * published: the failure path must not over-reject. */
+START_TEST(test_successful_mappings_still_load)
+{
+    uintptr_t entry = 0;
+    int ret;
+
+    build_elf();
+
+    ret = elf_load_image_mmu(g_image, sizeof(g_image), &entry, mmu_cb_ok);
+
+    ck_assert_int_eq(ret, 0);
+    ck_assert_int_eq(entry, 0x1000);
+    ck_assert_mem_eq(g_target, g_image + 256, 8);
+    ck_assert_mem_eq(g_target + 16, g_image + 264, 8);
+}
+END_TEST
+
+Suite *elf_mmu_fail_suite(void)
+{
+    Suite *s  = suite_create("ELF mmu failure");
+    TCase *tc = tcase_create("mmu-cb-failure");
+    tcase_add_test(tc, test_mmu_failure_aborts_load);
+    tcase_add_test(tc, test_successful_mappings_still_load);
+    tcase_set_timeout(tc, 10);
+    suite_add_tcase(s, tc);
+    return s;
+}
+
+int main(void)
+{
+    int    fails;
+    Suite *s  = elf_mmu_fail_suite();
+    SRunner *sr = srunner_create(s);
+    srunner_run_all(sr, CK_NORMAL);
+    fails = srunner_ntests_failed(sr);
+    srunner_free(sr);
+    return fails;
+}

--- a/tools/unit-tests/unit-fdt-memrsv-wrap.c
+++ b/tools/unit-tests/unit-fdt-memrsv-wrap.c
@@ -52,12 +52,6 @@
 #define BUF_SZ 96
 static uint8_t g_buf[BUF_SZ];
 
-/* Store a 32-bit field in FDT (big-endian) byte order. */
-static uint32_t put32(uint32_t v)
-{
-    return fdt32_to_cpu(v);
-}
-
 /* Craft a header with the given layout fields. The blocks are laid
  * out as: 40-byte header, reserve map (16-byte terminator), a 4-byte
  * structure block, a 4-byte string block, trailing slack. */
@@ -68,16 +62,16 @@ static void make_fdt(uint32_t total, uint32_t off_rsv, uint32_t off_dt,
 
     memset(g_buf, 0x77, sizeof(g_buf));
 
-    h->magic           = put32(FDT_MAGIC_V);
-    h->totalsize       = put32(total);
-    h->off_dt_struct   = put32(off_dt);
-    h->off_dt_strings  = put32(off_str);
-    h->off_mem_rsvmap  = put32(off_rsv);
-    h->version         = put32(17);
-    h->last_comp_version = put32(16);
-    h->boot_cpuid_phys = put32(0);
-    h->size_dt_strings = put32(size_str);
-    h->size_dt_struct  = put32(0);
+    h->magic           = cpu_to_fdt32(FDT_MAGIC_V);
+    h->totalsize       = cpu_to_fdt32(total);
+    h->off_dt_struct   = cpu_to_fdt32(off_dt);
+    h->off_dt_strings  = cpu_to_fdt32(off_str);
+    h->off_mem_rsvmap  = cpu_to_fdt32(off_rsv);
+    h->version         = cpu_to_fdt32(17);
+    h->last_comp_version = cpu_to_fdt32(16);
+    h->boot_cpuid_phys = cpu_to_fdt32(0);
+    h->size_dt_strings = cpu_to_fdt32(size_str);
+    h->size_dt_struct  = cpu_to_fdt32(0);
 
     /* Block contents only where they fit: the malformed-layout tests
      * carry out-of-buffer offsets, and the code under test must reject

--- a/tools/unit-tests/unit-fdt-memrsv-wrap.c
+++ b/tools/unit-tests/unit-fdt-memrsv-wrap.c
@@ -1,0 +1,190 @@
+/* unit-fdt-memrsv-wrap.c
+ *
+ * Regression test for F-11045: fdt_add_mem_rsv() in src/fdt.c added the
+ * 32-bit string-block offset and size without overflow checks. A
+ * wrapped data_end bypassed the capacity check, and the same wrapped
+ * expression derived the memmove length, so a malformed (or
+ * attacker-supplied) DTB produced a huge memmove - broad boot-time
+ * memory corruption. fdt_check_header validates only magic and
+ * version, so raw-DTB callers reach this code with inconsistent
+ * layout fields.
+ *
+ * The fix uses 64-bit arithmetic for the block end, validates the
+ * ordering of the reserve map / structure / string blocks, and
+ * derives the move length only after validation.
+ *
+ * The real fdt_add_mem_rsv() (plus the byte-order helpers) is
+ * extracted by the Makefile; the FDT under test is a crafted header
+ * plus block layout in a static buffer.
+ *
+ * Copyright (C) 2026 wolfSSL Inc.
+ *
+ * This file is part of wolfBoot.
+ *
+ * wolfBoot is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfBoot is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+#include <check.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "fdt.h"
+
+#define wolfBoot_printf(...) ((void)0)
+
+/* Byte-order helpers and the code under test, from src/fdt.c
+ * (extracted by the Makefile). */
+#include "fdt_memrsv_extract.h"
+
+#define FDT_MAGIC_V 0xD00DFEEDu
+#define BUF_SZ 96
+static uint8_t g_buf[BUF_SZ];
+
+/* Store a 32-bit field in FDT (big-endian) byte order. */
+static uint32_t put32(uint32_t v)
+{
+    return fdt32_to_cpu(v);
+}
+
+/* Craft a header with the given layout fields. The blocks are laid
+ * out as: 40-byte header, reserve map (16-byte terminator), a 4-byte
+ * structure block, a 4-byte string block, trailing slack. */
+static void make_fdt(uint32_t total, uint32_t off_rsv, uint32_t off_dt,
+                     uint32_t off_str, uint32_t size_str)
+{
+    struct fdt_header *h = (struct fdt_header *)g_buf;
+
+    memset(g_buf, 0x77, sizeof(g_buf));
+
+    h->magic           = put32(FDT_MAGIC_V);
+    h->totalsize       = put32(total);
+    h->off_dt_struct   = put32(off_dt);
+    h->off_dt_strings  = put32(off_str);
+    h->off_mem_rsvmap  = put32(off_rsv);
+    h->version         = put32(17);
+    h->last_comp_version = put32(16);
+    h->boot_cpuid_phys = put32(0);
+    h->size_dt_strings = put32(size_str);
+    h->size_dt_struct  = put32(0);
+
+    /* Block contents only where they fit: the malformed-layout tests
+     * carry out-of-buffer offsets, and the code under test must reject
+     * them before touching the blocks. */
+    if (off_rsv + 16 <= BUF_SZ) {
+        memset(g_buf + off_rsv, 0, 16);
+    }
+    if (off_dt + 4 <= BUF_SZ) {
+        memset(g_buf + off_dt, 0, 4);
+    }
+    if (off_str + 2 <= BUF_SZ) {
+        g_buf[off_str] = 'x';
+        g_buf[off_str + 1] = 0;
+    }
+}
+
+/* off_str + size_str wraps past 2^32 and the wrapped end lands below
+ * off_dt: pre-fix the memmove length wraps to ~2^32 (crash/corruption),
+ * post-fix the 64-bit end is far past totalsize and rejected. */
+START_TEST (test_wrap_past_off_dt_rejected)
+{
+    int ret;
+
+    /* off_str + size_str = 0x100000010 (wraps to 0x10 in 32-bit). */
+    make_fdt(0x2000, 40, 0x100, 0xFFFFFFF0u, 0x100u);
+
+    ret = fdt_add_mem_rsv(g_buf, 0x1000, 0x400);
+    ck_assert_int_ne(ret, 0);
+}
+END_TEST
+
+/* The wrapped end lands inside [off_dt, total): pre-fix this passed
+ * the capacity check, moved 0 bytes, and still published shifted
+ * header offsets (a silently corrupted FDT). Post-fix it is rejected. */
+START_TEST (test_wrap_inside_range_rejected)
+{
+    uint32_t off_str_before;
+    int ret;
+
+    /* off_str + size_str = 0x100000100 (wraps to 0x100 in 32-bit)
+     * which equals off_dt. */
+    make_fdt(0x2000, 40, 0x100, 0xFFFFFF00u, 0x200u);
+    off_str_before = fdt_off_dt_strings(g_buf);
+
+    ret = fdt_add_mem_rsv(g_buf, 0x1000, 0x400);
+    ck_assert_int_ne(ret, 0);
+    ck_assert_uint_eq(fdt_off_dt_strings(g_buf), off_str_before);
+    ck_assert_uint_eq(fdt_off_dt_struct(g_buf), 0x100u);
+}
+END_TEST
+
+/* A consistent layout still accepts the insertion: the entry goes in
+ * where the terminator was, the terminator moves down one, structure
+ * and string blocks shift by 16, and the header offsets follow. */
+START_TEST (test_valid_insertion_works)
+{
+    struct fdt_reserve_entry *rsv;
+    int i;
+    int ret;
+
+    /* Layout: header [0,40), rsv map [40,56) terminator, struct
+     * [56,60), strings [60,64); 32 bytes of slack for the shift. */
+    make_fdt(96, 40, 56, 60, 4);
+
+    ret = fdt_add_mem_rsv(g_buf, 0x80000000ULL, 0x400000ULL);
+    ck_assert_int_eq(ret, 0);
+
+    /* New entry where the terminator was, then the terminator. */
+    rsv = (struct fdt_reserve_entry *)(g_buf + 40);
+    ck_assert_uint_eq(fdt64_to_cpu(rsv[0].address), 0x80000000ULL);
+    ck_assert_uint_eq(fdt64_to_cpu(rsv[0].size), 0x400000ULL);
+    ck_assert_uint_eq(fdt64_to_cpu(rsv[1].address), 0ULL);
+    ck_assert_uint_eq(fdt64_to_cpu(rsv[1].size), 0ULL);
+
+    /* Header offsets shifted by one reserve entry (16 bytes). */
+    ck_assert_uint_eq(fdt_off_dt_struct(g_buf), 56 + 16);
+    ck_assert_uint_eq(fdt_off_dt_strings(g_buf), 60 + 16);
+
+    /* Structure block (4-byte end marker) and string block moved intact. */
+    for (i = 72; i < 76; i++)
+        ck_assert_uint_eq(g_buf[i], 0);
+    ck_assert_uint_eq(g_buf[76], 'x');
+    ck_assert_uint_eq(g_buf[77], 0);
+}
+END_TEST
+
+Suite *fdt_memrsv_wrap_suite(void)
+{
+    Suite *s  = suite_create("fdt memrsv wrap");
+    TCase *tc = tcase_create("layout-validation");
+
+    tcase_add_test(tc, test_wrap_past_off_dt_rejected);
+    tcase_add_test(tc, test_wrap_inside_range_rejected);
+    tcase_add_test(tc, test_valid_insertion_works);
+    tcase_set_timeout(tc, 10);
+    suite_add_tcase(s, tc);
+    return s;
+}
+
+int main(void)
+{
+    int fails;
+    Suite *s = fdt_memrsv_wrap_suite();
+    SRunner *sr = srunner_create(s);
+
+    srunner_run_all(sr, CK_NORMAL);
+    fails = srunner_ntests_failed(sr);
+    srunner_free(sr);
+    return fails;
+}

--- a/tools/unit-tests/unit-fwtpm-cmd-toctou.c
+++ b/tools/unit-tests/unit-fwtpm-cmd-toctou.c
@@ -1,0 +1,207 @@
+/* unit-fwtpm-cmd-toctou.c
+ *
+ * Regression test for F-11044: wcs_fwtpm_transmit() validated that cmd
+ * identifies non-secure memory and then passed that mutable buffer
+ * directly to FWTPM_ProcessCommand. The processor parses the packet
+ * more than once (authentication, then execution), so a DMA-capable
+ * non-secure attacker who rewrites the command buffer in between can
+ * make the authenticated command differ from the executed command.
+ *
+ * The fix copies the command into secure staging memory after the
+ * range validation and invokes the processor only on that copy, which
+ * an NS DMA master cannot touch.
+ *
+ * The real fwtpm_callable.c is included; FWTPM_ProcessCommand is
+ * mocked with two parse points (authentication, execution) and the
+ * test plays the attacker, rewriting the NS command buffer at the
+ * window between them. The mock may only rewrite the caller's buffer,
+ * never the secure staging, mirroring the hardware boundary.
+ *
+ * Copyright (C) 2026 wolfSSL Inc.
+ *
+ * This file is part of wolfBoot.
+ *
+ * wolfBoot is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfBoot is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+#include <check.h>
+#include <stdint.h>
+#include <string.h>
+
+#define WOLFBOOT_TZ_FWTPM
+
+/* Minimal types/macros that fwtpm_callable.c uses from wolftpm headers.
+ * Poison the include guards of the heavy fwtpm headers so they become
+ * no-ops; we define the handful of types/symbols we actually need
+ * ourselves (same pattern as unit-fwtpm-nv-oob). */
+#define _FWTPM_H_
+#define _FWTPM_COMMAND_H_
+#define _FWTPM_NV_H_
+
+#define WOLFTPM2_NO_WOLFCRYPT
+
+typedef uint8_t  byte;
+typedef uint32_t word32;
+
+#define BAD_FUNC_ARG    (-173)
+#define TPM_RC_SUCCESS   0x000
+#define TPM_RC_FAILURE   0x101
+#define TPM_RC_INITIALIZE 0x100
+
+#define XMEMCPY(d,s,l)  memcpy((d),(s),(l))
+#define XMEMSET(b,c,l)  memset((b),(c),(l))
+
+#define TPM2_HEADER_SIZE 10
+
+typedef struct FWTPM_NV_HAL_S {
+    int (*read)(void *ctx, word32 offset, byte *buf, word32 size);
+    int (*write)(void *ctx, word32 offset, const byte *buf, word32 size);
+    int (*erase)(void *ctx, word32 offset, word32 size);
+    void *ctx;
+    word32 maxSize;
+} FWTPM_NV_HAL;
+
+typedef struct FWTPM_CTX_S {
+    int wasStarted;
+} FWTPM_CTX;
+
+/* Stub symbols referenced by fwtpm_callable.c */
+unsigned int _start_heap;
+unsigned int _heap_size;
+
+void *wolfboot_store_sbrk(unsigned int incr, uint8_t **heap,
+    uint8_t *start, uint32_t size)
+{
+    (void)incr; (void)heap; (void)start; (void)size;
+    return NULL;
+}
+
+int FWTPM_Init(FWTPM_CTX *ctx) { (void)ctx; return 0; }
+int FWTPM_NV_SetHAL(FWTPM_CTX *ctx, FWTPM_NV_HAL *hal)
+    { (void)ctx; (void)hal; return 0; }
+
+static const uint8_t g_err_rsp[TPM2_HEADER_SIZE] = {
+    0x80, 0xC1, 0x00, 0x00, 0x00, 0x0A, 0x00, 0x00, 0x00, 0x09
+};
+
+#define CMD_SZ 24
+static uint8_t g_ns_cmd[CMD_SZ]; /* the non-secure world's command */
+
+/* 1 when the attacker fires in the parse window of this call. */
+static int g_attack;
+
+/* What the processor saw at each parse point. */
+static uint8_t g_authed[CMD_SZ];
+static uint8_t g_executed[CMD_SZ];
+
+int FWTPM_ProcessCommand(FWTPM_CTX *ctx, const byte *cmdBuf, int cmdSize,
+    byte *rspBuf, int *rspSize, int locality)
+{
+    (void)ctx; (void)locality;
+
+    /* Authentication parse. */
+    memcpy(g_authed, cmdBuf, (size_t)cmdSize);
+
+    if (g_attack) {
+        /* The attacker's DMA rewrite reaches only NS memory - the
+         * caller's command buffer - never secure staging. */
+        memset(g_ns_cmd, 0x5A, (size_t)cmdSize);
+    }
+
+    /* Execution parse. */
+    memcpy(g_executed, cmdBuf, (size_t)cmdSize);
+
+    memcpy(rspBuf, g_err_rsp, TPM2_HEADER_SIZE);
+    *rspSize = TPM2_HEADER_SIZE;
+    return TPM_RC_SUCCESS;
+}
+
+/* Bring in the code under test as part of this translation unit. */
+#include "../../src/fwtpm_callable.c"
+
+/* With the attacker firing mid-processing, the command the processor
+ * authenticates must be byte-identical to the command it executes:
+ * pre-fix the processor parses the caller's mutable buffer, so the
+ * rewrite changes the executed command. */
+START_TEST(cmd_immune_to_midflight_rewrite)
+{
+    uint8_t rsp[16];
+    uint32_t rspSz = sizeof(rsp);
+    int i;
+    int rc;
+
+    for (i = 0; i < CMD_SZ; i++)
+        g_ns_cmd[i] = (uint8_t)(0x10 + i);
+
+    wcs_fwtpm_init();
+    g_attack = 1;
+
+    rc = wcs_fwtpm_transmit(g_ns_cmd, CMD_SZ, rsp, &rspSz);
+    ck_assert_int_eq(rc, TPM_RC_SUCCESS);
+    ck_assert_uint_eq(rspSz, TPM2_HEADER_SIZE);
+
+    ck_assert_mem_eq(g_authed, g_executed, CMD_SZ);
+    /* The attacker did rewrite the NS buffer (the attack model fired);
+     * the processor just did not act on it. */
+    ck_assert_uint_eq(g_ns_cmd[0], 0x5A);
+    for (i = 0; i < CMD_SZ; i++)
+        ck_assert_uint_eq(g_executed[i], (uint8_t)(0x10 + i));
+}
+END_TEST
+
+/* No attacker: an ordinary transmission is unaffected by the staging. */
+START_TEST(cmd_plain_transmission_intact)
+{
+    uint8_t rsp[16];
+    uint32_t rspSz = sizeof(rsp);
+    int i;
+    int rc;
+
+    for (i = 0; i < CMD_SZ; i++)
+        g_ns_cmd[i] = (uint8_t)(0x40 + i);
+
+    wcs_fwtpm_init();
+    g_attack = 0;
+
+    rc = wcs_fwtpm_transmit(g_ns_cmd, CMD_SZ, rsp, &rspSz);
+    ck_assert_int_eq(rc, TPM_RC_SUCCESS);
+    ck_assert_uint_eq(rspSz, TPM2_HEADER_SIZE);
+    ck_assert_mem_eq(g_authed, g_executed, CMD_SZ);
+    for (i = 0; i < CMD_SZ; i++)
+        ck_assert_uint_eq(g_executed[i], (uint8_t)(0x40 + i));
+}
+END_TEST
+
+static Suite *fwtpm_cmd_toctou_suite(void)
+{
+    Suite *s = suite_create("fwtpm_cmd_toctou");
+    TCase *tc = tcase_create("midflight-rewrite");
+
+    tcase_add_test(tc, cmd_immune_to_midflight_rewrite);
+    tcase_add_test(tc, cmd_plain_transmission_intact);
+    suite_add_tcase(s, tc);
+    return s;
+}
+
+int main(void)
+{
+    int fails;
+    Suite *s = fwtpm_cmd_toctou_suite();
+    SRunner *sr = srunner_create(s);
+    srunner_run_all(sr, CK_NORMAL);
+    fails = srunner_ntests_failed(sr);
+    srunner_free(sr);
+    return fails == 0 ? 0 : 1;
+}

--- a/tools/unit-tests/unit-fwtpm-rsp-overrun.c
+++ b/tools/unit-tests/unit-fwtpm-rsp-overrun.c
@@ -159,6 +159,7 @@ START_TEST(rsp_fitting_capacity_gets_response)
 {
     uint8_t *rsp = g_mem + RSP_OFF;
     uint32_t rspSz = 16;
+    uint32_t cap;
     uint8_t cmd[4] = { 0x80, 0x01, 0x00, 0x04 };
     int i;
     int rc;
@@ -166,14 +167,18 @@ START_TEST(rsp_fitting_capacity_gets_response)
     mem_reset();
     wcs_fwtpm_init();
 
+    /* The call overwrites rspSz with the produced size; keep the
+     * offered capacity for the guard check below. */
+    cap = rspSz;
+
     rc = wcs_fwtpm_transmit(cmd, sizeof(cmd), rsp, &rspSz);
     ck_assert_int_eq(rc, TPM_RC_SUCCESS);
     ck_assert_uint_eq(rspSz, TPM2_HEADER_SIZE);
     for (i = 0; i < TPM2_HEADER_SIZE; i++)
         ck_assert_uint_eq(rsp[i], g_err_rsp[i]);
 
-    /* Nothing past the produced response. */
-    for (i = TPM2_HEADER_SIZE; i < (int)rspSz; i++)
+    /* Nothing past the produced response, up to the offered capacity. */
+    for (i = TPM2_HEADER_SIZE; i < (int)cap; i++)
         ck_assert_uint_eq(g_mem[RSP_OFF + i], GUARD_B);
 }
 END_TEST

--- a/tools/unit-tests/unit-fwtpm-rsp-overrun.c
+++ b/tools/unit-tests/unit-fwtpm-rsp-overrun.c
@@ -1,0 +1,223 @@
+/* unit-fwtpm-rsp-overrun.c
+ *
+ * Regression test for F-11043: wcs_fwtpm_transmit() validated the
+ * caller-supplied response capacity, then passed that (possibly short)
+ * buffer straight to FWTPM_ProcessCommand. The fwTPM processor emits a
+ * 10-byte error response for a malformed command regardless of the
+ * offered capacity, so a non-secure caller offering less than 10
+ * bytes got an out-of-range write before the wrapper compared rspLen
+ * against the capacity.
+ *
+ * The fix processes into a max-sized staging buffer inside the veneer
+ * and copies to the caller's buffer only after verifying the produced
+ * length fits the snapshotted capacity.
+ *
+ * The real fwtpm_callable.c is included; FWTPM_ProcessCommand is
+ * mocked to emulate the processor's behavior of writing the full
+ * 10-byte error response no matter what *rspSize was on entry.
+ *
+ * Copyright (C) 2026 wolfSSL Inc.
+ *
+ * This file is part of wolfBoot.
+ *
+ * wolfBoot is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfBoot is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+#include <check.h>
+#include <stdint.h>
+#include <string.h>
+
+#define WOLFBOOT_TZ_FWTPM
+
+/* Minimal types/macros that fwtpm_callable.c uses from wolftpm headers.
+ * Poison the include guards of the heavy fwtpm headers so they become
+ * no-ops; we define the handful of types/symbols we actually need
+ * ourselves (same pattern as unit-fwtpm-nv-oob). */
+#define _FWTPM_H_
+#define _FWTPM_COMMAND_H_
+#define _FWTPM_NV_H_
+
+#define WOLFTPM2_NO_WOLFCRYPT
+
+typedef uint8_t  byte;
+typedef uint32_t word32;
+
+#define BAD_FUNC_ARG    (-173)
+#define TPM_RC_SUCCESS   0x000
+#define TPM_RC_FAILURE   0x101
+#define TPM_RC_INITIALIZE 0x100
+
+#define XMEMCPY(d,s,l)  memcpy((d),(s),(l))
+#define XMEMSET(b,c,l)  memset((b),(c),(l))
+
+#define TPM2_HEADER_SIZE 10
+
+typedef struct FWTPM_NV_HAL_S {
+    int (*read)(void *ctx, word32 offset, byte *buf, word32 size);
+    int (*write)(void *ctx, word32 offset, const byte *buf, word32 size);
+    int (*erase)(void *ctx, word32 offset, word32 size);
+    void *ctx;
+    word32 maxSize;
+} FWTPM_NV_HAL;
+
+typedef struct FWTPM_CTX_S {
+    int wasStarted;
+} FWTPM_CTX;
+
+/* Stub symbols referenced by fwtpm_callable.c */
+unsigned int _start_heap;
+unsigned int _heap_size;
+
+void *wolfboot_store_sbrk(unsigned int incr, uint8_t **heap,
+    uint8_t *start, uint32_t size)
+{
+    (void)incr; (void)heap; (void)start; (void)size;
+    return NULL;
+}
+
+int FWTPM_Init(FWTPM_CTX *ctx) { (void)ctx; return 0; }
+int FWTPM_NV_SetHAL(FWTPM_CTX *ctx, FWTPM_NV_HAL *hal)
+    { (void)ctx; (void)hal; return 0; }
+
+/* The 10-byte error response the fwTPM processor emits for a malformed
+ * command: tag | size(=10) | rc, no handle area. */
+static const uint8_t g_err_rsp[TPM2_HEADER_SIZE] = {
+    0x80, 0xC1, 0x00, 0x00, 0x00, 0x0A, 0x00, 0x00, 0x00, 0x09
+};
+
+/* Emulates the real processor: writes the full 10-byte error response
+ * into rspBuf even when the offered *rspSize is smaller. */
+int FWTPM_ProcessCommand(FWTPM_CTX *ctx, const byte *cmdBuf, int cmdSize,
+    byte *rspBuf, int *rspSize, int locality)
+{
+    (void)ctx; (void)cmdBuf; (void)cmdSize; (void)locality;
+
+    memcpy(rspBuf, g_err_rsp, TPM2_HEADER_SIZE);
+    *rspSize = TPM2_HEADER_SIZE;
+    return TPM_RC_SUCCESS;
+}
+
+/* Bring in the code under test as part of this translation unit. */
+#include "../../src/fwtpm_callable.c"
+
+#define MEM_SZ   64
+#define GUARD_B  0x9C
+static uint8_t g_mem[MEM_SZ];
+
+static void mem_reset(void)
+{
+    int i;
+
+    for (i = 0; i < MEM_SZ; i++)
+        g_mem[i] = GUARD_B;
+}
+
+/* rsp is placed mid-array so any write past rspCapacity lands in the
+ * guard tail. */
+#define RSP_OFF  (MEM_SZ / 2 - 6)
+
+/* A response capacity below the 10-byte minimum response must not
+ * produce an out-of-range write; the veneer must refuse (the produced
+ * response does not fit) instead of letting the processor overrun the
+ * buffer. */
+START_TEST(rsp_short_capacity_no_overrun)
+{
+    uint8_t *rsp = g_mem + RSP_OFF;
+    uint32_t rspSz = 6; /* < 10: below any possible response */
+    uint8_t cmd[4] = { 0x80, 0x01, 0x00, 0x04 };
+    int i;
+    int rc;
+
+    mem_reset();
+    wcs_fwtpm_init();
+
+    rc = wcs_fwtpm_transmit(cmd, sizeof(cmd), rsp, &rspSz);
+    ck_assert_int_eq(rc, TPM_RC_FAILURE);
+
+    /* Nothing may have been written past the offered capacity. */
+    for (i = (int)rspSz; i < MEM_SZ - RSP_OFF; i++) {
+        ck_assert_msg(g_mem[RSP_OFF + i] == GUARD_B,
+            "write past the offered response capacity (offset %d)", i);
+    }
+}
+END_TEST
+
+/* A capacity that fits the response gets the full response copied. */
+START_TEST(rsp_fitting_capacity_gets_response)
+{
+    uint8_t *rsp = g_mem + RSP_OFF;
+    uint32_t rspSz = 16;
+    uint8_t cmd[4] = { 0x80, 0x01, 0x00, 0x04 };
+    int i;
+    int rc;
+
+    mem_reset();
+    wcs_fwtpm_init();
+
+    rc = wcs_fwtpm_transmit(cmd, sizeof(cmd), rsp, &rspSz);
+    ck_assert_int_eq(rc, TPM_RC_SUCCESS);
+    ck_assert_uint_eq(rspSz, TPM2_HEADER_SIZE);
+    for (i = 0; i < TPM2_HEADER_SIZE; i++)
+        ck_assert_uint_eq(rsp[i], g_err_rsp[i]);
+
+    /* Nothing past the produced response. */
+    for (i = TPM2_HEADER_SIZE; i < (int)rspSz; i++)
+        ck_assert_uint_eq(g_mem[RSP_OFF + i], GUARD_B);
+}
+END_TEST
+
+/* Boundary: a capacity of exactly 10 fits the minimum response. */
+START_TEST(rsp_exact_capacity_fits)
+{
+    uint8_t *rsp = g_mem + RSP_OFF;
+    uint32_t rspSz = TPM2_HEADER_SIZE;
+    uint8_t cmd[4] = { 0x80, 0x01, 0x00, 0x04 };
+    int i;
+    int rc;
+
+    mem_reset();
+    wcs_fwtpm_init();
+
+    rc = wcs_fwtpm_transmit(cmd, sizeof(cmd), rsp, &rspSz);
+    ck_assert_int_eq(rc, TPM_RC_SUCCESS);
+    ck_assert_uint_eq(rspSz, TPM2_HEADER_SIZE);
+    for (i = 0; i < TPM2_HEADER_SIZE; i++)
+        ck_assert_uint_eq(rsp[i], g_err_rsp[i]);
+    ck_assert_uint_eq(g_mem[RSP_OFF + TPM2_HEADER_SIZE], GUARD_B);
+}
+END_TEST
+
+static Suite *fwtpm_rsp_overrun_suite(void)
+{
+    Suite *s = suite_create("fwtpm_rsp_overrun");
+    TCase *tc = tcase_create("rsp-capacity-guard");
+
+    tcase_add_test(tc, rsp_short_capacity_no_overrun);
+    tcase_add_test(tc, rsp_fitting_capacity_gets_response);
+    tcase_add_test(tc, rsp_exact_capacity_fits);
+    suite_add_tcase(s, tc);
+    return s;
+}
+
+int main(void)
+{
+    int fails;
+    Suite *s = fwtpm_rsp_overrun_suite();
+    SRunner *sr = srunner_create(s);
+    srunner_run_all(sr, CK_NORMAL);
+    fails = srunner_ntests_failed(sr);
+    srunner_free(sr);
+    return fails == 0 ? 0 : 1;
+}

--- a/tools/unit-tests/unit-hifive1-flash-write.c
+++ b/tools/unit-tests/unit-hifive1-flash-write.c
@@ -77,6 +77,8 @@ static void fespi_write_enable(void)    { }
 #define ERASED 0xEE
 #define DATA_B 0xA1
 #define CANARY 0x5A
+#define REQ_LEN 356
+#define CANARY_LEN 160
 
 static void model_reset(void)
 {
@@ -92,23 +94,24 @@ static void model_reset(void)
  * erased pattern, and nothing past the requested bytes may change. */
 START_TEST (test_final_partial_page_not_overread)
 {
-    uint8_t data[356];
-    uint8_t canary[160];
+    /* One contiguous buffer so the canary is guaranteed to sit right
+     * after the requested data: an out-of-range read lands on known
+     * bytes instead of unspecified stack layout. */
+    uint8_t buf[REQ_LEN + CANARY_LEN];
+    uint8_t *data = buf;
+    uint8_t *canary = buf + REQ_LEN;
     int i;
     int ret;
 
-    /* data is exactly the request length; a canary sits right after it
-     * so any out-of-range read is observable. */
-    for (i = 0; i < (int)sizeof(data); i++)
+    for (i = 0; i < REQ_LEN; i++)
         data[i] = DATA_B;
-    for (i = 0; i < (int)sizeof(canary); i++)
+    for (i = 0; i < CANARY_LEN; i++)
         canary[i] = CANARY;
-    (void)canary;
 
     /* Relative offsets are accepted as-is (address < FLASH_BASE), which
      * keeps the 32-bit address parameter away from 64-bit host pointers. */
     model_reset();
-    ret = hal_flash_write(0, data, sizeof(data));
+    ret = hal_flash_write(0, data, REQ_LEN);
     ck_assert_int_eq(ret, 0);
 
     /* Page 0: full page of data. */
@@ -120,6 +123,11 @@ START_TEST (test_final_partial_page_not_overread)
                      100);
     for (i = 100; i < FLASH_PAGE_SIZE; i++) {
         ck_assert_uint_eq(g_flash[FLASH_PAGE_SIZE + i], ERASED);
+    }
+
+    /* Nothing past the request was written in the buffer. */
+    for (i = 0; i < CANARY_LEN; i++) {
+        ck_assert_uint_eq(canary[i], CANARY);
     }
 }
 END_TEST

--- a/tools/unit-tests/unit-hifive1-flash-write.c
+++ b/tools/unit-tests/unit-hifive1-flash-write.c
@@ -1,0 +1,194 @@
+/* unit-hifive1-flash-write.c
+ *
+ * Regression test for F-11035: hal_flash_write() in hal/hifive1.c
+ * selected the page path and sized the partial-page copy from the
+ * original total `len` instead of the bytes still remaining. A
+ * multi-page write that ends in a partial page therefore took the
+ * full-page branch on the last iteration, read past the end of the
+ * caller's buffer and programmed a whole page past the requested range.
+ *
+ * The real function is extracted by the Makefile and run against a
+ * mock fespi model: FLASH_BASE points at a flash image buffer,
+ * fespi_write_address()/fespi_sw_tx() program into it, and the
+ * read-modify-write path reads the current image back through
+ * FLASH_BASE, exactly as the hardware would.
+ *
+ * Copyright (C) 2026 wolfSSL Inc.
+ *
+ * This file is part of wolfBoot.
+ *
+ * wolfBoot is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfBoot is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+#include <check.h>
+#include <stdint.h>
+#include <string.h>
+
+#define RAMFUNCTION
+#define FLASH_PAGE_SIZE 256
+#define FESPI_PAGE_PROGRAM 0x02
+
+#define NUM_PAGES 4
+static uint8_t g_flash[NUM_PAGES * FLASH_PAGE_SIZE];
+#define FLASH_BASE ((uintptr_t)g_flash)
+
+static uint32_t g_txmark;
+#define FESPI_REG_TXMARK (g_txmark)
+
+/* ---- mock fespi model ------------------------------------------------ */
+
+static uint32_t g_cur; /* byte offset in g_flash the next sw_tx lands at */
+
+static void fespi_write_address(uint32_t address)
+{
+    g_cur = address;
+}
+
+static void fespi_sw_tx(uint8_t b)
+{
+    if (g_cur < sizeof(g_flash)) {
+        g_flash[g_cur++] = b;
+    }
+}
+
+static void fespi_hwmode(void)     { }
+static void fespi_swmode(void)     { }
+static void fespi_csmode_hold(void){ }
+static void fespi_csmode_auto(void){ }
+static void fespi_wait_txwm(void)  { }
+static void fespi_wait_flash_busy(void) { }
+static void fespi_write_enable(void)    { }
+
+/* The real hal_flash_write() from hal/hifive1.c (extracted). */
+#include "hifive1_flash_write_extract.h"
+
+#define ERASED 0xEE
+#define DATA_B 0xA1
+#define CANARY 0x5A
+
+static void model_reset(void)
+{
+    memset(g_flash, ERASED, sizeof(g_flash));
+    g_txmark = 0;
+    g_cur = 0;
+}
+
+/* The bug: a page-aligned multi-page write whose final page is partial.
+ * Pre-fix the last iteration took the full-page branch, read
+ * data[len..len+155] (past the buffer) and programmed 256 bytes where
+ * only 100 were requested. The tail of the last page must keep the
+ * erased pattern, and nothing past the requested bytes may change. */
+START_TEST (test_final_partial_page_not_overread)
+{
+    uint8_t data[356];
+    uint8_t canary[160];
+    int i;
+    int ret;
+
+    /* data is exactly the request length; a canary sits right after it
+     * so any out-of-range read is observable. */
+    for (i = 0; i < (int)sizeof(data); i++)
+        data[i] = DATA_B;
+    for (i = 0; i < (int)sizeof(canary); i++)
+        canary[i] = CANARY;
+    (void)canary;
+
+    /* Relative offsets are accepted as-is (address < FLASH_BASE), which
+     * keeps the 32-bit address parameter away from 64-bit host pointers. */
+    model_reset();
+    ret = hal_flash_write(0, data, sizeof(data));
+    ck_assert_int_eq(ret, 0);
+
+    /* Page 0: full page of data. */
+    ck_assert_mem_eq(g_flash, data, FLASH_PAGE_SIZE);
+
+    /* Page 1: first 100 bytes are data, the remaining 156 must stay
+     * erased (a full-page branch would have written data/canary here). */
+    ck_assert_mem_eq(g_flash + FLASH_PAGE_SIZE, data + FLASH_PAGE_SIZE,
+                     100);
+    for (i = 100; i < FLASH_PAGE_SIZE; i++) {
+        ck_assert_uint_eq(g_flash[FLASH_PAGE_SIZE + i], ERASED);
+    }
+}
+END_TEST
+
+/* A single unaligned write that stays within one page (the RMW path
+ * that already worked): leading and trailing bytes of the page are
+ * preserved. */
+START_TEST (test_unaligned_single_page_rmw)
+{
+    uint8_t data[64];
+    int i;
+    int ret;
+
+    for (i = 0; i < (int)sizeof(data); i++)
+        data[i] = (uint8_t)(i + 1);
+
+    model_reset();
+    ret = hal_flash_write(100, data, sizeof(data));
+    ck_assert_int_eq(ret, 0);
+
+    /* Offsets before and after the write keep the erased pattern. */
+    for (i = 0; i < 100; i++)
+        ck_assert_uint_eq(g_flash[i], ERASED);
+    ck_assert_mem_eq(g_flash + 100, data, sizeof(data));
+    for (i = 100 + (int)sizeof(data); i < FLASH_PAGE_SIZE; i++)
+        ck_assert_uint_eq(g_flash[i], ERASED);
+}
+END_TEST
+
+/* A write of exactly one full page is unchanged by the fix. */
+START_TEST (test_exact_full_page)
+{
+    uint8_t data[FLASH_PAGE_SIZE];
+    int i;
+    int ret;
+
+    for (i = 0; i < (int)sizeof(data); i++)
+        data[i] = (uint8_t)(0xC0 ^ (i & 0x1F));
+
+    model_reset();
+    ret = hal_flash_write(0, data, sizeof(data));
+    ck_assert_int_eq(ret, 0);
+    ck_assert_mem_eq(g_flash, data, FLASH_PAGE_SIZE);
+    for (i = 0; i < FLASH_PAGE_SIZE; i++)
+        ck_assert_uint_eq(g_flash[FLASH_PAGE_SIZE + i], ERASED);
+}
+END_TEST
+
+Suite *hifive1_flash_write_suite(void)
+{
+    Suite *s  = suite_create("hifive1 flash write");
+    TCase *tc = tcase_create("final-partial-page");
+
+    tcase_add_test(tc, test_final_partial_page_not_overread);
+    tcase_add_test(tc, test_unaligned_single_page_rmw);
+    tcase_add_test(tc, test_exact_full_page);
+    tcase_set_timeout(tc, 10);
+    suite_add_tcase(s, tc);
+    return s;
+}
+
+int main(void)
+{
+    int fails;
+    Suite *s = hifive1_flash_write_suite();
+    SRunner *sr = srunner_create(s);
+
+    srunner_run_all(sr, CK_NORMAL);
+    fails = srunner_ntests_failed(sr);
+    srunner_free(sr);
+    return fails;
+}

--- a/tools/unit-tests/unit-p1021-erase-advance.c
+++ b/tools/unit-tests/unit-p1021-erase-advance.c
@@ -1,0 +1,147 @@
+/* unit-p1021-erase-advance.c
+ *
+ * Regression test for F-11034: ext_flash_erase() in hal/nxp_p1021.c
+ * decremented the remaining length but never advanced `address`, so
+ * every loop iteration derived the same page and re-erased the first
+ * block while the rest of the requested range stayed intact.
+ *
+ * The real function is extracted by the Makefile together with the
+ * ELBC register macros it uses; the ELBC register access (set32/get32)
+ * and the flash helpers are mocked, and the test records the page
+ * address programmed for each erase command.
+ *
+ * Copyright (C) 2026 wolfSSL Inc.
+ *
+ * This file is part of wolfBoot.
+ *
+ * wolfBoot is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfBoot is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+#include <check.h>
+#include <stdint.h>
+#include <string.h>
+
+/* ELBC_BASE is built from CCSRBAR in the real file; pin it here. */
+#define CCSRBAR 0x0
+
+/* ELBC register macros + NAND command codes from hal/nxp_p1021.c
+ * (extracted by the Makefile). */
+#include "p1021_erase_extract.h"
+
+#define MAX_TRACKED_PAGES 32
+static int g_pages[MAX_TRACKED_PAGES];
+static int g_page_calls;
+static int g_cmd_calls;
+static int g_cmd_ret;
+
+static void mock_reset(int cmd_ret)
+{
+    g_page_calls = 0;
+    g_cmd_calls = 0;
+    g_cmd_ret = cmd_ret;
+}
+
+static void hal_flash_set_addr(int page, int col)
+{
+    (void)col;
+
+    if (g_page_calls < MAX_TRACKED_PAGES) {
+        g_pages[g_page_calls] = page;
+    }
+    g_page_calls++;
+}
+
+static int hal_flash_command(uint8_t iswrite)
+{
+    (void)iswrite;
+
+    g_cmd_calls++;
+    return g_cmd_ret;
+}
+
+/* Mocks for the ELBC register access helpers (hal/nxp_ppc.h). */
+static void set32(volatile unsigned int *addr, unsigned int val)
+{
+    (void)addr;
+    (void)val;
+}
+
+static uint32_t get32(volatile unsigned int *addr)
+{
+    (void)addr;
+    return 0; /* MDR status: no error */
+}
+
+/* The real ext_flash_erase() from hal/nxp_p1021.c (extracted). */
+#include "p1021_erase_fn_extract.h"
+
+/* Small-page geometry from the extracted FLASH_PAGE_SIZE (512):
+ * a 16 KiB block spans 32 pages. */
+#define TEST_PAGE_SIZE 512u
+#define TEST_BLOCK_SIZE (16u * 1024u)
+
+START_TEST (test_erase_advances_through_blocks)
+{
+    int ret;
+
+    mock_reset(0);
+
+    ret = ext_flash_erase(0, 2 * (int)TEST_BLOCK_SIZE);
+
+    ck_assert_int_eq(ret, 0);
+    /* Two blocks erased: page 0, then page 32 (one block later). */
+    ck_assert_int_eq(g_page_calls, 2);
+    ck_assert_int_eq(g_pages[0], 0);
+    ck_assert_int_eq(g_pages[1], (int)(TEST_BLOCK_SIZE / TEST_PAGE_SIZE));
+}
+END_TEST
+
+START_TEST (test_erase_stops_on_command_error)
+{
+    int ret;
+
+    mock_reset(-1);
+
+    ret = ext_flash_erase(0, 2 * (int)TEST_BLOCK_SIZE);
+
+    ck_assert_int_eq(ret, -1);
+    ck_assert_int_eq(g_page_calls, 1);
+    ck_assert_int_eq(g_pages[0], 0);
+}
+END_TEST
+
+Suite *p1021_erase_suite(void)
+{
+    Suite *s  = suite_create("p1021 erase advance");
+    TCase *tc = tcase_create("erase-address");
+
+    tcase_add_test(tc, test_erase_advances_through_blocks);
+    tcase_add_test(tc, test_erase_stops_on_command_error);
+    tcase_set_timeout(tc, 10);
+    suite_add_tcase(s, tc);
+    return s;
+}
+
+int main(void)
+{
+    int fails;
+    Suite *s = p1021_erase_suite();
+    SRunner *sr = srunner_create(s);
+
+    srunner_run_all(sr, CK_NORMAL);
+    fails = srunner_ntests_failed(sr);
+    srunner_free(sr);
+    return fails;
+}

--- a/tools/unit-tests/unit-stm32g4-write.c
+++ b/tools/unit-tests/unit-stm32g4-write.c
@@ -1,0 +1,216 @@
+/* unit-stm32g4-write.c
+ *
+ * Regression test for F-11023: the double-word fast path of
+ * hal_flash_write() in hal/stm32g4.c was selected on "len - i > 3"
+ * but consumed eight bytes, so an aligned 4-7 byte tail read up to
+ * four bytes past the caller's buffer and programmed them into
+ * flash. The fix requires at least eight remaining bytes before
+ * taking the fast path; shorter tails fall to the RMW branch, which
+ * rewrites the unit with the out-of-range bytes read back from
+ * flash.
+ *
+ * Same harness as the STM32L5/STM32U5 twins: extracted functions,
+ * registers on a host file, stale destination flash, canary after
+ * the source. The source buffer is 8-byte aligned so the fast-path
+ * alignment test on the data pointer can pass.
+ * Copyright (C) 2026 wolfSSL Inc.
+ *
+ * This file is part of wolfBoot.
+ *
+ * wolfBoot is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfBoot is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+#include <check.h>
+#include <stdint.h>
+#include <string.h>
+#include <sys/mman.h>
+
+/* Host stand-in for the ARM build attribute. */
+#define RAMFUNCTION
+
+/* Host FLASH register file (offsets as in hal/stm32g4.h). */
+static uint32_t g_flash_regs[0x20 / sizeof(uint32_t)];
+#define FLASH_BASE ((uintptr_t)g_flash_regs)
+#define FLASH_SR   (*(volatile uint32_t *)(FLASH_BASE + 0x10))
+#define FLASH_CR   (*(volatile uint32_t *)(FLASH_BASE + 0x14))
+#define FLASH_SR_EOP     (1 << 0)
+#define FLASH_SR_OPERR   (1 << 1)
+#define FLASH_SR_PROGERR (1 << 3)
+#define FLASH_SR_WRPERR  (1 << 4)
+#define FLASH_SR_PGAERR  (1 << 5)
+#define FLASH_SR_SIZERR  (1 << 6)
+#define FLASH_SR_PGSERR  (1 << 7)
+#define FLASH_SR_MISERR  (1 << 8)
+#define FLASH_SR_FASTERR (1 << 9)
+#define FLASH_SR_RDERR   (1 << 14)
+#define FLASH_SR_OPTVERR (1 << 15)
+#define FLASH_SR_BSY     (1 << 16)
+#define FLASH_CR_PG      (1 << 0)
+
+/* Destination flash: pre-filled with stale data (rewrite scenario).
+ * hal_flash_write() takes the address as uint32_t (32-bit MCU), so on
+ * the 64-bit host the flash must live at an address that fits in 32
+ * bits: map it at a fixed low location. */
+#define FLASH_MEM_SZ 256
+#define FLASH_MEM_ADDR 0x10000000UL
+static uint8_t *g_flash_mem;
+
+/* Source buffer followed by a canary: a pre-fix short write reads the
+ * canary and lands it in the destination flash. */
+#define DATA_SZ 64
+#define CANARY_SZ 32
+static uint8_t g_data[DATA_SZ + CANARY_SZ] __attribute__((aligned(8)));
+#define g_canary (g_data + DATA_SZ)
+
+/* The real functions from hal/stm32g4.c (extracted by the Makefile). */
+#include "stm32g4_write_extract.h"
+
+static void setup(void)
+{
+    int i;
+
+    memset(g_flash_regs, 0, sizeof(g_flash_regs));
+    for (i = 0; i < FLASH_MEM_SZ; i++)
+        g_flash_mem[i] = 0x12; /* stale */
+    for (i = 0; i < DATA_SZ; i++)
+        g_data[i] = (uint8_t)(0x30 + i);
+    /* 0x70..0x8F: distinct from the data bytes (0x30..0x6F), the stale
+     * flash fill (0x12) and the erased-value padding (0xFF), so a
+     * canary hit means source bytes past len were really read. */
+    for (i = 0; i < CANARY_SZ; i++)
+        g_canary[i] = (uint8_t)(0x70 + i);
+}
+
+static void teardown(void)
+{
+}
+
+static int canary_in_flash(void)
+{
+    int i;
+
+    for (i = 0; i < CANARY_SZ; i++)
+        if (memchr(g_flash_mem, g_canary[i], FLASH_MEM_SZ) != NULL)
+            return 1;
+    return 0;
+}
+
+/* A write of 60 bytes: seven full double words, then a 4-byte tail.
+ * Pre-fix the tail took the fast path and programmed bytes 60..63
+ * from source bytes past len. Post-fix the tail is RMW'd and nothing
+ * past len is read or written. */
+START_TEST(test_write_60_no_overread)
+{
+    int i;
+
+    ck_assert_int_eq(hal_flash_write((uint32_t)(uintptr_t)g_flash_mem,
+        g_data, 60), 0);
+
+    ck_assert_int_eq(memcmp(g_flash_mem, g_data, 60), 0);
+    for (i = 60; i < FLASH_MEM_SZ; i++)
+        ck_assert_uint_eq(g_flash_mem[i], 0x12);
+    ck_assert_int_eq(canary_in_flash(), 0);
+}
+END_TEST
+
+/* A write of 58 bytes: the final unit is partial (bytes 58,59 are
+ * outside the request); they are read back from flash and rewritten
+ * unchanged, and nothing past len is read. */
+START_TEST(test_write_58_partial_word_padded)
+{
+    int i;
+
+    ck_assert_int_eq(hal_flash_write((uint32_t)(uintptr_t)g_flash_mem,
+        g_data, 58), 0);
+
+    ck_assert_int_eq(memcmp(g_flash_mem, g_data, 58), 0);
+    /* word 14 (bytes 56..59): 58,59 keep their flash content */
+    ck_assert_uint_eq(g_flash_mem[58], 0x12);
+    ck_assert_uint_eq(g_flash_mem[59], 0x12);
+    for (i = 60; i < FLASH_MEM_SZ; i++)
+        ck_assert_uint_eq(g_flash_mem[i], 0x12);
+    ck_assert_int_eq(canary_in_flash(), 0);
+}
+END_TEST
+
+/* A write of 3 bytes: the whole 8-byte unit is programmed, but only
+ * bytes 0..2 take the requested value; the rest is rewritten with
+ * what flash already held. */
+START_TEST(test_write_3_single_word_padded)
+{
+    int i;
+
+    ck_assert_int_eq(hal_flash_write((uint32_t)(uintptr_t)g_flash_mem,
+        g_data, 3), 0);
+
+    ck_assert_int_eq(memcmp(g_flash_mem, g_data, 3), 0);
+    /* byte 3 and the whole second word are rewritten unchanged */
+    ck_assert_uint_eq(g_flash_mem[3], 0x12);
+    for (i = 4; i < FLASH_MEM_SZ; i++)
+        ck_assert_uint_eq(g_flash_mem[i], 0x12);
+    ck_assert_int_eq(canary_in_flash(), 0);
+}
+END_TEST
+
+/* A write of 64 bytes, a multiple of 8: the fast path is taken for
+ * every unit and behaves exactly as before the fix. */
+START_TEST(test_write_64_full_units)
+{
+    int i;
+
+    ck_assert_int_eq(hal_flash_write((uint32_t)(uintptr_t)g_flash_mem,
+        g_data, 64), 0);
+
+    ck_assert_int_eq(memcmp(g_flash_mem, g_data, 64), 0);
+    for (i = 64; i < FLASH_MEM_SZ; i++)
+        ck_assert_uint_eq(g_flash_mem[i], 0x12);
+}
+END_TEST
+
+Suite *stm32g4_write_suite(void)
+{
+    Suite *s = suite_create("stm32g4-write");
+    TCase *tc = tcase_create("stm32g4-write");
+
+    tcase_add_checked_fixture(tc, setup, teardown);
+    tcase_add_test(tc, test_write_60_no_overread);
+    tcase_add_test(tc, test_write_58_partial_word_padded);
+    tcase_add_test(tc, test_write_3_single_word_padded);
+    tcase_add_test(tc, test_write_64_full_units);
+    suite_add_tcase(s, tc);
+
+    return s;
+}
+
+int main(void)
+{
+    int fails;
+    Suite *s = stm32g4_write_suite();
+    SRunner *sr = srunner_create(s);
+
+    g_flash_mem = mmap((void *)FLASH_MEM_ADDR, FLASH_MEM_SZ,
+        PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED,
+        -1, 0);
+    if (g_flash_mem == MAP_FAILED)
+        return 99;
+
+    srunner_run_all(sr, CK_NORMAL);
+    fails = srunner_ntests_failed(sr);
+    srunner_free(sr);
+
+    munmap(g_flash_mem, FLASH_MEM_SZ);
+
+    return fails;
+}

--- a/tools/unit-tests/unit-t10xx-flash-status.c
+++ b/tools/unit-tests/unit-t10xx-flash-status.c
@@ -1,0 +1,251 @@
+/* unit-t10xx-flash-status.c
+ *
+ * Regression test for F-11033: hal_flash_write() and hal_flash_erase()
+ * in hal/nxp_t10xx.c discarded the return value of
+ * hal_flash_status_wait(), so a program or erase that timed out (the
+ * NOR stuck mid-operation) still reported success to the caller.
+ *
+ * The real functions are extracted by the Makefile and run against a
+ * mock QPI status model: offset 0 of a sector reports the DQ status
+ * byte (toggling while busy, 0x44 after a program, 0x4C after an
+ * erase). udelay() is a no-op, so a stuck device burns the full poll
+ * budget (200 ms / 1.1 s worth of iterations) in milliseconds.
+ *
+ * Copyright (C) 2026 wolfSSL Inc.
+ *
+ * This file is part of wolfBoot.
+ *
+ * wolfBoot is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfBoot is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+#include <check.h>
+#include <stdint.h>
+#include <string.h>
+
+/* 16-bit QPI configuration, as used by the T10xx targets. */
+#define FLASH_BASE_ADDR   0
+#define FLASH_PAGE_SIZE   1024
+#define FLASH_SECTOR_SIZE (128 * 1024)
+#define FLASH_CFI_WIDTH   16
+
+#define AMD_CMD_ERASE_START        0x80
+#define AMD_CMD_ERASE_SECTOR       0x30
+#define AMD_CMD_UNLOCK_START       0xAA
+#define AMD_CMD_UNLOCK_ACK         0x55
+#define AMD_CMD_WRITE_TO_BUFFER    0x25
+#define AMD_CMD_WRITE_BUFFER_CONFIRM 0x29
+#define AMD_STATUS_TOGGLE          0x40
+
+#define FLASH_UNLOCK_ADDR1 0x555
+#define FLASH_UNLOCK_ADDR2 0x2AA
+
+void udelay(uint32_t us);
+
+/* ---- mock QPI status model ------------------------------------------- */
+
+typedef enum t10xx_mock_state {
+    ST_IDLE = 0,
+    ST_PROGRAMMING,
+    ST_ERASING,
+    ST_PROG_DONE,
+    ST_ERASE_DONE,
+} t10xx_mock_state;
+
+#define MOCK_SECTOR_BYTES 64
+#define NSECTORS 4
+
+static uint8_t g_flash[NSECTORS * MOCK_SECTOR_BYTES];
+static int g_state[NSECTORS];
+static int g_stuck[NSECTORS];
+static int g_unlocks;
+
+static void mock_reset(int stuck)
+{
+    int s;
+
+    memset(g_flash, 0, sizeof(g_flash));
+    for (s = 0; s < NSECTORS; s++) {
+        g_state[s] = ST_IDLE;
+        g_stuck[s] = stuck;
+    }
+    g_unlocks = 0;
+}
+
+/* The real macros dereference the memory-mapped flash window; the test
+ * routes them through the model so command writes drive the state.
+ * 16-bit variant: every index is a word index (byte offset = 2 * n),
+ * and the 8-bit write replicates the byte across the 16-bit word. */
+static uint8_t mock_read8(uint32_t sector, uint32_t n)
+{
+    uint32_t byte_off = 2 * n;
+
+    if (n == 0 &&
+        ((g_state[sector] == ST_PROGRAMMING) ||
+         (g_state[sector] == ST_ERASING))) {
+        if (!g_stuck[sector]) {
+            /* Complete on the first status poll after the command. */
+            g_state[sector] = (g_state[sector] == ST_PROGRAMMING) ?
+                ST_PROG_DONE : ST_ERASE_DONE;
+            return (g_state[sector] == ST_PROG_DONE) ? 0x44 : 0x4C;
+        }
+        return AMD_STATUS_TOGGLE; /* busy, never completes */
+    }
+    if (n == 0) {
+        return 0x4C; /* idle: satisfies program (0x44) and erase (0x4C) */
+    }
+    if (byte_off < MOCK_SECTOR_BYTES) {
+        return g_flash[sector * MOCK_SECTOR_BYTES + byte_off];
+    }
+    return 0;
+}
+
+static uint16_t mock_read16(uint32_t sector, uint32_t n)
+{
+    uint32_t byte_off = 2 * n;
+
+    return (uint16_t)(g_flash[sector * MOCK_SECTOR_BYTES + byte_off] |
+                      ((uint16_t)g_flash[sector * MOCK_SECTOR_BYTES +
+                                          byte_off + 1] << 8));
+}
+
+static void mock_write8(uint32_t sector, uint32_t n, uint8_t val)
+{
+    uint32_t byte_off = 2 * n;
+
+    if (n == FLASH_UNLOCK_ADDR1 && val == AMD_CMD_UNLOCK_START) {
+        g_unlocks++;
+        return;
+    }
+    if (n == FLASH_UNLOCK_ADDR2 && val == AMD_CMD_UNLOCK_ACK) {
+        return;
+    }
+    if (n == 0 && val == AMD_CMD_ERASE_SECTOR) {
+        g_state[sector] = ST_ERASING;
+        return;
+    }
+    if (val == AMD_CMD_WRITE_BUFFER_CONFIRM) {
+        g_state[sector] = ST_PROGRAMMING;
+        return;
+    }
+    if (byte_off < MOCK_SECTOR_BYTES) {
+        g_flash[sector * MOCK_SECTOR_BYTES + byte_off] = val;
+        g_flash[sector * MOCK_SECTOR_BYTES + byte_off + 1] = val;
+    }
+}
+
+static void mock_write16(uint32_t sector, uint32_t n, uint16_t val)
+{
+    uint32_t byte_off = 2 * n;
+
+    if (byte_off + 1 < MOCK_SECTOR_BYTES) {
+        g_flash[sector * MOCK_SECTOR_BYTES + byte_off] = (uint8_t)(val & 0xFF);
+        g_flash[sector * MOCK_SECTOR_BYTES + byte_off + 1] =
+            (uint8_t)(val >> 8);
+    }
+}
+
+#define FLASH_IO8_READ(sec, n)  mock_read8((sec), (n))
+#define FLASH_IO8_WRITE(sec, n, val) mock_write8((sec), (n), (val))
+#define FLASH_IO16_READ(sec, n) mock_read16((sec), (n))
+#define FLASH_IO16_WRITE(sec, n, val) mock_write16((sec), (n), (val))
+
+/* The real functions from hal/nxp_t10xx.c (extracted by the Makefile). */
+static void hal_flash_unlock_sector(uint32_t sector);
+#include "t10xx_flash_status_extract.h"
+
+void udelay(uint32_t us)
+{
+    (void)us; /* no real delay: a stuck device burns the poll budget fast */
+}
+
+START_TEST (test_flash_write_success)
+{
+    uint8_t data[8];
+    int i;
+    int ret;
+
+    mock_reset(0);
+    for (i = 0; i < 8; i++)
+        data[i] = (uint8_t)(0xA0 + i);
+
+    ret = hal_flash_write(0, data, sizeof(data));
+    ck_assert_int_eq(ret, 0);
+    ck_assert_int_gt(g_unlocks, 0);
+    ck_assert_mem_eq(g_flash, data, 8);
+}
+END_TEST
+
+START_TEST (test_flash_write_timeout_returns_error)
+{
+    uint8_t data[8] = { 0 };
+    int ret;
+
+    /* Device stuck mid-program: the status never settles. */
+    mock_reset(1);
+
+    ret = hal_flash_write(0, data, sizeof(data));
+    ck_assert_int_eq(ret, -1);
+}
+END_TEST
+
+START_TEST (test_flash_erase_success)
+{
+    int ret;
+
+    mock_reset(0);
+
+    ret = hal_flash_erase(0, FLASH_SECTOR_SIZE);
+    ck_assert_int_eq(ret, 0);
+    ck_assert_int_gt(g_unlocks, 0);
+}
+END_TEST
+
+START_TEST (test_flash_erase_timeout_returns_error)
+{
+    int ret;
+
+    /* Device stuck mid-erase: the status never settles. */
+    mock_reset(1);
+
+    ret = hal_flash_erase(0, FLASH_SECTOR_SIZE);
+    ck_assert_int_eq(ret, -1);
+}
+END_TEST
+
+Suite *t10xx_flash_status_suite(void)
+{
+    Suite *s  = suite_create("t10xx flash status");
+    TCase *tc = tcase_create("flash-op-timeout");
+
+    tcase_add_test(tc, test_flash_write_success);
+    tcase_add_test(tc, test_flash_write_timeout_returns_error);
+    tcase_add_test(tc, test_flash_erase_success);
+    tcase_add_test(tc, test_flash_erase_timeout_returns_error);
+    tcase_set_timeout(tc, 30);
+    suite_add_tcase(s, tc);
+    return s;
+}
+
+int main(void)
+{
+    int fails;
+    Suite *s = t10xx_flash_status_suite();
+    SRunner *sr = srunner_create(s);
+
+    srunner_run_all(sr, CK_NORMAL);
+    fails = srunner_ntests_failed(sr);
+    srunner_free(sr);
+    return fails;
+}

--- a/tools/unit-tests/unit-update-ram.c
+++ b/tools/unit-tests/unit-update-ram.c
@@ -476,6 +476,32 @@ START_TEST (test_invalid_sha) {
     cleanup_flash();
 }
 
+START_TEST (test_both_images_corrupted_panics) {
+    uint8_t bad_digest[SHA256_DIGEST_SIZE];
+    reset_mock_stats();
+    prepare_flash();
+    /* Same version in both partitions: after a failure the loop must not
+     * be stopped by the anti-rollback guard, only by noticing that both
+     * candidates have already failed. */
+    add_payload(PART_BOOT, 2, TEST_SIZE_SMALL);
+    add_payload(PART_UPDATE, 2, TEST_SIZE_SMALL);
+
+    /* Corrupt both digests: two present images (nonzero versions, so the
+     * fallback check passes) that both fail verification. The boot loop
+     * must panic once both have been tried, not alternate forever. */
+    memset(bad_digest, 0xBA, SHA256_DIGEST_SIZE);
+    ext_flash_unlock();
+    ext_flash_write(WOLFBOOT_PARTITION_BOOT_ADDRESS + DIGEST_TLV_OFF_IN_HDR + 4, bad_digest, SHA256_DIGEST_SIZE);
+    ext_flash_write(WOLFBOOT_PARTITION_UPDATE_ADDRESS + DIGEST_TLV_OFF_IN_HDR + 4, bad_digest, SHA256_DIGEST_SIZE);
+    ext_flash_lock();
+
+    wolfBoot_start();
+    ck_assert(!wolfBoot_staged_ok);
+    ck_assert_int_eq(wolfBoot_panicked, 1);
+    cleanup_flash();
+}
+END_TEST
+
 START_TEST (test_emergency_rollback_to_older_version_denied) {
     uint8_t testing_flags[5] = { IMG_STATE_TESTING, 'B', 'O', 'O', 'T' };
     reset_mock_stats();
@@ -597,6 +623,7 @@ Suite *wolfboot_suite(void)
     TCase *emergency_rollback_failure_due_to_bad_update = tcase_create("Emergency rollback failure due to bad update");
     TCase *empty_boot_partition_update = tcase_create("Empty boot partition update");
     TCase *empty_boot_but_update_sha_corrupted_denied = tcase_create("Empty boot partition but update SHA corrupted");
+    TCase *both_images_corrupted = tcase_create("Both images corrupted");
 
 
 
@@ -620,6 +647,7 @@ Suite *wolfboot_suite(void)
     tcase_add_test(emergency_rollback_failure_due_to_bad_update, test_emergency_rollback_failure_due_to_bad_update);
     tcase_add_test(empty_boot_partition_update, test_empty_boot_partition_update);
     tcase_add_test(empty_boot_but_update_sha_corrupted_denied, test_empty_boot_but_update_sha_corrupted_denied);
+    tcase_add_test(both_images_corrupted, test_both_images_corrupted_panics);
 
 
 
@@ -642,6 +670,7 @@ Suite *wolfboot_suite(void)
     suite_add_tcase(s, emergency_rollback_failure_due_to_bad_update);
     suite_add_tcase(s, empty_boot_partition_update);
     suite_add_tcase(s, empty_boot_but_update_sha_corrupted_denied);
+    suite_add_tcase(s, both_images_corrupted);
 
 
     /* Set timeout for tests */
@@ -664,6 +693,7 @@ Suite *wolfboot_suite(void)
     tcase_set_timeout(emergency_rollback_failure_due_to_bad_update, 5);
     tcase_set_timeout(empty_boot_partition_update, 5);
     tcase_set_timeout(empty_boot_but_update_sha_corrupted_denied, 5);
+    tcase_set_timeout(both_images_corrupted, 5);
 
 
     return s;


### PR DESCRIPTION
d44ecc43 F-11045: validate the FDT layout before the memreserve memmove
972913d7 F-11044: stage the fwTPM command in secure memory before processing
fe7eb45f F-11043: stage the fwTPM response before copying to the caller buffer
5f914b69 F-11035: size the final partial page from remaining bytes in hifive1 write
572cef2f F-11034: advance the address in the P1021 multi-block NAND erase loop
aae94a64 F-11033: propagate program/erase timeouts from the T10xx flash HAL
b006b6f2 F-11029: publish IPI fence completion only after the fence executes
019c7f06 F-11028: panic when both RAM-boot images fail verification
8c970467 F-11027: abort the ELF load when an mmu_cb mapping fails
9e4abd4c F-9749: propagate the verify result from wolfBoot_start to the exit code
d8ffd2ea F-11024: pass full-width fields to wc_ecc_rs_raw_to_sig in the wolfHSM verify path
2964b375 F-11023: require a full double word in the STM32 fast write paths